### PR TITLE
task/remove-bigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.1] - 2023-11-15
 
+### Changed
+- Remove `BigInt` notation
+
 
 ## [0.5.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.5.1] - 2023-11-15
+## [0.5.1] - 2023-11-16
 
 ### Changed
 - Remove `BigInt` notation

--- a/lib/src/structuredfield/parse/parseIntegerOrDecimal.ts
+++ b/lib/src/structuredfield/parse/parseIntegerOrDecimal.ts
@@ -1,4 +1,5 @@
 import { INTEGER_DECIMAL } from '../utils/INTEGER_DECIMAL.js';
+import { isInvalidInt } from '../utils/isInvalidInt.js';
 import { ParsedValue } from './ParsedValue.js';
 import { parseError } from './parseError.js';
 
@@ -117,7 +118,7 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 			throw parseError(orig, INTEGER_DECIMAL);
 		}
 		value = parseInt(num) * sign;
-		if (value < -999999999999999n || 999999999999999n < value) {
+		if (isInvalidInt(value)) {
 			throw parseError(num, INTEGER_DECIMAL);
 		}
 	}

--- a/lib/src/structuredfield/serialize/serializeInteger.ts
+++ b/lib/src/structuredfield/serialize/serializeInteger.ts
@@ -1,4 +1,5 @@
 import { INTEGER } from '../utils/INTEGER.js';
+import { isInvalidInt } from '../utils/isInvalidInt.js';
 import { serializeError } from './serializeError.js';
 
 // 4.1.4.  Serializing an Integer
@@ -20,7 +21,7 @@ import { serializeError } from './serializeError.js';
 //
 // 5.  Return output.
 export function serializeInteger(value: number) {
-	if (value < -999999999999999n || 999999999999999n < value) {
+	if (isInvalidInt(value)) {
 		throw serializeError(value, INTEGER);
 	}
 

--- a/lib/src/structuredfield/utils/isInvalidInt.ts
+++ b/lib/src/structuredfield/utils/isInvalidInt.ts
@@ -1,0 +1,3 @@
+export function isInvalidInt(value: number) {
+	return value < -999999999999999 || 999999999999999 < value;
+}

--- a/lib/test/structuredfield/encodeSfItem.test.ts
+++ b/lib/test/structuredfield/encodeSfItem.test.ts
@@ -21,7 +21,8 @@ test('encodeSfItem', () => {
 	assert.throws(() => encodeSfItem(function () { }), /failed to serialize "function \(\) \{ \}" as Bare Item/);
 	// @ts-expect-error
 	assert.throws(() => encodeSfItem(() => { }), /failed to serialize "\(\) => \{ \}" as Bare Item/);
-	assert.throws(() => encodeSfItem(999), /failed to serialize "999" as Bare Item/);
+	// @ts-expect-error
+	assert.throws(() => encodeSfItem(999n), /failed to serialize "999" as Bare Item/);
 	// @ts-expect-error
 	assert.throws(() => encodeSfItem([]), /failed to serialize "\[\]" as Bare Item/);
 	// @ts-expect-error

--- a/lib/test/structuredfield/encodeSfItem.test.ts
+++ b/lib/test/structuredfield/encodeSfItem.test.ts
@@ -21,8 +21,7 @@ test('encodeSfItem', () => {
 	assert.throws(() => encodeSfItem(function () { }), /failed to serialize "function \(\) \{ \}" as Bare Item/);
 	// @ts-expect-error
 	assert.throws(() => encodeSfItem(() => { }), /failed to serialize "\(\) => \{ \}" as Bare Item/);
-	// @ts-expect-error
-	assert.throws(() => encodeSfItem(999n), /failed to serialize "999" as Bare Item/);
+	assert.throws(() => encodeSfItem(999), /failed to serialize "999" as Bare Item/);
 	// @ts-expect-error
 	assert.throws(() => encodeSfItem([]), /failed to serialize "\[\]" as Bare Item/);
 	// @ts-expect-error


### PR DESCRIPTION
Remove unnecessary use of `BigInt` notation that forced adapters to target newer versions of ES.