### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.0] - 2025-05-08
+
 ### Added
 
 - Added Throughput Calculation Interfaces
@@ -317,7 +319,8 @@ and this project adheres to
 - Bootstrap project
   ([#2](https://github.com/streaming-video-technology-alliance/common-media-library/issues/2))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.8.0...v0.9.0

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@svta/common-media-library-dev",
 	"private": true,
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@svta/common-media-library-docs",
 	"private": true,
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/common-media-library",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/lib/src/608.ts
+++ b/lib/src/608.ts
@@ -9,6 +9,8 @@ export { CaptionsLogger } from './cta/608/CaptionsLogger.ts';
 export { Cta608Channel } from './cta/608/Cta608Channel.ts';
 export { Cta608Parser } from './cta/608/Cta608Parser.ts';
 export type { CueHandler } from './cta/608/CueHandler.ts';
+export { extractCta608Data } from './cta/608/extractCta608Data.ts';
+export { findCta608Nalus } from './cta/608/findCta608Nalus.ts';
 export type { PACData } from './cta/608/PACData.ts';
 export { PenState } from './cta/608/PenState.ts';
 export type { PenStyles } from './cta/608/PenStyles.ts';
@@ -17,6 +19,3 @@ export { SccParser } from './cta/608/SccParser.ts';
 export { StyledUnicodeChar } from './cta/608/StyledUnicodeChar.ts';
 export type { SupportedField } from './cta/608/SupportedField.ts';
 export { VerboseLevel } from './cta/608/VerboseLevel.ts';
-export { extractCta608Data } from './cta/608/extractCta608Data.ts';
-export { findCta608Nalus } from './cta/608/findCta608Nalus.ts';
-

--- a/lib/src/isobmff.ts
+++ b/lib/src/isobmff.ts
@@ -1,3 +1,8 @@
+/**
+ * A collection of tools for working with ISO Base Media File Format (ISOBMFF).
+ *
+ * @packageDocumentation
+ */
 export * from './iso/bmff/Box.ts';
 export * from './iso/bmff/BoxFilter.ts';
 export * from './iso/bmff/BoxParser.ts';

--- a/lib/src/structuredfield.ts
+++ b/lib/src/structuredfield.ts
@@ -3,6 +3,12 @@
  *
  * @packageDocumentation
  */
+export { decodeSfDict } from './structuredfield/decodeSfDict.ts';
+export { decodeSfItem } from './structuredfield/decodeSfItem.ts';
+export { decodeSfList } from './structuredfield/decodeSfList.ts';
+export { encodeSfDict } from './structuredfield/encodeSfDict.ts';
+export { encodeSfItem } from './structuredfield/encodeSfItem.ts';
+export { encodeSfList } from './structuredfield/encodeSfList.ts';
 export type { SfBareItem } from './structuredfield/SfBareItem.ts';
 export type { SfDecodeOptions } from './structuredfield/SfDecodeOptions.ts';
 export type { SfDictionary } from './structuredfield/SfDictionary.ts';
@@ -12,9 +18,3 @@ export { SfItem } from './structuredfield/SfItem.ts';
 export type { SfMember } from './structuredfield/SfMember.ts';
 export type { SfParameters } from './structuredfield/SfParameters.ts';
 export { SfToken } from './structuredfield/SfToken.ts';
-export { decodeSfDict } from './structuredfield/decodeSfDict.ts';
-export { decodeSfItem } from './structuredfield/decodeSfItem.ts';
-export { decodeSfList } from './structuredfield/decodeSfList.ts';
-export { encodeSfDict } from './structuredfield/encodeSfDict.ts';
-export { encodeSfItem } from './structuredfield/encodeSfItem.ts';
-export { encodeSfList } from './structuredfield/encodeSfList.ts';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@svta/common-media-library-workspace",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@svta/common-media-library-workspace",
-			"version": "0.11.0",
+			"version": "0.12.0",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"lib",
@@ -34,7 +34,7 @@
 		},
 		"dev": {
 			"name": "@svta/common-media-library-dev",
-			"version": "0.11.0",
+			"version": "0.12.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@web/dev-server": "0.4.6"
@@ -42,12 +42,12 @@
 		},
 		"docs": {
 			"name": "@svta/common-media-library-docs",
-			"version": "0.11.0",
+			"version": "0.12.0",
 			"license": "Apache-2.0"
 		},
 		"lib": {
 			"name": "@svta/common-media-library",
-			"version": "0.11.0",
+			"version": "0.12.0",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@babel/code-frame": {
@@ -6056,7 +6056,7 @@
 			}
 		},
 		"samples/cmaf-ham-conversion": {
-			"version": "0.11.0",
+			"version": "0.12.0",
 			"license": "ISC",
 			"dependencies": {
 				"@svta/common-media-library": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/common-media-library-workspace",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/samples/cmaf-ham-conversion/package.json
+++ b/samples/cmaf-ham-conversion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cmaf-ham-conversion",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "",
 	"type": "module",
 	"scripts": {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,6 +5,6 @@
 		"noEmit": true,
 	},
 	"include": [
-		"src"
+		"./"
 	]
 }

--- a/scripts/version.mts
+++ b/scripts/version.mts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { cmd } from './cmd.mjs';
+import { cmd } from './cmd.mts';
 
 const ver = process.argv[2];
 


### PR DESCRIPTION
### Added

- Added Throughput Calculation Interfaces ([#170](https://github.com/streaming-video-technology-alliance/common-media-library/pull/170))
- Add ID3 scheme ID URI ([#174](https://github.com/streaming-video-technology-alliance/common-media-library/pull/174))
- PlayReady DRM Utilities ([#172](https://github.com/streaming-video-technology-alliance/common-media-library/issues/172))

### Changed

- Ensure CML is compliant with the type annotations proposal ([#134](https://github.com/streaming-video-technology-alliance/common-media-library/issues/134))

### Fixed

- TSLib imported in version 0.11.0's utils.js. ([#177](https://github.com/streaming-video-technology-alliance/common-media-library/issues/177))