### PR TITLE
chore: limit dep versions

### DIFF
--- a/libs/c2pa/package.json
+++ b/libs/c2pa/package.json
@@ -54,6 +54,6 @@
 	"peerDependencies": {
 		"@svta/cml-iso-bmff": ">=1.0.1",
 		"@svta/cml-utils": ">=1.0.0",
-		"cbor-x": ">=1.6.0"
+		"cbor-x": "1.6.4"
 	}
 }

--- a/libs/c2pa/package.json
+++ b/libs/c2pa/package.json
@@ -54,6 +54,6 @@
 	"peerDependencies": {
 		"@svta/cml-iso-bmff": ">=1.0.1",
 		"@svta/cml-utils": ">=1.0.0",
-		"cbor-x": "^1.6.4"
+		"cbor-x": ">=1.6.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,8 @@
 			},
 			"peerDependencies": {
 				"@svta/cml-iso-bmff": ">=1.0.1",
-				"cbor-x": "^1.6.4"
+				"@svta/cml-utils": ">=1.0.0",
+				"cbor-x": "1.6.4"
 			}
 		},
 		"libs/cmaf-ham": {


### PR DESCRIPTION
use exact package version