### PR TITLE
fix(c2pa): enforce 8-byte offset prefix for the flat v3 init hash

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `validateC2paInitSegment` now enforces the 8-byte box-offset prefix (C2PA §18.6.2) when verifying the flat `c2pa.hash.bmff.v3` assertion hash, matching c2pa-rs; unprefixed flat hashes are no longer accepted
+
 ## [1.0.1] - 2026-05-13
 
 ### Changed

--- a/libs/c2pa/src/init/validateC2paInitSegment.ts
+++ b/libs/c2pa/src/init/validateC2paInitSegment.ts
@@ -6,13 +6,13 @@ import type { C2paStatusCode } from '../C2paStatusCode.ts'
 import { LiveVideoStatusCode } from '../LiveVideoStatusCode.ts'
 import { readC2paManifest } from '../readC2paManifest.ts'
 import { extractCertificateFromSignatureBytes } from '../extractManifestCertificate.ts'
-import { validateBmffHash } from '../bmff/validateBmffHash.ts'
+import { computeBmffHash } from '../bmff/computeBmffHash.ts'
 import type { BmffHashExclusion } from '../bmff/BmffHashExclusion.ts'
 import { validateManifestIntegrity } from '../claim/validateManifestIntegrity.ts'
 import { convertCoseKeyToJwk } from '../cose/convertCoseKeyToJwk.ts'
 import { verifySignerBinding } from '../cose/verifySignerBinding.ts'
 import type { InitSegmentValidation, ValidatedSessionKey } from './InitSegmentValidation.ts'
-import { bytesToHex, isKeyExpired, normalizeAlgorithmName } from '../utils.ts'
+import { bytesToHex, hashesEqual, isKeyExpired, normalizeAlgorithmName } from '../utils.ts'
 
 const BMFF_HASH_ASSERTION_LABEL = 'c2pa.hash.bmff.v3'
 const SESSION_KEYS_ASSERTION_LABEL = 'c2pa.session-keys'
