### PR TITLE
fix: drop eagerly-built module-scope tables from consumer bundles

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - `validateC2paManifestBoxSegment` now enforces the 8-byte box-offset prefix (C2PA §18.6.2) when verifying the flat `c2pa.hash.bmff.v3` assertion hash, matching c2pa-rs; unprefixed flat hashes are no longer accepted. The VSI path (§19.7.3) keeps dual-mode validation since its hash comes from the VSI map, not a §18.6.2 assertion.
 - `validateC2paInitSegment` now enforces the 8-byte box-offset prefix (C2PA §18.6.2) when verifying the flat `c2pa.hash.bmff.v3` assertion hash, matching c2pa-rs; unprefixed flat hashes are no longer accepted
+- The module-scope hex lookup table in `bytesToHex` is now marked side-effect free so consumer bundlers can drop it when unused (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
 
 ## [1.0.1] - 2026-05-13
 

--- a/libs/c2pa/src/utils.ts
+++ b/libs/c2pa/src/utils.ts
@@ -14,7 +14,7 @@ export function normalizeAlgorithmName(rawAlg?: string): string {
 	return (rawAlg ?? 'SHA-256').replace(SHA_ALGORITHM_PATTERN, 'SHA-$1')
 }
 
-const HEX_TABLE: readonly string[] = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'))
+const HEX_TABLE: readonly string[] = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'))
 
 /**
  * Converts a Uint8Array to a lowercase hex string.

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Module-scope key-table `Set`/`Map` initializers (and the `CmcdReporter` state-field tables) are now marked side-effect free so consumer bundlers can drop them when unused; a bare import of the package previously retained ~4.9 KB of eagerly-built tables (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+
 ### Documentation
 
 - Clarify recommended event-firing patterns in `CmcdReporter`: state-change events are fired via `update()`, with snapshot context attached by combining the state field and continuous metrics in a single call. `recordEvent()`'s `data` argument is documented as intended for non-state-change events (custom, error, ad-lifecycle, mute/unmute, expand/collapse, skip). Calling `recordEvent()` for a state-change event after `update()` has auto-fired it silently drops the second call's data; see the user guide for the recommended pattern.

--- a/libs/cmcd/src/CMCD_KEYS.ts
+++ b/libs/cmcd/src/CMCD_KEYS.ts
@@ -9,7 +9,7 @@ import type { CmcdKey } from './CmcdKey.ts'
  *
  * @public
  */
-export const CMCD_KEYS: CmcdKey[] = [
+export const CMCD_KEYS: CmcdKey[] = /* @__PURE__ */ [
 	...CMCD_V1_KEYS,
 	...CMCD_REQUEST_KEYS,
 	...CMCD_RESPONSE_KEYS,

--- a/libs/cmcd/src/CMCD_STATE_EVENT_FIELDS.ts
+++ b/libs/cmcd/src/CMCD_STATE_EVENT_FIELDS.ts
@@ -24,7 +24,7 @@ import type { CmcdKey } from './CmcdKey.ts'
  *
  * @internal
  */
-export const CMCD_STATE_EVENT_FIELDS: ReadonlyMap<CmcdEventType, CmcdKey> = new Map([
+export const CMCD_STATE_EVENT_FIELDS: ReadonlyMap<CmcdEventType, CmcdKey> = /* @__PURE__ */ new Map([
 	[CMCD_EVENT_PLAY_STATE, 'sta'],
 	[CMCD_EVENT_PLAYBACK_RATE, 'pr'],
 	[CMCD_EVENT_CONTENT_ID, 'cid'],

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -109,7 +109,7 @@ const identity = <T>(v: T): T => v
  * Maps each tracked state field to its event type and equality function.
  * Order matters: `update()` fires events in this order for multi-field updates.
  */
-const STATE_FIELDS: readonly StateFieldEntry[] = Array.from(
+const STATE_FIELDS: readonly StateFieldEntry[] = /* @__PURE__ */ Array.from(
 	CMCD_STATE_EVENT_FIELDS,
 	([event, field]): StateFieldEntry => {
 		if (field === 'br') {
@@ -124,8 +124,8 @@ const STATE_FIELDS: readonly StateFieldEntry[] = Array.from(
 	},
 )
 
-const STATE_FIELDS_BY_EVENT: ReadonlyMap<CmcdEventType, StateFieldEntry> = new Map(
-	STATE_FIELDS.map(e => [e.event, e]),
+const STATE_FIELDS_BY_EVENT: ReadonlyMap<CmcdEventType, StateFieldEntry> = /* @__PURE__ */ new Map(
+	/* @__PURE__ */ STATE_FIELDS.map(e => [e.event, e]),
 )
 
 function defaultRequester(request: HttpRequest): Promise<{ status: number; }> {

--- a/libs/cmcd/src/isCmcdEventKey.ts
+++ b/libs/cmcd/src/isCmcdEventKey.ts
@@ -3,7 +3,7 @@ import type { Cmcd } from './Cmcd.ts'
 import { isCmcdRequestKey } from './isCmcdRequestKey.ts'
 import { isCmcdResponseReceivedKey } from './isCmcdResponseReceivedKey.ts'
 
-const CMCD_EVENT_KEY_SET: ReadonlySet<string> = new Set(CMCD_EVENT_KEYS)
+const CMCD_EVENT_KEY_SET: ReadonlySet<string> = /* @__PURE__ */ new Set(CMCD_EVENT_KEYS)
 
 /**
  * Check if a key is a valid CMCD event key.

--- a/libs/cmcd/src/isCmcdRequestKey.ts
+++ b/libs/cmcd/src/isCmcdRequestKey.ts
@@ -3,7 +3,7 @@ import type { Cmcd } from './Cmcd.ts'
 import type { CmcdKey } from './CmcdKey.ts'
 import { isCmcdCustomKey } from './isCmcdCustomKey.ts'
 
-const CMCD_REQUEST_KEY_SET: ReadonlySet<string> = new Set(CMCD_REQUEST_KEYS)
+const CMCD_REQUEST_KEY_SET: ReadonlySet<string> = /* @__PURE__ */ new Set(CMCD_REQUEST_KEYS)
 
 /**
  * Check if a key is a valid CMCD request key.

--- a/libs/cmcd/src/isCmcdResponseReceivedKey.ts
+++ b/libs/cmcd/src/isCmcdResponseReceivedKey.ts
@@ -1,7 +1,7 @@
 import { CMCD_RESPONSE_KEYS } from './CMCD_RESPONSE_KEYS.ts'
 import type { Cmcd } from './Cmcd.ts'
 
-const CMCD_RESPONSE_KEY_SET: ReadonlySet<string> = new Set(CMCD_RESPONSE_KEYS)
+const CMCD_RESPONSE_KEY_SET: ReadonlySet<string> = /* @__PURE__ */ new Set(CMCD_RESPONSE_KEYS)
 
 /**
  * Check if a key is a valid CMCD response key.

--- a/libs/cmcd/src/isCmcdV1Key.ts
+++ b/libs/cmcd/src/isCmcdV1Key.ts
@@ -2,7 +2,7 @@ import { CMCD_V1_KEYS } from './CMCD_V1_KEYS.ts'
 import type { CmcdKey } from './CmcdKey.ts'
 import { isCmcdCustomKey } from './isCmcdCustomKey.ts'
 
-const CMCD_V1_KEY_SET: ReadonlySet<string> = new Set(CMCD_V1_KEYS)
+const CMCD_V1_KEY_SET: ReadonlySet<string> = /* @__PURE__ */ new Set(CMCD_V1_KEYS)
 
 /**
  * Filter function for CMCD v1 keys.

--- a/libs/cmcd/src/isTokenField.ts
+++ b/libs/cmcd/src/isTokenField.ts
@@ -1,4 +1,4 @@
-const TOKEN_FIELDS = new Set(['ot', 'sf', 'st', 'e', 'sta'])
+const TOKEN_FIELDS = /* @__PURE__ */ new Set(['ot', 'sf', 'st', 'e', 'sta'])
 
 /**
  * Checks if the given key is a token field.

--- a/libs/cmcd/src/validateCmcdKeys.ts
+++ b/libs/cmcd/src/validateCmcdKeys.ts
@@ -8,8 +8,8 @@ import { CMCD_VALIDATION_SEVERITY_ERROR } from './CmcdValidationSeverity.ts'
 import { isCmcdCustomKey } from './isCmcdCustomKey.ts'
 import { resolveVersion } from './resolveVersion.ts'
 
-const CMCD_V1_KEY_SET: ReadonlySet<string> = new Set(CMCD_V1_KEYS)
-const CMCD_KEY_SET: ReadonlySet<string> = new Set(CMCD_KEYS)
+const CMCD_V1_KEY_SET: ReadonlySet<string> = /* @__PURE__ */ new Set(CMCD_V1_KEYS)
+const CMCD_KEY_SET: ReadonlySet<string> = /* @__PURE__ */ new Set(CMCD_KEYS)
 
 /**
  * Validates that all keys in a CMCD payload are recognized spec keys or valid custom keys.

--- a/libs/cmcd/src/validateCmcdValues.ts
+++ b/libs/cmcd/src/validateCmcdValues.ts
@@ -11,8 +11,8 @@ import { CMCD_VALIDATION_SEVERITY_ERROR, CMCD_VALIDATION_SEVERITY_WARNING } from
 import { isCmcdCustomKey } from './isCmcdCustomKey.ts'
 import { resolveVersion } from './resolveVersion.ts'
 
-const HUNDRED_ROUNDING_KEYS = new Set(['bl', 'dl', 'mtp', 'rtp', 'tbl'])
-const INTEGER_ROUNDING_KEYS = new Set(['br', 'd', 'tb'])
+const HUNDRED_ROUNDING_KEYS = /* @__PURE__ */ new Set(['bl', 'dl', 'mtp', 'rtp', 'tbl'])
+const INTEGER_ROUNDING_KEYS = /* @__PURE__ */ new Set(['br', 'd', 'tb'])
 
 function isFiniteNumber(value: unknown): value is number {
 	return typeof value === 'number' && Number.isFinite(value)

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `ensureEncryptedInit`'s sample-entry reader/writer tables are now built inside side-effect-free initializers, so importing the package no longer eagerly registers ISO BMFF sample-entry readers and consumer bundlers can drop the tables (and their `@svta/cml-iso-bmff` factory imports) when `ensureEncryptedInit` is unused (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+
 ## [1.1.6] - 2026-05-13
 
 ### Changed

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Fixed
 
-- `ensureEncryptedInit`'s sample-entry reader/writer tables are now built inside side-effect-free initializers, so importing the package no longer eagerly registers ISO BMFF sample-entry readers and consumer bundlers can drop the tables (and their `@svta/cml-iso-bmff` factory imports) when `ensureEncryptedInit` is unused (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+- `ensureEncryptedInit`'s sample-entry reader/writer tables are now built inside side-effect-free (`/* @__PURE__ */`) initializers so consumer bundlers can drop the tables (and their `@svta/cml-iso-bmff` factory imports) when `ensureEncryptedInit` is unused; runtime import behavior is unchanged (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
 
 ## [1.1.6] - 2026-05-13
 

--- a/libs/drm/src/ensureEncryptedInit.ts
+++ b/libs/drm/src/ensureEncryptedInit.ts
@@ -22,22 +22,28 @@ const videoTypes = [
 	'dvi1',
 ]
 
-const readers = {
-	stsd: readStsd,
-}
-audioTypes.forEach(type => (readers as any)[type] = createAudioSampleEntryReader(type))
-videoTypes.forEach(type => (readers as any)[type] = createVisualSampleEntryReader(type))
+const readers = /* @__PURE__ */ (() => {
+	const map = {
+		stsd: readStsd,
+	}
+	audioTypes.forEach(type => (map as any)[type] = createAudioSampleEntryReader(type))
+	videoTypes.forEach(type => (map as any)[type] = createVisualSampleEntryReader(type))
+	return map
+})()
 
-const writers = {
-	stsd: writeStsd,
-	frma: writeFrma,
-	schm: writeSchm,
-	tenc: writeTenc,
-	encv: writeVisualSampleEntryBox,
-	enca: writeAudioSampleEntryBox,
-}
-audioTypes.forEach(type => (writers as any)[type] = writeAudioSampleEntryBox)
-videoTypes.forEach(type => (writers as any)[type] = writeVisualSampleEntryBox)
+const writers = /* @__PURE__ */ (() => {
+	const map = {
+		stsd: writeStsd,
+		frma: writeFrma,
+		schm: writeSchm,
+		tenc: writeTenc,
+		encv: writeVisualSampleEntryBox,
+		enca: writeAudioSampleEntryBox,
+	}
+	audioTypes.forEach(type => (map as any)[type] = writeAudioSampleEntryBox)
+	videoTypes.forEach(type => (map as any)[type] = writeVisualSampleEntryBox)
+	return map
+})()
 
 /**
  * Options for the `ensureEncryptedInit` function.


### PR DESCRIPTION
## Description

Follow-up to the module-scope side-effect audit in #382 (ES-builtin retention; the platform-global cases are fixed by #383). A bare-import Rollup probe (bundle `import '<pkg>/dist/index.js'` at default treeshake settings and inspect what survives) showed three packages retain eagerly-built module-scope work in every consumer bundle, regardless of which exports are used:

- **cmcd** (~4.9 KB retained): top-level `new Set(...)`/`new Map(...)` key tables built from imported key arrays, `CMCD_KEYS`' spread + `.filter()`, and the `CmcdReporter` state-field tables. Rollup's default treeshake only models argless collection constructors as pure, so the tables plus every constant they reference were retained. Fixed with `/* @__PURE__ */` annotations on the initializers.
- **c2pa**: the 256-entry `HEX_TABLE` (`Array.from`) behind `bytesToHex`. Same annotation treatment.
- **drm**: `ensureEncryptedInit` built its reader/writer tables with module-scope `forEach` loops that call the `@svta/cml-iso-bmff` sample-entry factories at import time, retaining the audio/visual factory chain for all drm consumers. The factories are pure closures (no shared registry mutation), so the tables are now built inside `/* @__PURE__ */` IIFEs: same objects and iteration order, droppable when unused.

No runtime behavior change in any package; annotations and equivalent construction only.

### Verification

Probe results with Rollup 4.52.5, default treeshake, against fresh builds:

| Package | Before | After |
| --- | --- | --- |
| cmcd | 4,882 B retained | clean (bare external imports only) |
| c2pa | hex table + `TextDecoder`/`TextEncoder` | only the #383-scope `TextDecoder`/`TextEncoder` lines |
| drm | type arrays + factory `forEach` loops + named iso-bmff factory imports | only the #383-scope `MediaKeys` probe line |

With #383 merged in (verified via a local throwaway merge), all three packages probe fully clean. All package tests pass (cmcd 341, c2pa 127, drm 47), plus full-project typecheck and lint.

### Reviewer notes

- A `@__PURE__` annotation covers the call itself, not argument evaluation. `STATE_FIELDS_BY_EVENT`'s inner `STATE_FIELDS.map(...)` needed its own annotation; without it that single unannotated argument anchored the entire state-field chain (`STATE_FIELDS`, `CMCD_STATE_EVENT_FIELDS`, the event-type constants, and two helper functions) in consumer bundles.
- Two listed sites (`isTokenField`, `validateCmcdValues`) are already dropped by current Rollup, which treats `new Set(<inline array literal>)` as pure. They are annotated anyway because esbuild- and terser-based consumer pipelines model neither form, and this library optimizes for all consumers.
- Independent of #383 (no shared source files), but both PRs append adjacent CHANGELOG lines in c2pa and drm; whichever merges second will see a trivial changelog conflict.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed (no test changes needed: no runtime behavior change; all existing suites pass)
- [x] Docs/guides updated (n/a: internal initializers only, no public API or docs impact)
- [x] Changelog updated (cmcd, c2pa, drm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)