### PR TITLE
fix: Empty CMCDv2 keys array sends mandatory keys

### DIFF
--- a/libs/cmcd/src/prepareCmcdData.ts
+++ b/libs/cmcd/src/prepareCmcdData.ts
@@ -109,10 +109,6 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 		keys = keys.filter(filter)
 	}
 
-	if (keys.length === 0) {
-		return results
-	}
-
 	// Ensure all required event keys are present before sorting
 	const needsTimestamp = reportingMode === CMCD_EVENT_MODE
 
@@ -132,6 +128,10 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 
 	if (version > 1 && !keys.includes('v')) {
 		keys.push('v')
+	}
+
+	if (keys.length === 0) {
+		return results
 	}
 
 	const formatters = Object.assign({}, CMCD_FORMATTER_MAP, options.formatters)


### PR DESCRIPTION
## Description

Please describe the changes:

This PR fixes a bug where configuring an empty keys array would also filter out mandatory keys. With the new implementation, the prepareCmcdData function preserves mandatory keys.

## Requirements Checklist

- [ ] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed
- [ ] Docs/guides updated
- [ ] Changelog updated
