### PR TITLE
docs(cmcd): clarify CmcdReporter event-firing patterns

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to
 
 ### Changed
 
-- `CmcdReporter.update()` now auto-fires the corresponding state-change event (`PLAY_STATE`, `PLAYBACK_RATE`, `CONTENT_ID`, `BACKGROUNDED_MODE`, `BITRATE_CHANGE`) when a tracked field's value changes. The two-step `update()` + `recordEvent()` pattern still works and is harmlessly deduplicated.
+- `CmcdReporter.update()` now auto-fires the corresponding state-change event (`PLAY_STATE`, `PLAYBACK_RATE`, `CONTENT_ID`, `BACKGROUNDED_MODE`, `BITRATE_CHANGE`) when a tracked field's value changes. A subsequent `recordEvent()` call for the same state-change event is deduplicated, which silently drops any enrichment data passed to it.
 - `CmcdReporter.recordEvent()` with a state-change event now persists the dedup field from its `data` argument into the persistent data store (write-through), keeping `this.data` consistent with the most recently reported value.
 - Consecutive state-change events with the same effective field value are now suppressed, matching CTA-5004-B's definition of these events as state transitions.
 

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Documentation
+
+- Clarify recommended event-firing patterns in `CmcdReporter`: state-change events are fired via `update()`, with snapshot context attached by combining the state field and continuous metrics in a single call. `recordEvent()`'s `data` argument is documented as intended for non-state-change events (custom, error, ad-lifecycle, mute/unmute, expand/collapse, skip). Calling `recordEvent()` for a state-change event after `update()` has auto-fired it silently drops the second call's data; see the user guide for the recommended pattern.
+
 ## [2.4.0] - 2026-05-22
 
 ### Added

