### PR TITLE
Fix: retain query params in `urlToRelativePath`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Scan through our [existing issues](https://github.com/streaming-video-technology
 
 1. Create a working branch and start with your changes!
 
-1. Update the [CHANGELOG](./CHANGELOG.md). Make sure to update the change log with the change you've made, along with a referene to the issue.
+1. Update the [CHANGELOG](./CHANGELOG.md). Make sure to update the change log with the change you've made, along with a reference to the issue.
 
 1. Add yourself to the [Contributors List](./CONTRIBUTORS.md) if you haven't already.
 
@@ -44,7 +44,7 @@ Scan through our [existing issues](https://github.com/streaming-video-technology
 
 1. Make sure all tests pass by running `npm run test`.
 
-1. Mare sure to include a committ message that describes the change, following the [Conventional Commits](https://www.conventionalcommits.org/) format.
+1. Mare sure to include a commit message that describes the change, following the [Conventional Commits](https://www.conventionalcommits.org/) format.
 
 ### Pull Request
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Please add entries to the bottom of the list in the following format:
 - @agajassi [Agajan Jumakuliyev, Paramount]
 - @willdharris [Will Harris, Paramount]
 - @beraliv [Alexey Berezin, DAZN]
+- @mcintyrehh [Henry McIntyre, Vimeo]

--- a/lib/README.md
+++ b/lib/README.md
@@ -12,7 +12,7 @@ npm install @svta/common-media-library
 ```
 
 ## Usage
-Too ensure the smallest bundle sizes possible, it is best practice to import all members and type definitions
+To ensure the smallest bundle sizes possible, it is best practice to import all members and type definitions
 individually from the library.
 ```typescript
 import { appendCmcdQuery } from '@svta/common-media-library/cmcd/appendCmcdQuery';

--- a/lib/src/utils/urlToRelativePath.ts
+++ b/lib/src/utils/urlToRelativePath.ts
@@ -32,5 +32,8 @@ export function urlToRelativePath(url: string, base: string): string {
 		toPath.unshift('..');
 	}
 
-	return toPath.join('/');
+	const relativePath = toPath.join('/');
+
+	// preserve query parameters and hash of the destination url
+	return relativePath + to.search + to.hash;
 }

--- a/lib/test/utils/urlToRelativePath.test.ts
+++ b/lib/test/utils/urlToRelativePath.test.ts
@@ -24,7 +24,11 @@ describe('urlToRelativePath', () => {
 
 	});
 
-	it('return url when origins are different', () => {
+	it('returns url when origins are different', () => {
 		equal(urlToRelativePath('http://foo.com/1.mp4', 'http://test.com/base/manifest/manifest.mpd'), 'http://foo.com/1.mp4');
+	});
+
+	it('maintains query parameters and hash in the relative path', () => {
+		equal(urlToRelativePath('http://test.com/base/segments/video/1.mp4?param=foo&another=bar#hash=baz', 'http://test.com/base/manifest/manifest.mpd'), '../segments/video/1.mp4?param=foo&another=bar#hash=baz');
 	});
 });


### PR DESCRIPTION
## Description
Please describe the changes:
- Updates the `urlToRelativePath` util to persist the destination url's query params and hash in the relative path that is returned.

In the case of CMCD's `nor` key it is important to persist the original url's query params, as these may contain signatures or other information required for the pre-fetching of the next segment. 

## Requirements Checklist
- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated
