### PR TITLE
fix: allow large ints to be passed in as time values for processUriTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.4] - 2025-05-16
+
+### Fixed
+
+- `processUriTemplate` cannot correctly resolve time values larger than MAX_SAFE_INTEGER
+  ([#190](https://github.com/streaming-video-technology-alliance/common-media-library/issues/190))
+
 ## [0.12.3] - 2025-05-15
 
 ### Fixed
@@ -340,7 +347,8 @@ and this project adheres to
 - Bootstrap project
   ([#2](https://github.com/streaming-video-technology-alliance/common-media-library/issues/2))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.3...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.4...HEAD
+[0.12.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/v0.12.0...v0.12.1

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@svta/common-media-library-dev",
 	"private": true,
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@svta/common-media-library-docs",
 	"private": true,
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/lib/config/common-media-library.api.md
+++ b/lib/config/common-media-library.api.md
@@ -1332,7 +1332,7 @@ export type Presentation = Ham & {
 export function prft(view: IsoView): ProducerReferenceTimeBox;
 
 // @beta
-export function processUriTemplate(uriTemplate: string, representationId: string | null | undefined, number: number | null | undefined, subNumber: number | null | undefined, bandwidth: number | null | undefined, time: number | null | undefined): string;
+export function processUriTemplate(uriTemplate: string, representationId: string | null | undefined, number: number | null | undefined, subNumber: number | null | undefined, bandwidth: number | null | undefined, time: string | number | null | undefined): string;
 
 // @beta
 export type ProducerReferenceTimeBox = FullBox & {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/common-media-library",
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/lib/src/dash/processUriTemplate.ts
+++ b/lib/src/dash/processUriTemplate.ts
@@ -8,7 +8,7 @@ const TOKENS = /\$(RepresentationID|Number|SubNumber|Bandwidth|Time)?(?:%0([0-9]
  * @param number - Number.
  * @param subNumber - Sub-number.
  * @param bandwidth - Bandwidth.
- * @param time - Time.
+ * @param time - Time. If the value is larger than MAX_SAFE_INTEGER, it should be provided as a string.
  *
  * @returns Processed URI template.
  *
@@ -50,7 +50,11 @@ export function processUriTemplate(
 				break;
 
 			case 'Time':
-				value = (typeof time === 'number') ? Math.round(time) : time;
+				if (typeof time === 'string') {
+					return time;
+				}
+
+				value = time ? Math.round(time) : time;
 				break;
 
 			default:

--- a/lib/src/dash/processUriTemplate.ts
+++ b/lib/src/dash/processUriTemplate.ts
@@ -24,7 +24,7 @@ export function processUriTemplate(
 	number: number | null | undefined,
 	subNumber: number | null | undefined,
 	bandwidth: number | null | undefined,
-	time: number | null | undefined,
+	time: string | number | null | undefined,
 ): string {
 	const uri = uriTemplate.replace(TOKENS, (match, name, widthStr, format) => {
 		let value: string | number | null | undefined;
@@ -50,7 +50,7 @@ export function processUriTemplate(
 				break;
 
 			case 'Time':
-				value = time ? Math.round(time) : time;
+				value = (typeof time === 'number') ? Math.round(time) : time;
 				break;
 
 			default:

--- a/lib/src/dash/processUriTemplate.ts
+++ b/lib/src/dash/processUriTemplate.ts
@@ -8,7 +8,7 @@ const TOKENS = /\$(RepresentationID|Number|SubNumber|Bandwidth|Time)?(?:%0([0-9]
  * @param number - Number.
  * @param subNumber - Sub-number.
  * @param bandwidth - Bandwidth.
- * @param time - Time. If the value is larger than MAX_SAFE_INTEGER, it should be provided as a string.
+ * @param time - Time. Should be passed as a number unless the value is larger than `MAX_SAFE_INTEGER`, it should be provided as a string. If the value is a string all format tags will be ignored.
  *
  * @returns Processed URI template.
  *

--- a/lib/src/dash/processUriTemplate.ts
+++ b/lib/src/dash/processUriTemplate.ts
@@ -8,7 +8,7 @@ const TOKENS = /\$(RepresentationID|Number|SubNumber|Bandwidth|Time)?(?:%0([0-9]
  * @param number - Number.
  * @param subNumber - Sub-number.
  * @param bandwidth - Bandwidth.
- * @param time - Time. Should be passed as a number unless the value is larger than `MAX_SAFE_INTEGER`, it should be provided as a string. If the value is a string all format tags will be ignored.
+ * @param time - Time. Should be passed as a number unless the value is larger than `MAX_SAFE_INTEGER`, then it should be provided as a string. If the value is a string all format tags will be ignored.
  *
  * @returns Processed URI template.
  *

--- a/lib/test/dash/processUriTemplate.test.ts
+++ b/lib/test/dash/processUriTemplate.test.ts
@@ -249,4 +249,14 @@ describe('processUriTemplate', () => {
 			'/000b4_B4_180_264.mp4',
 		);
 	});
+
+	it('handles Times bigger than MAX_SAFE_INTEGER', () => {
+		equal(
+			processUriTemplate(
+				'/example/$Time$.mp4',
+				null, null, null, null, '17472959488675333',
+			),
+			'/example/17472959488675333.mp4',
+		);
+	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@svta/common-media-library-workspace",
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@svta/common-media-library-workspace",
-			"version": "0.12.3",
+			"version": "0.12.4",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"lib",
@@ -34,7 +34,7 @@
 		},
 		"dev": {
 			"name": "@svta/common-media-library-dev",
-			"version": "0.12.3",
+			"version": "0.12.4",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@web/dev-server": "0.4.6"
@@ -42,12 +42,12 @@
 		},
 		"docs": {
 			"name": "@svta/common-media-library-docs",
-			"version": "0.12.3",
+			"version": "0.12.4",
 			"license": "Apache-2.0"
 		},
 		"lib": {
 			"name": "@svta/common-media-library",
-			"version": "0.12.3",
+			"version": "0.12.4",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@babel/code-frame": {
@@ -6056,7 +6056,7 @@
 			}
 		},
 		"samples/cmaf-ham-conversion": {
-			"version": "0.12.3",
+			"version": "0.12.4",
 			"license": "ISC",
 			"dependencies": {
 				"@svta/common-media-library": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/common-media-library-workspace",
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library",
 	"authors": "Casey Occhialini <1508707+littlespex@users.noreply.github.com>",

--- a/samples/cmaf-ham-conversion/package.json
+++ b/samples/cmaf-ham-conversion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cmaf-ham-conversion",
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"description": "",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Description
see: #190 & https://github.com/Dash-Industry-Forum/dash.js/issues/4774

## Requirements Checklist
- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated
