### PR TITLE
docs(cmcd): document recordEvent's undefined-drop behavior

### DIFF
--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -322,7 +322,10 @@ export class CmcdReporter {
 	 * `BACKGROUNDED_MODE`, `BITRATE_CHANGE`), this method:
 	 * 1. Persists the dedup field from `data` (if present) into the reporter's
 	 *    persistent data store — equivalent to a write-through `update()`.
-	 * 2. Suppresses the event if the field's current value matches the
+	 * 2. Drops the event entirely if the dedup field has no value after the
+	 *    write-through (never set, or cleared via `update({ field: undefined })`).
+	 *    State-change events without their required field would violate CTA-5004-B.
+	 * 3. Suppresses the event if the field's current value matches the
 	 *    last-emitted value (no state transition).
 	 *
 	 * For all other event types, the event is always emitted.


### PR DESCRIPTION
## Summary

- Documents the undefined-drop guard in `CmcdReporter.recordEvent()` TSDoc as step 2, between write-through and dedup
- The behavior shipped in #367 (drop state-change events when the dedup field is `undefined` after write-through) but the TSDoc only listed write-through and dedup, leaving the guard implicit

## Why

Caught during a post-merge doc audit on #367. The implementation has three branches for state-change events — write-through, undefined-drop, dedup — but the TSDoc only described two. The drop branch enforces CTA-5004-B's requirement that state-change events carry their dedup field; without it documented, the spec rationale is invisible to callers reading the API surface.

## Test plan

- [x] No code change, doc-only — existing tests still cover the behavior (`drops PLAY_STATE with no sta defined anywhere`, `drops PLAY_STATE when sta is explicitly cleared to undefined`)
- [x] `npm test -w libs/cmcd` — 263 pass, 0 fail, 2 todo
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)