--- a/libs/cmcd/docs/user-guide.md
+++ b/libs/cmcd/docs/user-guide.md
@@ -185,41 +185,73 @@ reporter.update({
 
 ## Recording Events
 
-Use the `recordEvent()` method to record player events for event-mode reporting. The second argument is an optional object of data to include in the event report:
+State-change events (`PLAY_STATE`, `PLAYBACK_RATE`, `CONTENT_ID`,
+`BACKGROUNDED_MODE`, `BITRATE_CHANGE`) are fired automatically by
+`update()` whenever a tracked field's value differs from the last
+reported value. Use `update()` as the canonical entry point.
 
 ```typescript
 import { CmcdEventType } from "@svta/cml-cmcd";
 
-// State-change events fire automatically from update() when the value differs
-// from the previously reported value. The reporter emits the corresponding
-// event without an explicit recordEvent() call.
-reporter.update({ sta: "p" });
-// → fires CmcdEventType.PLAY_STATE
+reporter.update({ sta: "p" });        // → fires PLAY_STATE
+reporter.update({ pr: 1.5 });         // → fires PLAYBACK_RATE
+reporter.update({ cid: "movie-42" }); // → fires CONTENT_ID
+reporter.update({ bg: true });        // → fires BACKGROUNDED_MODE
+reporter.update({ br: [5000] });      // → fires BITRATE_CHANGE
 
-reporter.update({ pr: 1.5 });
-// → fires CmcdEventType.PLAYBACK_RATE
-
-reporter.update({ cid: "movie-42" });
-// → fires CmcdEventType.CONTENT_ID
-
-reporter.update({ bg: true });
-// → fires CmcdEventType.BACKGROUNDED_MODE
-
-reporter.update({ br: [5000] });
-// → fires CmcdEventType.BITRATE_CHANGE
-
-// Consecutive same-value updates are deduplicated.
-reporter.update({ sta: "p" }); // dropped (unchanged from the initial update above)
-
-// To attach extra context at the moment of a transition, use recordEvent()
-// directly. The dedup field is persisted into the reporter's data (same as
-// update() would), and additional fields are included in the event payload.
-reporter.recordEvent(CmcdEventType.PLAY_STATE, { sta: "a", bl: [3000] });
-// → fires PLAY_STATE with sta="a" (transition from "p") and bl=[3000]
-
-// recordEvent() is also used for non-state events like CUSTOM_EVENT and ERROR.
-reporter.recordEvent(CmcdEventType.CUSTOM_EVENT, { cen: "custom-event-name" });
+// Consecutive updates with the same value are deduplicated.
+reporter.update({ sta: "p" }); // dropped (unchanged)
 ```
+
+### Snapshot context on state changes
+
+Pass continuous metrics alongside the state field in the same `update()`
+call. They're persisted into the reporter's data and emitted with the
+auto-fired event:
+
+```typescript
+reporter.update({ sta: "p", bl: [3000], mtp: [8500], pt: 12500 });
+// → fires PLAY_STATE with sta="p", bl=[3000], mtp=[8500], pt=12500
+```
+
+Persisting these fields also makes `TIME_INTERVAL` reports useful:
+they're emitted by the reporter on a timer and carry whatever is in
+the reporter's data store at that moment. Keep continuous metrics
+fresh by calling `update()` as they change in the player.
+
+### Don't pair `update()` with `recordEvent()` for the same state-change field
+
+The second call's payload is dropped by dedup:
+
+```typescript
+reporter.update({ sta: "p" });                              // auto-fires PLAY_STATE
+reporter.recordEvent(CmcdEventType.PLAY_STATE, {            // suppressed:
+  sta: "p",                                                 //   sta unchanged
+  bl: [3000],                                               //   bl never emitted
+});
+```
+
+Use the single-call form shown above instead.
+
+### Using `recordEvent()`
+
+`recordEvent()` is for events whose payload is intrinsic to the event
+call — they don't represent a persisted state transition:
+
+```typescript
+// Custom event: the name and any payload only make sense for this call.
+reporter.recordEvent(CmcdEventType.CUSTOM_EVENT, { cen: "ad-quartile" });
+
+// Error: ec/et describe this specific error.
+reporter.recordEvent(CmcdEventType.ERROR, { ec: "FATAL", et: "network" });
+
+// Ad lifecycle, mute/unmute, player expand/collapse, skip.
+reporter.recordEvent(CmcdEventType.AD_START, { /* ad metadata */ });
+reporter.recordEvent(CmcdEventType.MUTE);
+```
+
+For `RESPONSE_RECEIVED`, prefer `recordResponseReceived()` (see below)
+— it derives the per-response fields for you.
 
 ### Recording Response Received Events
 

--- a/libs/cmcd/docs/user-guide.md
+++ b/libs/cmcd/docs/user-guide.md
@@ -205,19 +205,33 @@ reporter.update({ sta: "p" }); // dropped (unchanged)
 
 ### Snapshot context on state changes
 
-Pass continuous metrics alongside the state field in the same `update()`
-call. They're persisted into the reporter's data and emitted with the
-auto-fired event:
+Auto-fired events emit whatever is currently in the reporter's
+persistent data store. Snapshot context can be attached either by
+combining the continuous metrics with the state field in a single
+`update()` call:
 
 ```typescript
 reporter.update({ sta: "p", bl: [3000], mtp: [8500], pt: 12500 });
 // → fires PLAY_STATE with sta="p", bl=[3000], mtp=[8500], pt=12500
 ```
 
-Persisting these fields also makes `TIME_INTERVAL` reports useful:
-they're emitted by the reporter on a timer and carry whatever is in
-the reporter's data store at that moment. Keep continuous metrics
-fresh by calling `update()` as they change in the player.
+…or by persisting them via earlier `update()` calls so they're already
+in the data store when the state field changes:
+
+```typescript
+// Keep metrics fresh as the player computes them
+reporter.update({ bl: [3000], mtp: [8500], pt: 12500 });
+
+// Later, when state changes
+reporter.update({ sta: "p" });
+// → fires PLAY_STATE with sta="p", bl=[3000], mtp=[8500], pt=12500
+```
+
+The same pattern keeps `TIME_INTERVAL` reports useful: those events
+are emitted by the reporter on a timer and carry whatever is in the
+reporter's data store at that moment, with no caller hook for
+per-event data. Keep continuous metrics fresh via `update()` as they
+change in the player.
 
 ### Don't pair `update()` with `recordEvent()` for the same state-change field
 

--- a/libs/cmcd/docs/user-guide.md
+++ b/libs/cmcd/docs/user-guide.md
@@ -242,8 +242,9 @@ call — they don't represent a persisted state transition:
 // Custom event: the name and any payload only make sense for this call.
 reporter.recordEvent(CmcdEventType.CUSTOM_EVENT, { cen: "ad-quartile" });
 
-// Error: ec/et describe this specific error.
-reporter.recordEvent(CmcdEventType.ERROR, { ec: "FATAL", et: "network" });
+// Error: ec carries the player error code(s). Per CTA-5004-B the list
+// notation is required even for a single code.
+reporter.recordEvent(CmcdEventType.ERROR, { ec: ["FATAL"] });
 
 // Ad lifecycle, mute/unmute, player expand/collapse, skip.
 reporter.recordEvent(CmcdEventType.AD_START, { /* ad metadata */ });

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -290,6 +290,14 @@ export class CmcdReporter {
 	 * `cid` → `bg` → `br`. The order of keys in the input object does not
 	 * affect the firing order.
 	 *
+	 * To attach snapshot context (e.g., `bl`, `mtp`, `pt`, `ltc`) to a
+	 * state-change event, include those fields in the same `update()` call
+	 * as the state field. They are persisted into the reporter's data and
+	 * emitted with the auto-fired event. This is also how to keep
+	 * `TIME_INTERVAL` reports useful — those events draw from the
+	 * persistent data store with no caller hook for per-event data, so
+	 * fields the player wants in periodic reports must be kept fresh here.
+	 *
 	 * A `sid` change resets the dedup baseline.
 	 *
 	 * @param data - The data to update.
@@ -333,9 +341,19 @@ export class CmcdReporter {
 	 *
 	 * For all other event types, the event is always emitted.
 	 *
-	 * Most callers can rely on {@link CmcdReporter.update} to auto-fire state-change events.
-	 * Use `recordEvent` directly when you need to attach extra context to the
-	 * event report (e.g., `bl`, `pt` at the moment of a play-state transition).
+	 * For state-change events, prefer {@link CmcdReporter.update} — including
+	 * for snapshot enrichment via a combined call like
+	 * `update({ sta: 'p', bl: [3000], mtp: [8500] })`. Calling `recordEvent()`
+	 * for a state-change event after `update()` has already auto-fired it
+	 * silently drops the second call's `data`, because dedup suppresses the
+	 * second emission.
+	 *
+	 * Use `recordEvent()` directly for events whose payload is intrinsic to
+	 * the event call — `CUSTOM_EVENT` with `cen`, `ERROR` with `ec`/`et`,
+	 * ad-lifecycle events, `MUTE`/`UNMUTE`, `PLAYER_EXPAND`/`PLAYER_COLLAPSE`,
+	 * `SKIP`. For `RESPONSE_RECEIVED`, prefer
+	 * {@link CmcdReporter.recordResponseReceived}, which derives the
+	 * per-response fields automatically.
 	 *
 	 * @param type - The type of event to record.
 	 * @param data - Additional data to record with the event. This data

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -349,7 +349,7 @@ export class CmcdReporter {
 	 * second emission.
 	 *
 	 * Use `recordEvent()` directly for events whose payload is intrinsic to
-	 * the event call — `CUSTOM_EVENT` with `cen`, `ERROR` with `ec`/`et`,
+	 * the event call — `CUSTOM_EVENT` with `cen`, `ERROR` with `ec`,
 	 * ad-lifecycle events, `MUTE`/`UNMUTE`, `PLAYER_EXPAND`/`PLAYER_COLLAPSE`,
 	 * `SKIP`. For `RESPONSE_RECEIVED`, prefer
 	 * {@link CmcdReporter.recordResponseReceived}, which derives the

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -291,12 +291,14 @@ export class CmcdReporter {
 	 * affect the firing order.
 	 *
 	 * To attach snapshot context (e.g., `bl`, `mtp`, `pt`, `ltc`) to a
-	 * state-change event, include those fields in the same `update()` call
-	 * as the state field. They are persisted into the reporter's data and
-	 * emitted with the auto-fired event. This is also how to keep
-	 * `TIME_INTERVAL` reports useful — those events draw from the
-	 * persistent data store with no caller hook for per-event data, so
-	 * fields the player wants in periodic reports must be kept fresh here.
+	 * state-change event, ensure those fields are in the reporter's data
+	 * before the state field changes. Either include them alongside the
+	 * state field in the same `update()` call, or persist them via earlier
+	 * `update()` calls — auto-fired events emit whatever is currently in
+	 * the persistent data store. This is also how to keep `TIME_INTERVAL`
+	 * reports useful — those events draw from the persistent data store
+	 * with no caller hook for per-event data, so fields the player wants
+	 * in periodic reports must be kept fresh here.
 	 *
 	 * A `sid` change resets the dedup baseline.
 	 *


### PR DESCRIPTION
## Summary

- Document `update()` as the canonical path for state-change event emission, including snapshot enrichment via combined calls (e.g., `update({ sta: 'p', bl: [3000], mtp: [8500] })`).
- Re-scope `recordEvent()`'s `data` argument to non-state-change events (custom, error, ad-lifecycle, mute/unmute, expand/collapse, skip) in both the TSDoc and the user guide.
- Flag the `update() + recordEvent()` double-call as a dedup footgun that silently drops the second payload — surfaced by reviewing dash.js's existing pattern under the 2.4.0 auto-fire behavior.
- Add a `### Documentation` entry to the `[Unreleased]` CHANGELOG section.

## Background

2.4.0 added auto-firing of state-change events from `CmcdReporter.update()`. Reviewing how dash.js wires up CMCD (`CmcdController.js` / `CmcdModel.js` on the `development` branch) showed that their existing `update({ sta }); recordEvent('ps', getEventModeData())` pattern silently loses enrichment data under 2.4.0: the first call auto-fires `ps` with bare persisted state, and the second `recordEvent` call is dedup-suppressed because `lastEmitted.sta` already matches.

No API or behavior changes are in this PR. The fix is documentation: callers should put continuous metrics (`bl`, `mtp`, `pt`, `ltc`) in `update()` — either combined with the state field in one call, or kept fresh in separate `update()` calls so they're available when state changes auto-fire. This also makes `TIME_INTERVAL` reports useful, since those events draw exclusively from the persistent data store with no caller hook for per-event data.

## Files touched

- `libs/cmcd/src/CmcdReporter.ts` — TSDoc on `update()` and `recordEvent()`.
- `libs/cmcd/docs/user-guide.md` — `## Recording Events` section rewrite with new subsections for snapshot context, the dedup-footgun warning, and re-scoped `recordEvent()` examples.
- `libs/cmcd/CHANGELOG.md` — new `### Documentation` entry under `[Unreleased]`.

`libs/cmcd/config/cml-cmcd.api.md` is unchanged (TSDoc body text doesn't flow into the extracted API surface).

## Test plan

- [x] `npm run build -w libs/cmcd` (tsdown + api-extractor) passes
- [x] `libs/cmcd/config/cml-cmcd.api.md` shows no diff
- [x] `npm test -w libs/cmcd` passes (341/343, 2 pre-existing todos)
- [x] `npx eslint libs/cmcd/src/CmcdReporter.ts` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)