### PR TITLE
Potential fix for code scanning alert no. 3: Insecure randomness

### DIFF
--- a/libs/utils/CHANGELOG.md
+++ b/libs/utils/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Security
+
+- Replace `Math.random()`-based UUID fallback with `crypto.getRandomValues` to use a cryptographically secure RNG ([#3](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/3))
+
 ## [1.5.0] - 2026-05-13
 
 ### Added

--- a/libs/utils/src/uuid.ts
+++ b/libs/utils/src/uuid.ts
@@ -17,13 +17,12 @@ export function uuid(): string {
 			return uuid.slice(uuid.lastIndexOf('/') + 1)
 		}
 		catch (error) {
-			let dt = new Date().getTime()
-			const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-				const r = (dt + Math.random() * 16) % 16 | 0
-				dt = Math.floor(dt / 16)
-				return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16)
-			})
-			return uuid
+			const bytes = crypto.getRandomValues(new Uint8Array(16))
+			bytes[6] = (bytes[6] & 0x0f) | 0x40
+			bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+			const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'))
+			return `${hex[0]}${hex[1]}${hex[2]}${hex[3]}-${hex[4]}${hex[5]}-${hex[6]}${hex[7]}-${hex[8]}${hex[9]}-${hex[10]}${hex[11]}${hex[12]}${hex[13]}${hex[14]}${hex[15]}`
 		}
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/3](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/3)

Use a cryptographically secure RNG in the final fallback UUID construction instead of `Math.random()`.  
Best fix without changing functionality: keep the same UUID v4 format logic, but replace random nibble generation with secure random bytes from `crypto.getRandomValues` (browser/Web Crypto API). This preserves output format and removes predictable randomness.

In `libs/utils/src/uuid.ts`, update only the innermost `catch` block (currently lines 20–26). Remove the timestamp/`Math.random()` approach and generate a 16-byte array with `crypto.getRandomValues(new Uint8Array(16))`, then set RFC4122 v4/version and variant bits, and format bytes into canonical UUID string.

No new imports are required if `crypto` is already available globally in this code context (as implied by existing `crypto.randomUUID()` use).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
