### PR TITLE
fix: guard module-scope reads of web platform globals

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - `validateC2paManifestBoxSegment` now enforces the 8-byte box-offset prefix (C2PA §18.6.2) when verifying the flat `c2pa.hash.bmff.v3` assertion hash, matching c2pa-rs; unprefixed flat hashes are no longer accepted. The VSI path (§19.7.3) keeps dual-mode validation since its hash comes from the VSI map, not a §18.6.2 assertion.
 - `validateC2paInitSegment` now enforces the 8-byte box-offset prefix (C2PA §18.6.2) when verifying the flat `c2pa.hash.bmff.v3` assertion hash, matching c2pa-rs; unprefixed flat hashes are no longer accepted
+- Top-level `TextDecoder` and `TextEncoder` instantiations are now marked side-effect free so consumer bundlers can drop them when unused ([#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
 
 ## [1.0.1] - 2026-05-13
 

--- a/libs/c2pa/src/cose/buildSigStructure.ts
+++ b/libs/c2pa/src/cose/buildSigStructure.ts
@@ -7,7 +7,7 @@ const CBOR_UINT32_LENGTH_INDICATOR = 0x5a
 const CBOR_INLINE_MAX = 23
 const CBOR_UINT8_MAX = 255
 const CBOR_UINT16_MAX = 65535
-const COSE_SIG1_CONTEXT_BYTES = new TextEncoder().encode('Signature1')
+const COSE_SIG1_CONTEXT_BYTES = /* @__PURE__ */ new TextEncoder().encode('Signature1')
 
 function byteStringHeaderSize(length: number): number {
 	if (length <= CBOR_INLINE_MAX) return 1

--- a/libs/c2pa/src/jumbf/parseJumbfLabel.ts
+++ b/libs/c2pa/src/jumbf/parseJumbfLabel.ts
@@ -1,4 +1,4 @@
-const TEXT_DECODER = new TextDecoder()
+const TEXT_DECODER = /* @__PURE__ */ new TextDecoder()
 const JUMD_UUID_SIZE = 16
 const JUMD_TOGGLES_OFFSET = 16
 const JUMD_LABEL_START = 17

--- a/libs/c2pa/src/readC2paManifest.ts
+++ b/libs/c2pa/src/readC2paManifest.ts
@@ -1,4 +1,4 @@
-const TEXT_DECODER = new TextDecoder()
+const TEXT_DECODER = /* @__PURE__ */ new TextDecoder()
 
 import { readIsoBoxes, type ParsedIsoBox } from '@svta/cml-iso-bmff'
 import { decode } from 'cbor-x/decode'

--- a/libs/c2pa/src/x509/extractCertificateInfo.ts
+++ b/libs/c2pa/src/x509/extractCertificateInfo.ts
@@ -1,4 +1,4 @@
-const TEXT_DECODER = new TextDecoder()
+const TEXT_DECODER = /* @__PURE__ */ new TextDecoder()
 
 import type { CertificateInfo } from './CertificateInfo.ts'
 import {

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- The module-scope `MediaKeys.isTypeSupported` probe is now marked side-effect free so consumer bundlers can drop it when `getSupportedKeySystemConfiguration` is unused ([#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+
 ## [1.1.6] - 2026-05-13
 
 ### Changed

--- a/libs/drm/src/keysystem/getSupportedKeySystemConfiguration.ts
+++ b/libs/drm/src/keysystem/getSupportedKeySystemConfiguration.ts
@@ -1,4 +1,9 @@
-const isTypeSupported: (keySystem: string, type: string) => boolean | undefined = (typeof MediaKeys !== 'undefined' && typeof (MediaKeys as any).isTypeSupported === 'function') ? (MediaKeys as any).isTypeSupported : undefined
+// The pure IIFE keeps this module-scope MediaKeys read from being retained by
+// consumer bundlers when this function is unused (unknown global reads are
+// treated as side effects).
+const isTypeSupported: (keySystem: string, type: string) => boolean | undefined = /* @__PURE__ */ (() =>
+	(typeof MediaKeys !== 'undefined' && typeof (MediaKeys as any).isTypeSupported === 'function') ? (MediaKeys as any).isTypeSupported : undefined
+)()
 
 /**
  * Filters and returns the supported key system configuration for a given system string.

--- a/libs/iso-bmff/CHANGELOG.md
+++ b/libs/iso-bmff/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `IsoBoxReadableStream` no longer reads the bare `ReadableStream` global at module scope: importing the package never throws on runtimes without the Web Streams API. Instantiating `IsoBoxReadableStream` on such runtimes throws a descriptive error instead ([#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+
 ## [1.0.2] - 2026-05-13
 
 ### Changed

--- a/libs/iso-bmff/config/cml-iso-bmff.api.md
+++ b/libs/iso-bmff/config/cml-iso-bmff.api.md
@@ -449,8 +449,10 @@ export type IsoBoxMap = {
     vtte: WebVttEmptySampleBox;
 };
 
+// Warning: (ae-forgotten-export) The symbol "ReadableStreamBase" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class IsoBoxReadableStream extends ReadableStream<Uint8Array> {
+export class IsoBoxReadableStream extends ReadableStreamBase<Uint8Array> {
     constructor(boxes: Iterable<IsoBoxStreamable>, config: IsoBoxWriteViewConfig);
 }
 

--- a/libs/iso-bmff/src/IsoBoxReadableStream.ts
+++ b/libs/iso-bmff/src/IsoBoxReadableStream.ts
@@ -3,12 +3,29 @@ import type { IsoBoxWriteViewConfig } from './IsoBoxWriteViewConfig.ts'
 import { createWriterConfig } from './utils/createWriterConfig.ts'
 import { writeIsoBox } from './writeIsoBox.ts'
 
+// Extending the bare ReadableStream global would read it at module scope, which
+// breaks tree-shaking (bundlers treat unknown global reads as side effects) and
+// throws at import time on runtimes without the Web Streams API. Resolve the base
+// class through a guarded local binding instead: `typeof` on an undeclared
+// identifier never throws, and the pure IIFE lets bundlers drop the whole
+// statement when IsoBoxReadableStream is unused.
+const ReadableStreamBase: typeof ReadableStream = /* @__PURE__ */ (() =>
+	typeof ReadableStream === 'undefined'
+		// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+		? class {
+			constructor() {
+				throw new Error('ReadableStream is not available in this environment')
+			}
+		} as unknown as typeof ReadableStream
+		: ReadableStream
+)()
+
 /**
  * A readable stream of ISO BMFF boxes as Uint8Arrays.
  *
  * @public
  */
-export class IsoBoxReadableStream extends ReadableStream<Uint8Array> {
+export class IsoBoxReadableStream extends ReadableStreamBase<Uint8Array> {
 	/**
 	 * Constructs a new IsoBoxReadableStream.
 	 *

--- a/libs/iso-bmff/test/IsoBoxReadableStream.environment.test.ts
+++ b/libs/iso-bmff/test/IsoBoxReadableStream.environment.test.ts
@@ -1,0 +1,27 @@
+import { equal, throws } from 'node:assert'
+import { describe, it } from 'node:test'
+
+// This file must not import @svta/cml-iso-bmff statically: the module has to be
+// evaluated for the first time after ReadableStream has been removed to
+// simulate a runtime without the Web Streams API.
+
+describe('IsoBoxReadableStream in a runtime without ReadableStream', () => {
+	it('can be imported, and instantiation throws a descriptive error', async () => {
+		const NativeReadableStream = globalThis.ReadableStream
+
+		// @ts-expect-error - simulate a runtime without the Web Streams API
+		delete globalThis.ReadableStream
+
+		try {
+			const { fourCcToUint32, IsoBoxReadableStream } = await import('@svta/cml-iso-bmff')
+
+			equal(typeof IsoBoxReadableStream, 'function')
+			throws(() => new IsoBoxReadableStream([], { writers: {} }), /ReadableStream is not available in this environment/)
+
+			// Non-stream exports remain fully usable
+			equal(fourCcToUint32('ftyp'), 0x66747970)
+		} finally {
+			globalThis.ReadableStream = NativeReadableStream
+		}
+	})
+})

--- a/libs/webvtt/CHANGELOG.md
+++ b/libs/webvtt/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `WebVttTransformStream` no longer reads the bare `TransformStream` global at module scope: importing only non-stream exports is now fully tree-shakeable, and importing the package never throws on runtimes without the Web Streams API. Instantiating `WebVttTransformStream` on such runtimes throws a descriptive error instead ([#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+
 ## [1.0.6] - 2026-05-13
 
 ### Changed

--- a/libs/webvtt/config/cml-webvtt.api.md
+++ b/libs/webvtt/config/cml-webvtt.api.md
@@ -134,8 +134,10 @@ export class WebVttTransformer {
     transform(chunk: string, controller: TransformStreamDefaultController<WebVttResult>): void;
 }
 
+// Warning: (ae-forgotten-export) The symbol "TransformStreamBase" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class WebVttTransformStream extends TransformStream<string, WebVttResult> {
+export class WebVttTransformStream extends TransformStreamBase<string, WebVttResult> {
     constructor(writableStrategy?: QueuingStrategy<string>, readableStrategy?: QueuingStrategy<WebVttResult>);
 }
 

--- a/libs/webvtt/src/WebVttTransformStream.ts
+++ b/libs/webvtt/src/WebVttTransformStream.ts
@@ -1,12 +1,29 @@
 import type { WebVttResult } from './WebVttResult.ts'
 import { WebVttTransformer } from './WebVttTransformer.ts'
 
+// Extending the bare TransformStream global would read it at module scope, which
+// breaks tree-shaking (bundlers treat unknown global reads as side effects) and
+// throws at import time on runtimes without the Web Streams API. Resolve the base
+// class through a guarded local binding instead: `typeof` on an undeclared
+// identifier never throws, and the pure IIFE lets bundlers drop the whole
+// statement when WebVttTransformStream is unused.
+const TransformStreamBase: typeof TransformStream = /* @__PURE__ */ (() =>
+	typeof TransformStream === 'undefined'
+		// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+		? class {
+			constructor() {
+				throw new Error('TransformStream is not available in this environment')
+			}
+		} as unknown as typeof TransformStream
+		: TransformStream
+)()
+
 /**
  * WebVTT transform stream.
  *
  * @public
  */
-export class WebVttTransformStream extends TransformStream<string, WebVttResult> {
+export class WebVttTransformStream extends TransformStreamBase<string, WebVttResult> {
 	constructor(writableStrategy?: QueuingStrategy<string>, readableStrategy?: QueuingStrategy<WebVttResult>) {
 		super(new WebVttTransformer(), writableStrategy, readableStrategy)
 	}

--- a/libs/webvtt/test/WebVttTransformStream.environment.test.ts
+++ b/libs/webvtt/test/WebVttTransformStream.environment.test.ts
@@ -1,0 +1,28 @@
+import { equal, throws } from 'node:assert'
+import { describe, it } from 'node:test'
+
+// This file must not import @svta/cml-webvtt statically: the module has to be
+// evaluated for the first time after TransformStream has been removed to
+// simulate a runtime without the Web Streams API.
+
+describe('WebVttTransformStream in a runtime without TransformStream', () => {
+	it('can be imported, and instantiation throws a descriptive error', async () => {
+		const NativeTransformStream = globalThis.TransformStream
+
+		// @ts-expect-error - simulate a runtime without the Web Streams API
+		delete globalThis.TransformStream
+
+		try {
+			const { parseWebVtt, WebVttTransformStream } = await import('@svta/cml-webvtt')
+
+			equal(typeof WebVttTransformStream, 'function')
+			throws(() => new WebVttTransformStream(), /TransformStream is not available in this environment/)
+
+			// Non-stream exports remain fully usable
+			const { cues } = await parseWebVtt('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\ntest')
+			equal(cues.length, 1)
+		} finally {
+			globalThis.TransformStream = NativeTransformStream
+		}
+	})
+})


### PR DESCRIPTION
## Summary

`WebVttTransformStream extends TransformStream` read the bare global in its heritage clause at module evaluation, which broke tree shaking for every consumer of the flat dist bundle and crashed legacy runtimes at import time. This PR guards all module-scope reads of web platform globals found by a monorepo sweep.

Fixes #382

## Root cause

- Bundlers treat reads of unknown globals as potential side effects (Rollup default `treeshake.unknownGlobalSideEffects: true`). `TransformStream` is not in Rollup's known-globals list, so `class extends TransformStream` was retained even when only `parseWebVtt` was imported. `"sideEffects": false` cannot help; it governs whole-module inclusion, not statement-level retention.
- After downstream transpile + minify, the retained class collapses to a bare `TransformStream;` statement that throws `ReferenceError` at script evaluation on Chrome < 67, Safari < 14.1, Firefox < 102, Node < 18. Importing `parseWebVtt` alone was enough to crash a smart-TV runtime.

## Fix

Resolve the base class through a guarded local binding wrapped in a `/* @__PURE__ */` IIFE (approach (a) from the issue):

- `typeof TransformStream === 'undefined'` never throws, even where the global is undeclared. The guard deliberately avoids `globalThis`, which is itself missing on Chrome < 71.
- The heritage clause now reads a local binding, so the class body is tree-shakeable, and the pure annotation (preserved by tsdown into the dist) lets bundlers drop the guard statement itself when unused.
- On runtimes without the Web Streams API, importing the package succeeds and instantiating the stream class throws `Error: TransformStream is not available in this environment`.
- Runtime subclass semantics (`instanceof`, prototype chain) and the declared type surface (`TransformStreamBase: typeof TransformStream`) are unchanged. The separate-entry-point and lazy-factory alternatives were rejected since both are API changes and (a) meets every requirement.

Same treatment applied where the sweep found the pattern:

| Package | Site | Hazard |
| --- | --- | --- |
| webvtt | `WebVttTransformStream extends TransformStream` | retention + legacy import crash |
| iso-bmff | `IsoBoxReadableStream extends ReadableStream` | legacy import crash (`ReadableStream` is in Rollup's known-globals list, so no default-Rollup retention) |
| c2pa | 3x top-level `new TextDecoder()`, 1x `new TextEncoder().encode()` | retention only |
| drm | top-level guarded `MediaKeys.isTypeSupported` probe | retention only |

## Verification

- Rollup 4.52.4, default treeshake, entry importing only `parseWebVtt` from the built dist: **0** `TransformStream` matches (previously retained the full class chain; bundle 16.5KB → 14.5KB).
- Bare `import '<dist>'` probe of every built package: webvtt and iso-bmff retain **nothing**; c2pa and drm retain no platform-global references.
- Node with `delete globalThis.TransformStream` / `delete globalThis.ReadableStream` before first import: import succeeds, instantiation throws the descriptive error. Covered by new `*.environment.test.ts` tests in webvtt and iso-bmff (verified to fail against the previous implementation).
- `npm run lint`, `tsc --noEmit`, and the full workspace test suite pass: 1031 tests, 0 failures (1 pre-existing skip, 2 pre-existing todos).

The sweep also surfaced module-scope eager work retained via ES builtins (cmcd `new Set`/`new Map` key tables, c2pa `Array.from` hex table, drm eager sample-entry reader registration). Those cannot crash legacy runtimes and are deliberately left out of this PR; tracked as a follow-up in #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
