### PR TITLE
chore: update node dev version to 24

### DIFF
--- a/.github/workflows/ci.pr.yml
+++ b/.github/workflows/ci.pr.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 23
+          node-version: 24
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
           scope: "@svta"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 23
-          cache: 'npm'
+          node-version: 24
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
           scope: "@svta"
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 23
+          node-version: 24
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
           scope: "@svta"

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       tag:
         description: "The npm tag (i.e @svta/common-media-library@dev)"
-        default: 'dev'
+        default: "dev"
         required: true
       id:
         description: "An id to append to the version. Defaults to the current timestamp"
@@ -31,8 +31,8 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 23
-          cache: 'npm'
+          node-version: 24
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
           scope: "@svta"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 23
-          cache: 'npm'
+          node-version: 24
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
           scope: "@svta"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Update Node.js development version to 24
+  ([#211](https://github.com/streaming-video-technology-alliance/common-media-library/issues/211))
+
 ## [0.13.0] - 2025-06-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": ">=23.9.0",
+			"version": ">=24",
 			"onFail": "error"
 		}
 	},


### PR DESCRIPTION
## Description

Resolves: #211 

The current dev version, 23.9.0, reached end of life and is no longer supported. Update to LTS version 24. This only affects devs. The library is still backward compatible to version 20.

## Requirements Checklist
- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated
