### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.pr.yml
+++ b/.github/workflows/ci.pr.yml
@@ -9,6 +9,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   pull_request_ci:
     concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/2](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained regardless of org/repo defaults.  
Best fix here (without changing behavior) is to set workflow-level permissions to read-only for repository contents, since the job only needs to clone and read code for test execution.

**Where to change:** `.github/workflows/ci.pr.yml`, near the top-level keys (`name`, `on`, `jobs`).  
**What to add:**  
```yml
permissions:
  contents: read
```
No imports, methods, or dependencies are needed for YAML workflow permission configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