@@ -98,7 +98,10 @@ async function validateBmffHashAssertion(
 		rawHash instanceof Uint8Array ? rawHash : new Uint8Array(rawHash as number[])
 	const alg = normalizeAlgorithmName(data['alg'] as string | undefined)
 	const exclusions = (data['exclusions'] as BmffHashExclusion[] | undefined) ?? []
-	return validateBmffHash(bytes, expectedHash, { exclusions, alg })
+	// §18.6.2: the flat v2/v3 hash covers offset || data for every non-excluded root
+	// box; only Merkle tree hashes may omit the 8-byte offset prefix.
+	const computed = await computeBmffHash(bytes, { exclusions, alg, offsetPrefixSize: 8 })
+	return hashesEqual(computed, expectedHash)
 }
 
 type SessionKeyFields = {

--- a/libs/c2pa/test/init/validateC2paInitSegment.test.ts
+++ b/libs/c2pa/test/init/validateC2paInitSegment.test.ts
@@ -1,6 +1,9 @@
 import { validateC2paInitSegment, LiveVideoStatusCode } from '@svta/cml-c2pa'
-import { deepStrictEqual, rejects, strictEqual } from 'node:assert'
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
+import { readFileSync } from 'node:fs'
 import { describe, it } from 'node:test'
+import { encode } from 'cbor-x/encode'
+import { computeBmffHash } from '../../src/bmff/computeBmffHash.ts'
 
 describe('validateC2paInitSegment', () => {
 	// #region example
@@ -23,5 +26,99 @@ describe('validateC2paInitSegment', () => {
 		strictEqual(result.isValid, false)
 		strictEqual(result.manifest, null)
 		deepStrictEqual(result.errorCodes, [LiveVideoStatusCode.INIT_INVALID])
+	})
+})
+
+describe('validateC2paInitSegment — BMFF hash assertion offset prefix (§18.6.2)', () => {
+	const TEXT_ENCODER = new TextEncoder()
+
+	// JUMBF UUID per ISO 19566-5 (same value as the internal JUMBF_UUID in src/utils.ts)
+	const JUMBF_UUID = [
+		0xd8, 0xfe, 0xc3, 0xd6, 0x1b, 0x0e, 0x48, 0x3c,
+		0x92, 0x97, 0x58, 0x28, 0x87, 0x7e, 0xc4, 0x81,
+	] as const
+
+	function concatBytes(...parts: readonly Uint8Array[]): Uint8Array {
+		const out = new Uint8Array(parts.reduce((sum, p) => sum + p.length, 0))
+		let offset = 0
+		for (const part of parts) {
+			out.set(part, offset)
+			offset += part.length
+		}
+		return out
+	}
+
+	function buildBox(type: string, payload: Uint8Array = new Uint8Array(0)): Uint8Array {
+		const box = new Uint8Array(8 + payload.length)
+		new DataView(box.buffer).setUint32(0, box.length, false)
+		for (let i = 0; i < 4; i++) box[4 + i] = type.charCodeAt(i)
+		box.set(payload, 8)
+		return box
+	}
+
+	function buildJumd(label: string): Uint8Array {
+		const labelBytes = TEXT_ENCODER.encode(label)
+		const data = new Uint8Array(16 + 1 + labelBytes.length + 1)
+		data[16] = 0x03 // toggles: requestable + label present
+		data.set(labelBytes, 17)
+		return buildBox('jumd', data)
+	}
+
+	function buildJumb(label: string, ...content: readonly Uint8Array[]): Uint8Array {
+		return buildBox('jumb', concatBytes(buildJumd(label), ...content))
+	}
+
+	function buildInitMediaBoxes(): Uint8Array {
+		return concatBytes(buildBox('ftyp', TEXT_ENCODER.encode('isom')), buildBox('moov'))
+	}
+
+	// Unsigned init segment with a `c2pa.hash.bmff.v3` assertion; no signature box,
+	// so integrity checks skip signature verification.
+	function buildInitSegment(assertionData: Record<string, unknown>): Uint8Array {
+		const bmffAssertion = buildJumb('c2pa.hash.bmff.v3', buildBox('cbor', encode(assertionData) as Uint8Array))
+		const assertionStore = buildJumb('c2pa.assertions', bmffAssertion)
+		const claimData = { instanceID: 'urn:uuid:bmff-hash-test-manifest', created_assertions: [] }
+		const claim = buildJumb('c2pa.claim', buildBox('cbor', encode(claimData) as Uint8Array))
+		const manifestJumb = buildJumb('urn:uuid:bmff-hash-test-manifest', claim, assertionStore)
+		const store = buildJumb('c2pa', manifestJumb)
+
+		const purpose = TEXT_ENCODER.encode('manifest')
+		const prefix = new Uint8Array(4 + purpose.length + 1 + 8) // fullbox header + purpose\0 + aux offset
+		prefix.set(purpose, 4)
+		const uuidBox = buildBox('uuid', concatBytes(new Uint8Array(JUMBF_UUID), prefix, store))
+
+		return concatBytes(buildInitMediaBoxes(), uuidBox)
+	}
+
+	// /uuid is excluded, so the flat hash covers only ftyp + moov — computable up front.
+	async function buildInitWithFlatHash(offsetPrefixSize: number): Promise<Uint8Array> {
+		const hash = await computeBmffHash(buildInitMediaBoxes(), { offsetPrefixSize })
+		return buildInitSegment({ exclusions: [{ xpath: '/uuid' }], alg: 'sha256', hash })
+	}
+
+	it('accepts a flat hash computed with 8-byte box-offset prefixes', async () => {
+		const init = await buildInitWithFlatHash(8)
+
+		const result = await validateC2paInitSegment(init)
+
+		strictEqual(result.errorCodes.includes(LiveVideoStatusCode.INIT_INVALID), false)
+	})
+
+	it('rejects a flat hash computed without box-offset prefixes', async () => {
+		const init = await buildInitWithFlatHash(0)
+
+		const result = await validateC2paInitSegment(init)
+
+		ok(result.errorCodes.includes(LiveVideoStatusCode.INIT_INVALID))
+	})
+
+	it('accepts the flat hash of a real signed init segment', async () => {
+		const bytes = new Uint8Array(
+			readFileSync(new URL('../fixtures/init_signed_with_session_keys.m4s', import.meta.url)),
+		)
+
+		const result = await validateC2paInitSegment(bytes)
+
+		strictEqual(result.errorCodes.includes(LiveVideoStatusCode.INIT_INVALID), false)
 	})
 })


### PR DESCRIPTION
## Summary

`validateC2paInitSegment` verified the flat `c2pa.hash.bmff.v3` assertion hash through the lenient dual-mode `validateBmffHash` helper, which tries the 8-byte box-offset prefix first and then falls back to no prefix. C2PA 2.4 §18.6.2 is unambiguous for v2/v3 assertions: the hash input for every non-excluded root box is `offset || data` (8-byte big-endian absolute file offset), and the offset is only omitted for Merkle tree hashes when the bmff-hash-map carries both `hash` and `merkle`. The flat hash field always uses offsets, precisely so "a root box included in the hash cannot change positions in the file."

`validateBmffHashAssertion` now computes the hash strictly with `offsetPrefixSize: 8` and compares, instead of accepting either mode. This also aligns the flat-hash path with the Merkle path introduced in #378, which already derives the prefix mode per the spec rule.

## Evidence

- **Spec**: §18.6.2 (quoted above) mandates the offset prefix for the flat v2/v3 hash with no exception.
- **c2pa-rs interop reference**: verification injects an 8-byte big-endian offset entry per non-excluded top-level box when `bmff_version > 1` (`HashRange::set_bmff_offset` in `bmff_io.rs`, hashed via `start.to_be_bytes()` in `hash_utils.rs`). Strict, no fallback mode.
- **Fixtures/encoders**: both real signed fixtures in the repo (`init_signed_with_session_keys.m4s` and `test-segment.m4s`) match only the prefixed mode, so nothing relies on the unprefixed fallback. The fallback shipped with the original helper in #337 before any caller existed and no issue/PR documents a real unprefixed signer.

The dual-mode `validateBmffHash` helper is intentionally unchanged for the VSI (§19.7.3) and manifest-box (§19.7.2) live-segment paths, where its doc comment documents the inter-signer leniency for the draft live workflow.

## Impact

Before, an init segment whose flat assertion hash was computed without offset prefixes (spec-non-compliant signer) validated cleanly; such hashes do not bind box positions, so excluded-box insertion/resizing went undetected for those streams. Now they fail with `INIT_INVALID`, matching what c2pa-rs would report. Spec-compliant streams are unaffected (the prefixed mode was already tried first).

## Test plan

- New regression tests in `validateC2paInitSegment.test.ts`: prefixed flat hash accepted, unprefixed flat hash rejected (fails on the previous code), and the real signed fixture end-to-end.
- `npm test -w=libs/c2pa`: 124/124 pass. Lint, typecheck, and build clean.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated (no public API change; internal comment cites §18.6.2)
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)