### PR TITLE
fix(c2pa): enforce 8-byte offset prefix for the manifest-box v3 hash

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `validateC2paManifestBoxSegment` now enforces the 8-byte box-offset prefix (C2PA §18.6.2) when verifying the flat `c2pa.hash.bmff.v3` assertion hash, matching c2pa-rs; unprefixed flat hashes are no longer accepted. The VSI path (§19.7.3) keeps dual-mode validation since its hash comes from the VSI map, not a §18.6.2 assertion.
+
 ## [1.0.1] - 2026-05-13
 
 ### Changed

--- a/libs/c2pa/src/bmff/validateBmffHash.ts
+++ b/libs/c2pa/src/bmff/validateBmffHash.ts
@@ -18,9 +18,10 @@ export type BmffHashValidationOptions = {
  * Validates the C2PA BMFF content hash (`c2pa.hash.bmff.v3`) for a DASH segment.
  *
  * Tries both offset-prefix modes — 8-byte file offset prefix and no prefix — to handle
- * inter-signer interoperability until a standard signaling mechanism is defined in the spec.
- *
- * Use {@link computeBmffHash} directly when the offset prefix size is known.
+ * inter-signer interoperability for hashes carried in the VSI CBOR map (§19.7.3), where
+ * the spec does not signal the prefix mode. Flat hashes from a `c2pa.hash.bmff.v3`
+ * assertion always use the 8-byte prefix (§18.6.2); verify those with
+ * {@link computeBmffHash} and `offsetPrefixSize: 8` instead.
  *
  * @param segmentBytes - Raw segment bytes to validate
  * @param expectedHash - Expected hash bytes from the VSI CBOR map

--- a/libs/c2pa/src/manifestbox/validateC2paManifestBoxSegment.ts
+++ b/libs/c2pa/src/manifestbox/validateC2paManifestBoxSegment.ts
@@ -3,8 +3,8 @@ import type { C2paManifest } from '../C2paManifest.ts'
 import type { C2paStatusCode } from '../C2paStatusCode.ts'
 import { LiveVideoStatusCode } from '../LiveVideoStatusCode.ts'
 import { readC2paManifest } from '../readC2paManifest.ts'
-import { bytesToHex, normalizeAlgorithmName } from '../utils.ts'
-import { validateBmffHash } from '../bmff/validateBmffHash.ts'
+import { bytesToHex, hashesEqual, normalizeAlgorithmName } from '../utils.ts'
+import { computeBmffHash } from '../bmff/computeBmffHash.ts'
 import type { BmffHashConstraint, BmffHashExclusion } from '../bmff/BmffHashExclusion.ts'
 import type { InternalManifestData } from '../claim/InternalManifestData.ts'
 import { validateManifestIntegrity } from '../claim/validateManifestIntegrity.ts'
@@ -224,10 +224,14 @@ export async function validateC2paManifestBoxSegment(
 
 	let bmffHashMatches = true
 	if (bmff.hashBytes !== null) {
-		bmffHashMatches = await validateBmffHash(bytes, bmff.hashBytes, {
+		// §18.6.2: the flat v2/v3 hash covers offset || data for every non-excluded root
+		// box; only Merkle tree hashes may omit the 8-byte offset prefix.
+		const computed = await computeBmffHash(bytes, {
 			exclusions: bmff.exclusions,
 			alg: bmff.alg ?? undefined,
+			offsetPrefixSize: 8,
 		})
+		bmffHashMatches = hashesEqual(computed, bmff.hashBytes)
 	}
 
 	const liveVideoCodes = collectErrorCodes(

--- a/libs/c2pa/test/manifestbox/validateC2paManifestBoxSegment.test.ts
+++ b/libs/c2pa/test/manifestbox/validateC2paManifestBoxSegment.test.ts
@@ -1,6 +1,9 @@
-import { validateC2paManifestBoxSegment } from '@svta/cml-c2pa'
-import { strictEqual } from 'node:assert'
+import { validateC2paManifestBoxSegment, LiveVideoStatusCode } from '@svta/cml-c2pa'
+import { ok, strictEqual } from 'node:assert'
+import { readFileSync } from 'node:fs'
 import { describe, it } from 'node:test'
+import { encode } from 'cbor-x/encode'
+import { computeBmffHash } from '../../src/bmff/computeBmffHash.ts'
 
 describe('validateC2paManifestBoxSegment', () => {
 	// #region example
@@ -53,5 +56,103 @@ describe('validateC2paManifestBoxSegment', () => {
 		)
 
 		strictEqual(result.errorCodes.includes('livevideo.segment.invalid'), false)
+	})
+})
+
+describe('validateC2paManifestBoxSegment — BMFF hash assertion offset prefix (§18.6.2)', () => {
+	const TEXT_ENCODER = new TextEncoder()
+
+	// JUMBF UUID per ISO 19566-5 (same value as the internal JUMBF_UUID in src/utils.ts)
+	const JUMBF_UUID = [
+		0xd8, 0xfe, 0xc3, 0xd6, 0x1b, 0x0e, 0x48, 0x3c,
+		0x92, 0x97, 0x58, 0x28, 0x87, 0x7e, 0xc4, 0x81,
+	] as const
+
+	function concatBytes(...parts: readonly Uint8Array[]): Uint8Array {
+		const out = new Uint8Array(parts.reduce((sum, p) => sum + p.length, 0))
+		let offset = 0
+		for (const part of parts) {
+			out.set(part, offset)
+			offset += part.length
+		}
+		return out
+	}
+
+	function buildBox(type: string, payload: Uint8Array = new Uint8Array(0)): Uint8Array {
+		const box = new Uint8Array(8 + payload.length)
+		new DataView(box.buffer).setUint32(0, box.length, false)
+		for (let i = 0; i < 4; i++) box[4 + i] = type.charCodeAt(i)
+		box.set(payload, 8)
+		return box
+	}
+
+	function buildJumd(label: string): Uint8Array {
+		const labelBytes = TEXT_ENCODER.encode(label)
+		const data = new Uint8Array(16 + 1 + labelBytes.length + 1)
+		data[16] = 0x03 // toggles: requestable + label present
+		data.set(labelBytes, 17)
+		return buildBox('jumd', data)
+	}
+
+	function buildJumb(label: string, ...content: readonly Uint8Array[]): Uint8Array {
+		return buildBox('jumb', concatBytes(buildJumd(label), ...content))
+	}
+
+	function buildMediaBoxes(): Uint8Array {
+		return concatBytes(
+			buildBox('styp', TEXT_ENCODER.encode('msdh')),
+			buildBox('moof'),
+			buildBox('mdat', TEXT_ENCODER.encode('media payload')),
+		)
+	}
+
+	// Unsigned manifest-box segment with a `c2pa.hash.bmff.v3` assertion; no signature
+	// box, so integrity checks skip signature verification.
+	function buildSegment(assertionData: Record<string, unknown>): Uint8Array {
+		const bmffAssertion = buildJumb('c2pa.hash.bmff.v3', buildBox('cbor', encode(assertionData) as Uint8Array))
+		const assertionStore = buildJumb('c2pa.assertions', bmffAssertion)
+		const claimData = { instanceID: 'urn:uuid:bmff-hash-test-manifest', created_assertions: [] }
+		const claim = buildJumb('c2pa.claim', buildBox('cbor', encode(claimData) as Uint8Array))
+		const manifestJumb = buildJumb('urn:uuid:bmff-hash-test-manifest', claim, assertionStore)
+		const store = buildJumb('c2pa', manifestJumb)
+
+		const purpose = TEXT_ENCODER.encode('manifest')
+		const prefix = new Uint8Array(4 + purpose.length + 1 + 8) // fullbox header + purpose\0 + aux offset
+		prefix.set(purpose, 4)
+		const uuidBox = buildBox('uuid', concatBytes(new Uint8Array(JUMBF_UUID), prefix, store))
+
+		return concatBytes(buildMediaBoxes(), uuidBox)
+	}
+
+	// /uuid is excluded, so the flat hash covers only styp + moof + mdat — computable up front.
+	async function buildSegmentWithFlatHash(offsetPrefixSize: number): Promise<Uint8Array> {
+		const hash = await computeBmffHash(buildMediaBoxes(), { offsetPrefixSize })
+		return buildSegment({ exclusions: [{ xpath: '/uuid' }], alg: 'sha256', hash })
+	}
+
+	it('accepts a flat hash computed with 8-byte box-offset prefixes', async () => {
+		const segment = await buildSegmentWithFlatHash(8)
+
+		const { result } = await validateC2paManifestBoxSegment(segment, null)
+
+		strictEqual(result.errorCodes.includes(LiveVideoStatusCode.SEGMENT_INVALID), false)
+	})
+
+	it('rejects a flat hash computed without box-offset prefixes', async () => {
+		const segment = await buildSegmentWithFlatHash(0)
+
+		const { result } = await validateC2paManifestBoxSegment(segment, null)
+
+		ok(result.errorCodes.includes(LiveVideoStatusCode.SEGMENT_INVALID))
+	})
+
+	it('accepts the flat hash of a real signed manifest-box segment', async () => {
+		const bytes = new Uint8Array(
+			readFileSync(new URL('../fixtures/test-segment.m4s', import.meta.url)),
+		)
+
+		const { result } = await validateC2paManifestBoxSegment(bytes, null)
+
+		strictEqual(result.errorCodes.includes(LiveVideoStatusCode.SEGMENT_INVALID), false)
 	})
 })


### PR DESCRIPTION
## Summary

- `validateC2paManifestBoxSegment` verified the flat `c2pa.hash.bmff.v3` assertion hash of a §19.7.2 live segment via the lenient dual-mode `validateBmffHash` helper, so unprefixed (spec-noncompliant) flat hashes validated cleanly even though they do not bind box positions. C2PA 2.4 §18.6.2 mandates the 8-byte big-endian box-offset prefix for flat v2/v3 assertion hashes; only Merkle tree hashes may omit it.
- The hash is now computed strictly with `offsetPrefixSize: 8` and compared, matching c2pa-rs and the init-segment change from #380. Unprefixed flat hashes now fail with `SEGMENT_INVALID`.
- The VSI path (§19.7.3) intentionally keeps dual-mode validation: its hash comes from the VSI CBOR map, where the spec does not signal a prefix mode. The `validateBmffHash` doc comment now scopes the inter-signer leniency rationale to VSI-sourced hashes.
- The real signed fixture `test-segment.m4s` matches only the prefixed mode (now covered by an end-to-end regression test), so spec-compliant streams are unaffected.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-c2pa | 1.0.1 | fix |

## Test Plan

- [x] New regression tests in `validateC2paManifestBoxSegment.test.ts`: prefixed flat hash accepted, unprefixed flat hash rejected (fails on the previous code), and the real signed `test-segment.m4s` fixture end-to-end
- [x] `npm test -w libs/c2pa`: 124/124 pass
- [x] Lint, typecheck, and docs build clean (0 errors)

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated (no public API change; internal comment cites §18.6.2, helper TSDoc scoped to VSI)
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)