### PR TITLE
fix(c2pa): address release readiness review (#346)

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -18,8 +18,6 @@ and this project adheres to
 - COSE_Sign1 cryptographic support (RFC 9052): decoding, signature verification, key conversion, signer binding
 - X.509 certificate parsing (issuer, validity period)
 - BMFF content hash computation and validation
-- `readC2paManifest(bytes)` — read a C2PA manifest store from raw BMFF bytes
-- `extractManifestCertificate(bytes)` — extract the signing certificate from a BMFF container
 - EMSG box parsing (ISO 14496-12, v0 and v1)
 - VSI (Verifiable Segment Info) CBOR map decoding
 - Sequence number validation (monotonic, gap/duplicate detection)

--- a/libs/c2pa/README.md
+++ b/libs/c2pa/README.md
@@ -16,6 +16,45 @@ npm i @svta/cml-c2pa
 
 > **Note:** `@svta/cml-iso-bmff`, `@svta/cml-utils`, and `cbor-x` are peer dependencies. Most package managers install them automatically, but you may need to add them explicitly.
 
+> **Note:** This library uses the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (`crypto.subtle`) for COSE signature verification and BMFF hash computation. In Node.js 20+ this is available globally. In browsers, `crypto.subtle` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`).
+
+## Usage
+
+### Manifest Box method (per-segment manifests)
+
+```typescript
+import { validateC2paManifestBoxSegment } from '@svta/cml-c2pa'
+import type { ManifestBoxValidationState } from '@svta/cml-c2pa'
+
+let lastManifestId: string | null = null
+let state: ManifestBoxValidationState | undefined
+
+for (const segmentUrl of segmentUrls) {
+  const bytes = new Uint8Array(await fetch(segmentUrl).then(r => r.arrayBuffer()))
+  const { result, nextManifestId, nextState } = await validateC2paManifestBoxSegment(
+    bytes,
+    lastManifestId,
+    state,
+  )
+  lastManifestId = nextManifestId
+  state = nextState
+
+  console.log(result.isValid, result.errorCodes)
+}
+```
+
+### VSI/EMSG method (init segment + media segments)
+
+```typescript
+import { validateC2paInitSegment, validateC2paSegment } from '@svta/cml-c2pa'
+
+const initBytes = new Uint8Array(await fetch(initUrl).then(r => r.arrayBuffer()))
+const init = await validateC2paInitSegment(initBytes)
+
+const segmentBytes = new Uint8Array(await fetch(segmentUrl).then(r => r.arrayBuffer()))
+const validated = await validateC2paSegment(segmentBytes, init.sessionKeys)
+```
+
 ## Docs
 
 - [VSI/EMSG Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/vsi-validation.md) — Validate using Verifiable Segment Info (§19.4)

--- a/libs/c2pa/package.json
+++ b/libs/c2pa/package.json
@@ -3,6 +3,11 @@
 	"version": "0.1.0",
 	"description": "C2PA (Coalition for Content Provenance and Authenticity) live video validation for BMFF/MP4 containers",
 	"license": "Apache-2.0",
+	"authors": [
+		"Casey Occhialini <1508707+littlespex@users.noreply.github.com>",
+		"Nicolás Caballero <8515648+N1Knight@users.noreply.github.com>",
+		"Valentina Giusti <234478367+valentinamgiusti@users.noreply.github.com>"
+	],
 	"type": "module",
 	"homepage": "https://github.com/streaming-video-technology-alliance/common-media-library/tree/main/libs/c2pa",
 	"repository": {

--- a/libs/c2pa/src/bmff/computeBmffHash.ts
+++ b/libs/c2pa/src/bmff/computeBmffHash.ts
@@ -8,7 +8,7 @@ const DEFAULT_HASH_ALG = 'SHA-256'
 /**
  * Options for BMFF content hash computation.
  *
- * @public
+ * @internal
  */
 export type BmffHashOptions = {
 	readonly exclusions?: readonly BmffHashExclusion[]
@@ -87,7 +87,7 @@ function buildHashInput(
  * @example
  * {@includeCode ../../test/bmff/computeBmffHash.test.ts#example}
  *
- * @public
+ * @internal
  */
 export async function computeBmffHash(segmentBytes: Uint8Array, options?: BmffHashOptions): Promise<Uint8Array> {
 	const exclusions = options?.exclusions ?? []

--- a/libs/c2pa/src/cose/decodeCoseSign1.ts
+++ b/libs/c2pa/src/cose/decodeCoseSign1.ts
@@ -39,7 +39,7 @@ function toUint8Array(value: unknown): Uint8Array {
  * @example
  * {@includeCode ../../test/cose/decodeCoseSign1.test.ts#example}
  *
- * @public
+ * @internal
  */
 export function decodeCoseSign1(coseBytes: Uint8Array): CoseSign1 {
 	try {

--- a/libs/c2pa/src/manifestbox/validateC2paManifestBoxSegment.ts
+++ b/libs/c2pa/src/manifestbox/validateC2paManifestBoxSegment.ts
@@ -6,6 +6,9 @@ import { readC2paManifest } from '../readC2paManifest.ts'
 import { bytesToHex, normalizeAlgorithmName } from '../utils.ts'
 import { validateBmffHash } from '../bmff/validateBmffHash.ts'
 import type { BmffHashConstraint, BmffHashExclusion } from '../bmff/BmffHashExclusion.ts'
+import type { InternalManifestData } from '../claim/InternalManifestData.ts'
+import { validateManifestIntegrity } from '../claim/validateManifestIntegrity.ts'
+import { extractCertificateFromSignatureBytes } from '../extractManifestCertificate.ts'
 import type { ManifestBoxValidationResult, ManifestBoxValidationState } from './ManifestBoxValidation.ts'
 
 const LIVE_VIDEO_ASSERTION_LABEL = 'c2pa.livevideo.segment'
@@ -120,21 +123,24 @@ type ParsedManifest = {
 	issuer: string | null
 	liveVideo: LiveVideoFields | null
 	bmff: BmffHashFields
+	internalData: InternalManifestData | null
 }
 
 function parseManifest(bytes: Uint8Array): ParsedManifest {
 	try {
-		const { manifest } = readC2paManifest(bytes)
-		if (!manifest) return { manifest: null, issuer: null, liveVideo: null, bmff: EMPTY_BMFF_HASH }
+		const internalData = readC2paManifest(bytes)
+		const { manifest } = internalData
+		if (!manifest) return { manifest: null, issuer: null, liveVideo: null, bmff: EMPTY_BMFF_HASH, internalData: null }
 
 		return {
 			manifest,
 			issuer: manifest.signatureInfo?.issuer ?? null,
 			liveVideo: parseLiveVideoAssertion(manifest.assertions),
 			bmff: parseBmffHashAssertion(manifest.assertions),
+			internalData,
 		}
 	} catch {
-		return { manifest: null, issuer: null, liveVideo: null, bmff: EMPTY_BMFF_HASH }
+		return { manifest: null, issuer: null, liveVideo: null, bmff: EMPTY_BMFF_HASH, internalData: null }
 	}
 }
 
@@ -204,7 +210,7 @@ export async function validateC2paManifestBoxSegment(
 	readonly nextManifestId: string | null
 	readonly nextState: ManifestBoxValidationState
 }> {
-	const { manifest, issuer, liveVideo, bmff } = parseManifest(bytes)
+	const { manifest, issuer, liveVideo, bmff, internalData } = parseManifest(bytes)
 
 	const sequenceNumber = liveVideo?.sequenceNumber ?? null
 	const previousManifestId = liveVideo?.previousManifestId ?? null
@@ -230,7 +236,14 @@ export async function validateC2paManifestBoxSegment(
 		continuityMethod, previousManifestId, lastManifestId,
 	)
 
-	const errorCodes: (LiveVideoStatusCode | C2paStatusCode)[] = [...liveVideoCodes]
+	const integrityCodes: readonly C2paStatusCode[] = internalData
+		? await validateManifestIntegrity(
+			internalData,
+			internalData.signatureBytes ? extractCertificateFromSignatureBytes(internalData.signatureBytes) : null,
+		)
+		: []
+
+	const errorCodes: (LiveVideoStatusCode | C2paStatusCode)[] = [...liveVideoCodes, ...integrityCodes]
 
 	const currentManifestId = manifest?.instanceId ?? null
 

--- a/libs/c2pa/src/x509/extractCertificateInfo.ts
+++ b/libs/c2pa/src/x509/extractCertificateInfo.ts
@@ -80,7 +80,7 @@ function findRDNValue(issuerValue: Uint8Array, targetOID: Uint8Array): string | 
  * @example
  * {@includeCode ../../test/x509/extractCertificateInfo.test.ts#example}
  *
- * @public
+ * @internal
  */
 export function extractCertificateInfo(certDER: Uint8Array): CertificateInfo | null {
 	try {


### PR DESCRIPTION
Covering https://github.com/streaming-video-technology-alliance/common-media-library/issues/346

## Summary

- Mark internal helpers (`computeBmffHash`, `decodeCoseSign1`, `extractCertificateInfo`) as `@internal` to reduce public API surface before publish
- Add manifest integrity validation (`validateManifestIntegrity`) to the Manifest Box segment validation pipeline
- Remove undocumented function entries from CHANGELOG
- Add usage examples (Manifest Box + VSI/EMSG methods) and Web Crypto requirements note to README
- Add `authors` field to package.json

## Test plan

- [x] All 121 `@svta/cml-c2pa` tests pass (Node 24.14.1)
- [x] Full workspace: 891 pass / 0 fail across all packages
- [x] `typecheck` and `lint` clean
