### PR TITLE
fix(c2pa): type manifestId as string per C2PA tstr spec

### DIFF
--- a/libs/c2pa/config/cml-c2pa.api.md
+++ b/libs/c2pa/config/cml-c2pa.api.md
@@ -91,7 +91,7 @@ export type ManifestBoxValidationState = {
 // @public
 export type SegmentValidationResult = {
     readonly sequenceNumber: number;
-    readonly manifestId: Uint8Array;
+    readonly manifestId: string;
     readonly bmffHashHex: string | null;
     readonly kidHex: string | null;
     readonly sequenceResult: SequenceValidationResult;

--- a/libs/c2pa/src/segment/SegmentValidation.ts
+++ b/libs/c2pa/src/segment/SegmentValidation.ts
@@ -10,7 +10,7 @@ import type { SequenceValidationResult } from '../vsi/SequenceState.ts'
  */
 export type SegmentValidationResult = {
 	readonly sequenceNumber: number
-	readonly manifestId: Uint8Array
+	readonly manifestId: string
 	readonly bmffHashHex: string | null
 	readonly kidHex: string | null
 	readonly sequenceResult: SequenceValidationResult

--- a/libs/c2pa/src/vsi/VsiMap.ts
+++ b/libs/c2pa/src/vsi/VsiMap.ts
@@ -16,5 +16,5 @@ export type VsiMap = {
 		readonly alg: string
 		readonly exclusions: readonly BmffHashExclusion[]
 	}
-	readonly manifestId: Uint8Array
+	readonly manifestId: string
 }

--- a/libs/c2pa/src/vsi/decodeVsiMap.ts
+++ b/libs/c2pa/src/vsi/decodeVsiMap.ts
@@ -38,7 +38,7 @@ export function decodeVsiMap(vsiCborBytes: Uint8Array): VsiMap {
 	if (exclusions !== undefined && !Array.isArray(exclusions)) throw new Error('VSI map bmffHash.exclusions must be an array')
 
 	const manifestId = raw['manifestId']
-	if (!(manifestId instanceof Uint8Array)) throw new Error('VSI map missing or invalid manifestId')
+	if (typeof manifestId !== 'string') throw new Error('VSI map missing or invalid manifestId')
 
 	const alg = normalizeAlgorithmName(bmffHashRaw['alg'] as string | undefined)
 

--- a/libs/c2pa/test/vsi/decodeVsiMap.test.ts
+++ b/libs/c2pa/test/vsi/decodeVsiMap.test.ts
@@ -1,14 +1,30 @@
 import { decodeVsiMap } from '../../src/vsi/decodeVsiMap.ts'
-import { throws } from 'node:assert'
+import { deepStrictEqual, strictEqual, throws } from 'node:assert'
 import { describe, it } from 'node:test'
+import { encode } from 'cbor-x/encode'
 
 describe('decodeVsiMap', () => {
 	// #region example
+	it('decodes a valid VSI map with string manifestId', () => {
+		const hash = new Uint8Array([0xaa, 0xbb, 0xcc])
+		const vsiCbor = encode({
+			sequenceNumber: 7,
+			bmffHash: { hash, alg: 'sha256', exclusions: [] },
+			manifestId: 'urn:c2pa:12345',
+		})
+		const result = decodeVsiMap(new Uint8Array(vsiCbor))
+		strictEqual(result.sequenceNumber, 7)
+		strictEqual(result.manifestId, 'urn:c2pa:12345')
+		strictEqual(result.bmffHash.alg, 'SHA-256')
+		deepStrictEqual(result.bmffHash.hash, hash)
+		deepStrictEqual(result.bmffHash.exclusions, [])
+	})
+	// #endregion example
+
 	it('throws for non-object CBOR input', () => {
 		// CBOR integer 42 = 0x18 0x2a
 		throws(() => decodeVsiMap(new Uint8Array([0x18, 0x2a])), /VSI map/)
 	})
-	// #endregion example
 
 	it('throws when sequenceNumber is missing', () => {
 		// CBOR empty map {}
@@ -17,5 +33,14 @@ describe('decodeVsiMap', () => {
 
 	it('throws for invalid CBOR input', () => {
 		throws(() => decodeVsiMap(new Uint8Array([0xff, 0xff])))
+	})
+
+	it('throws when manifestId is not a string', () => {
+		const vsiCbor = encode({
+			sequenceNumber: 1,
+			bmffHash: { hash: new Uint8Array([0x01]), alg: 'sha256', exclusions: [] },
+			manifestId: new Uint8Array([0x01, 0x02]),
+		})
+		throws(() => decodeVsiMap(new Uint8Array(vsiCbor)), /manifestId/)
 	})
 })


### PR DESCRIPTION
## Summary

- Fix `manifestId` type from `Uint8Array` to `string` in `VsiMap`, `SegmentValidationResult`, and `decodeVsiMap`
- The C2PA spec defines `manifestId` as `tstr` (CBOR text string), and c2patool produces it as a string
- The previous `instanceof Uint8Array` check always failed for string values, causing all VSI segment validations to throw errors


Spec ref: https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_use_in_an_emsg_box