### PR TITLE
fix: restore broken fixable rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- The format command no longer works
+  ([#166](https://github.com/streaming-video-technology-alliance/common-media-library/issues/166))
+
 ## [0.10.0] - 2025-03-10
 
 ### Added
@@ -16,7 +21,7 @@ and this project adheres to
   ([#131](https://github.com/streaming-video-technology-alliance/common-media-library/issues/131))
 - Add `prefix` and `localName` support to the XML types and utilities
   ([#145](https://github.com/streaming-video-technology-alliance/common-media-library/issues/145))
-- Common DRM Models and Constants 
+- Common DRM Models and Constants
   ([#154](https://github.com/streaming-video-technology-alliance/common-media-library/issues/154))
 
 ## [0.9.0] - 2025-02-21

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,93 +1,64 @@
-import { FlatCompat } from '@eslint/eslintrc';
-import js from '@eslint/js';
+import { default as stylistic } from '@stylistic/eslint-plugin';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import tsdoc from 'eslint-plugin-tsdoc';
-import typescriptEnum from 'eslint-plugin-typescript-enum';
 import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-	baseDirectory: __dirname,
-	recommendedConfig: js.configs.recommended,
-	allConfig: js.configs.all,
-});
-
-export default [{
-	ignores: ['**/dist'],
-}, ...compat.extends(
-	'eslint:recommended',
-	'plugin:@typescript-eslint/recommended',
-	'plugin:typescript-enum/recommended',
-), {
-	plugins: {
-		'@typescript-eslint': typescriptEslint,
-		tsdoc,
-		'typescript-enum': typescriptEnum,
+export default [
+	{
+		ignores: ['**/dist'],
 	},
-
-	files: ['**/*.js', '**/*.ts'],
-
-	languageOptions: {
-		globals: {
-			...globals.browser,
-			...globals.node,
+	{
+		plugins: {
+			'@stylistic': stylistic,
+			'@typescript-eslint': typescriptEslint,
+			tsdoc,
 		},
 
-		parser: tsParser,
-	},
+		files: ['**/*.js', '**/*.ts'],
 
-	rules: {
-		'@typescript-eslint/consistent-type-imports': 'error',
-		'@typescript-eslint/no-empty-interface': 'error',
-		'@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-		'@typescript-eslint/no-duplicate-enum-values': 'off',
-		'@typescript-eslint/no-use-before-define': 'off',
-		'@typescript-eslint/no-unused-vars': 'off',
-		'@typescript-eslint/no-explicit-any': 'off',
-		'@typescript-eslint/ban-ts-comment': 'off',
-		'@typescript-eslint/no-inferrable-types': 'off',
-		'@typescript-eslint/no-empty-function': 'off',
-		'no-unused-vars': 'off',
-		'no-case-declarations': 'off',
-		'no-fallthrough': 'off',
-		semi: ['error', 'always'],
+		languageOptions: {
+			globals: {
+				...globals.browser,
+				...globals.node,
+			},
+			parser: tsParser,
+		},
 
-		indent: ['error', 'tab', {
-			SwitchCase: 1,
-			MemberExpression: 1,
-
-			ignoredNodes: [
-				'FunctionExpression > .params[decorators.length > 0]',
-				'FunctionExpression > .params > :matches(Decorator,:not(:first-child))',
-				'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key',
-			],
-		}],
-
-		'space-infix-ops': ['error'],
-		'key-spacing': ['error'],
-		'eol-last': ['error', 'always'],
-		'comma-dangle': ['error', 'always-multiline'],
-
-		quotes: ['error', 'single', {
-			allowTemplateLiterals: true,
-			avoidEscape: true,
-		}],
-
-		'keyword-spacing': ['error', {
-			after: true,
-		}],
-
-		curly: ['error'],
-		'object-curly-spacing': ['error', 'always'],
-
-		'brace-style': ['error', 'stroustrup', {
-			allowSingleLine: false,
-		}],
-
-		'tsdoc/syntax': 'warn',
-	},
-}];
+		rules: {
+			'@typescript-eslint/consistent-type-imports': 'error',
+			'@typescript-eslint/no-empty-interface': 'error',
+			'@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+			'@stylistic/no-duplicate-enum-values': 'off',
+			'@stylistic/no-use-before-define': 'off',
+			'@stylistic/no-unused-vars': 'off',
+			'@stylistic/no-explicit-any': 'off',
+			'@stylistic/ban-ts-comment': 'off',
+			'@stylistic/no-inferrable-types': 'off',
+			'@stylistic/no-empty-function': 'off',
+			'@stylistic/no-unused-vars': 'off',
+			'@stylistic/no-case-declarations': 'off',
+			'@stylistic/no-fallthrough': 'off',
+			'@stylistic/space-infix-ops': ['error'],
+			'@stylistic/key-spacing': ['error'],
+			'@stylistic/eol-last': ['error', 'always'],
+			'@stylistic/comma-dangle': ['error', 'always-multiline'],
+			'@stylistic/indent': ['error', 'tab', {
+				SwitchCase: 1,
+				MemberExpression: 1,
+			}],
+			'@stylistic/quotes': ['error', 'single', {
+				allowTemplateLiterals: true,
+				avoidEscape: true,
+			}],
+			'@stylistic/keyword-spacing': ['error', {
+				after: true,
+			}],
+			'@/curly': ['error'],
+			'@stylistic/object-curly-spacing': ['error', 'always'],
+			'@stylistic/brace-style': ['error', 'stroustrup', {
+				allowSingleLine: false,
+			}],
+			'tsdoc/syntax': 'warn',
+		},
+	}];

--- a/lib/src/drm/common/KeyMessage.ts
+++ b/lib/src/drm/common/KeyMessage.ts
@@ -7,8 +7,8 @@ import type { MEDIA_KEY_MESSAGE_TYPES } from '../common/MEDIA_KEY_MESSAGE_TYPES'
  * @beta
  */
 export type KeyMessage = {
-  sessionId?: string;
-  message: ArrayBuffer;
-  defaultUrl?: string;
-  messageType: (typeof MEDIA_KEY_MESSAGE_TYPES)[keyof typeof MEDIA_KEY_MESSAGE_TYPES];
+	sessionId?: string;
+	message: ArrayBuffer;
+	defaultUrl?: string;
+	messageType: (typeof MEDIA_KEY_MESSAGE_TYPES)[keyof typeof MEDIA_KEY_MESSAGE_TYPES];
 }

--- a/lib/src/drm/common/KeySystemAccess.ts
+++ b/lib/src/drm/common/KeySystemAccess.ts
@@ -6,6 +6,6 @@
  * @public
  */
 export type KeySystemAccess = {
-    keySystem: string;
-    configuration: MediaKeySystemConfiguration;
+	keySystem: string;
+	configuration: MediaKeySystemConfiguration;
 }

--- a/lib/src/drm/common/KeySystemConfiguration.ts
+++ b/lib/src/drm/common/KeySystemConfiguration.ts
@@ -7,11 +7,11 @@ import type { MediaCapability } from './MediaCapability';
  * @beta
  */
 export type KeySystemConfiguration = {
-  initDataTypes?: string[];
-  audioCapabilities?: MediaCapability[];
-  videoCapabilities?: MediaCapability[];
-  distinctiveIdentifier?: 'required' | 'optional' | 'not-allowed';
-  persistentState?: 'required' | 'optional' | 'not-allowed';
-  sessionTypes?: string[];
+	initDataTypes?: string[];
+	audioCapabilities?: MediaCapability[];
+	videoCapabilities?: MediaCapability[];
+	distinctiveIdentifier?: 'required' | 'optional' | 'not-allowed';
+	persistentState?: 'required' | 'optional' | 'not-allowed';
+	sessionTypes?: string[];
 }
 

--- a/lib/src/drm/common/LicenseRequest.ts
+++ b/lib/src/drm/common/LicenseRequest.ts
@@ -9,45 +9,45 @@
  * @beta
  */
 export type LicenseRequest = {
-    /**
+	/**
      * License server URL.
      */
-    url: string;
+	url: string;
 
-    /**
+	/**
      * HTTP method 
      */
-    method: 'GET' | 'POST';
+	method: 'GET' | 'POST';
 
-    /**
+	/**
      * The HTTP response type
      */
-    responseType: XMLHttpRequestResponseType;
+	responseType: XMLHttpRequestResponseType;
 
-    /**
+	/**
      * The HTP request headers
      */
-    headers?: Record<string, string>;
+	headers?: Record<string, string>;
 
-    /**
+	/**
      * Whether request is done using credentials (cross-site cookies)
      */
-    withCredentials?: boolean;
+	withCredentials?: boolean;
 
-    /**
+	/**
      * The license request message type 
      * (see https://www.w3.org/TR/encrypted-media/#dom-mediakeymessagetype)
      */
-    messageType?: MediaKeyMessageType;
+	messageType?: MediaKeyMessageType;
 
-    /**
+	/**
      * The corresponding EME session ID
      */
-    sessionId?: string;
+	sessionId?: string;
 
-    /**
+	/**
      * The license request data
      */
-    data?: ArrayBuffer;
+	data?: ArrayBuffer;
 }
 

--- a/lib/src/drm/common/MediaCapability.ts
+++ b/lib/src/drm/common/MediaCapability.ts
@@ -8,6 +8,6 @@
  * @beta
  */
 export type MediaCapability = {
-    contentType: string;
-    robustness: string;
+	contentType: string;
+	robustness: string;
 }

--- a/lib/src/structuredfield/utils/STRING_REGEX.ts
+++ b/lib/src/structuredfield/utils/STRING_REGEX.ts
@@ -1,1 +1,1 @@
-export const STRING_REGEX: RegExp = /[\x00-\x1f\x7f]+/; // eslint-disable-line no-control-regex
+export const STRING_REGEX: RegExp = /[\x00-\x1f\x7f]+/;  

--- a/lib/test/structuredfield/serializeString.test.ts
+++ b/lib/test/structuredfield/serializeString.test.ts
@@ -6,7 +6,7 @@ test('serializeString', () => {
 	assert.deepStrictEqual(serializeString('string'), `"string"`);
 	assert.deepStrictEqual(serializeString('str\\ing'), `"str\\\\ing"`);
 	assert.deepStrictEqual(serializeString('str"ing'), `"str\\"ing"`);
-	assert.throws(() => serializeString('str\x00ing'), /failed to serialize "str\x00ing" as String/); // eslint-disable-line no-control-regex
-	assert.throws(() => serializeString('str\x1fing'), /failed to serialize "str\x1fing" as String/); // eslint-disable-line no-control-regex
+	assert.throws(() => serializeString('str\x00ing'), /failed to serialize "str\x00ing" as String/);  
+	assert.throws(() => serializeString('str\x1fing'), /failed to serialize "str\x1fing" as String/);  
 	assert.throws(() => serializeString('str\x7fing'), /failed to serialize "str\x7fing" as String/);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@eslint/eslintrc": "3.1.0",
 				"@eslint/js": "9.13.0",
 				"@microsoft/api-extractor": "7.47.11",
+				"@stylistic/eslint-plugin": "4.2.0",
 				"@types/node": "22.8.0",
 				"@typescript-eslint/eslint-plugin": "8.11.0",
 				"@typescript-eslint/parser": "8.11.0",
@@ -1296,6 +1297,205 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@stylistic/eslint-plugin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
+			"integrity": "sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/utils": "^8.23.0",
+				"eslint-visitor-keys": "^4.2.0",
+				"espree": "^10.3.0",
+				"estraverse": "^5.3.0",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=9.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
+			"integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.29.0",
+				"@typescript-eslint/visitor-keys": "8.29.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "8.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
+			"integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
+			"integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.29.0",
+				"@typescript-eslint/visitor-keys": "8.29.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^2.0.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "8.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
+			"integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.29.0",
+				"@typescript-eslint/types": "8.29.0",
+				"@typescript-eslint/typescript-estree": "8.29.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
+			"integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.29.0",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/semver": {
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/ts-api-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
 		"node_modules/@svta/common-media-library": {
 			"resolved": "lib",
 			"link": true
@@ -1959,9 +2159,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-			"integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3369,15 +3569,15 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
-			"integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.12.0",
+				"acorn": "^8.14.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.1.0"
+				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3387,9 +3587,9 @@
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-			"integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"@eslint/eslintrc": "3.1.0",
 		"@eslint/js": "9.13.0",
 		"@microsoft/api-extractor": "7.47.11",
+		"@stylistic/eslint-plugin": "4.2.0",
 		"@types/node": "22.8.0",
 		"@typescript-eslint/eslint-plugin": "8.11.0",
 		"@typescript-eslint/parser": "8.11.0",


### PR DESCRIPTION
Eslint formatting rules were moved out of core and into the `@stylistic` package. When we upgraded to ESLint v9, we didn't not migrate the rules. This PR update the rules and fixes the `npm run format` command.
