### PR TITLE
fix: resolve CodeQL alerts for polynomial ReDoS and insecure uuid fallback

### DIFF
--- a/libs/cmaf-ham/src/utils/dash/iso8601DurationToNumber.ts
+++ b/libs/cmaf-ham/src/utils/dash/iso8601DurationToNumber.ts
@@ -1,10 +1,16 @@
+// The (?:^|[^.,\d]) prefix pins each match to the start of a number run,
+// keeping the scan linear on non-matching input (CodeQL js/polynomial-redos).
+const HOURS_REGEX = /(?:^|[^.,\d])([.,\d]+)H/
+const MINUTES_REGEX = /(?:^|[^.,\d])([.,\d]+)M/
+const SECONDS_REGEX = /(?:^|[^.,\d])([.,\d]+)S/
+
 /**
  * @internal
  */
 export function iso8601DurationToNumber(isoDuration: string): number {
-	const hours = /(?:([.,\d]+)H)/.exec(isoDuration)
-	const minutes = /(?:([.,\d]+)M)/.exec(isoDuration)
-	const seconds = /(?:([.,\d]+)S)/.exec(isoDuration)
+	const hours = HOURS_REGEX.exec(isoDuration)
+	const minutes = MINUTES_REGEX.exec(isoDuration)
+	const seconds = SECONDS_REGEX.exec(isoDuration)
 
 	let duration = 0
 	if (hours) {

--- a/libs/cmaf-ham/test/utils.test.ts
+++ b/libs/cmaf-ham/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { equal } from 'node:assert'
+import { equal, ok } from 'node:assert'
 import { describe, it } from 'node:test'
 
 import { iso8601DurationToNumber, numberToIso8601Duration } from '@svta/cml-cmaf-ham'
@@ -17,6 +17,33 @@ describe('iso8601DurationToNumber', () => {
 	it('converts PT7M24S to 444', () => {
 		const res = iso8601DurationToNumber('PT7M24S')
 		equal(res, 444)
+	})
+
+	it('converts PT1H2M3S to 3723', () => {
+		const res = iso8601DurationToNumber('PT1H2M3S')
+		equal(res, 3723)
+	})
+
+	it('converts fractional seconds', () => {
+		const res = iso8601DurationToNumber('PT1.5S')
+		equal(res, 1.5)
+	})
+
+	it('extracts time components from a full designator', () => {
+		const res = iso8601DurationToNumber('P1DT2H')
+		equal(res, 7200)
+	})
+
+	it('returns 0 when no components match', () => {
+		equal(iso8601DurationToNumber(''), 0)
+		equal(iso8601DurationToNumber('P'), 0)
+	})
+
+	it('runs in linear time on adversarial input', () => {
+		const evil = ','.repeat(50_000)
+		const start = performance.now()
+		equal(iso8601DurationToNumber(evil), 0)
+		ok(performance.now() - start < 500, 'iso8601DurationToNumber took too long')
 	})
 })
 

--- a/libs/cmcd/src/isCmcdCustomKey.ts
+++ b/libs/cmcd/src/isCmcdCustomKey.ts
@@ -1,6 +1,6 @@
 import type { CmcdKey } from './CmcdKey.ts'
 
-const CUSTOM_KEY_REGEX = /^[a-zA-Z0-9-.]+-[a-zA-Z0-9-.]+$/
+const CUSTOM_KEY_REGEX = /^[a-zA-Z0-9.-]+$/
 
 /**
  * Check if a key is a custom key.
@@ -10,7 +10,12 @@ const CUSTOM_KEY_REGEX = /^[a-zA-Z0-9-.]+-[a-zA-Z0-9-.]+$/
  * @returns `true` if the key is a custom key, `false` otherwise.
  *
  * @public
+ *
+ * @example
+ * {@includeCode ../test/isCmcdCustomKey.test.ts#example}
  */
 export function isCmcdCustomKey(key: CmcdKey): boolean {
-	return CUSTOM_KEY_REGEX.test(key)
+	// The separator is checked outside the regex to keep matching linear (CodeQL js/polynomial-redos).
+	const separator = key.indexOf('-', 1)
+	return separator > 0 && separator < key.length - 1 && CUSTOM_KEY_REGEX.test(key)
 }

--- a/libs/cmcd/test/isCmcdCustomKey.test.ts
+++ b/libs/cmcd/test/isCmcdCustomKey.test.ts
@@ -1,0 +1,41 @@
+import type { CmcdKey } from '@svta/cml-cmcd'
+import { isCmcdCustomKey } from '@svta/cml-cmcd'
+import { equal, ok } from 'node:assert'
+import { describe, it } from 'node:test'
+
+describe('isCmcdCustomKey', () => {
+	it('provides a valid example', () => {
+		//#region example
+		equal(isCmcdCustomKey('com.example-key'), true)
+		equal(isCmcdCustomKey('br'), false)
+		//#endregion example
+	})
+
+	it('Accepts hyphenated keys', () => {
+		equal(isCmcdCustomKey('com.hello.world-foo'), true)
+		equal(isCmcdCustomKey('a-b'), true)
+		equal(isCmcdCustomKey('a--b'), true)
+		equal(isCmcdCustomKey('--b'), true)
+		equal(isCmcdCustomKey('a--'), true)
+	})
+
+	it('Rejects keys without an interior hyphen', () => {
+		equal(isCmcdCustomKey('sid'), false)
+		equal(isCmcdCustomKey('-'), false)
+		equal(isCmcdCustomKey('-b'), false)
+		equal(isCmcdCustomKey('a-'), false)
+	})
+
+	it('Rejects keys with invalid characters', () => {
+		equal(isCmcdCustomKey('com.example-key!'), false)
+		equal(isCmcdCustomKey('a b-c'), false)
+		equal(isCmcdCustomKey('a_b-c'), false)
+	})
+
+	it('Runs in linear time on adversarial input', () => {
+		const evil = ('-'.repeat(50_000) + '!') as CmcdKey
+		const start = performance.now()
+		equal(isCmcdCustomKey(evil), false)
+		ok(performance.now() - start < 500, 'isCmcdCustomKey took too long')
+	})
+})

--- a/libs/utils/src/uuid.ts
+++ b/libs/utils/src/uuid.ts
@@ -1,9 +1,14 @@
+import { arrayBufferToUuid } from './arrayBufferToUuid.ts'
+
 /**
  * Generate a random v4 UUID
  *
  * @returns A random v4 UUID
  *
  * @public
+ *
+ * @example
+ * {@includeCode ../test/uuid.test.ts#example}
  */
 export function uuid(): string {
 	try {
@@ -11,19 +16,19 @@ export function uuid(): string {
 	}
 	catch (error) {
 		try {
+			const bytes = crypto.getRandomValues(new Uint8Array(16))
+
+			// Set the version (4) and variant (RFC 4122) bits
+			bytes[6] = (bytes[6] & 0x0f) | 0x40
+			bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+			return arrayBufferToUuid(bytes.buffer)
+		}
+		catch (error) {
 			const url = URL.createObjectURL(new Blob())
 			const uuid = url.toString()
 			URL.revokeObjectURL(url)
 			return uuid.slice(uuid.lastIndexOf('/') + 1)
-		}
-		catch (error) {
-			let dt = new Date().getTime()
-			const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-				const r = (dt + Math.random() * 16) % 16 | 0
-				dt = Math.floor(dt / 16)
-				return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16)
-			})
-			return uuid
 		}
 	}
 }

--- a/libs/utils/test/uuid.test.ts
+++ b/libs/utils/test/uuid.test.ts
@@ -6,11 +6,30 @@ describe('UUID generation', () => {
 	const regex = /^[A-F\d]{8}-[A-F\d]{4}-4[A-F\d]{3}-[89AB][A-F\d]{3}-[A-F\d]{12}$/i
 	const id = uuid()
 
+	it('provides a valid example', () => {
+		//#region example
+		const id = uuid()
+		equal(id.length, 36)
+		//#endregion example
+	})
+
 	it('is formatted correctly', () => {
 		equal(regex.test(id), true)
 	})
 
 	it('produces unique IDs', () => {
 		equal(uuid() == id, false)
+	})
+
+	it('generates a v4 UUID when crypto.randomUUID is unavailable', () => {
+		Object.defineProperty(crypto, 'randomUUID', { value: undefined, configurable: true })
+		try {
+			const fallback = uuid()
+			equal(regex.test(fallback), true)
+			equal(fallback === uuid(), false)
+		}
+		finally {
+			Reflect.deleteProperty(crypto, 'randomUUID')
+		}
 	})
 })


### PR DESCRIPTION
## Summary

Verifies and fixes all five open code scanning alerts. Each was confirmed as a true positive before fixing: the two ReDoS patterns were reproduced locally with perfect quadratic scaling (2x input -> 4x time, ~3s at 40k chars), and both parse attacker-reachable input (CMCD keys decoded from request headers/queries, DASH manifest durations).

### [Alert #7](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/7) - `isCmcdCustomKey` polynomial ReDoS
`/^[a-zA-Z0-9-.]+-[a-zA-Z0-9-.]+$/` is ambiguous because the character classes include `-`, so the literal hyphen can match at many positions in a dash run. Replaced with one unambiguous full-string class regex plus an interior-hyphen `indexOf` check.

### [Alerts #4](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/4), [#5](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/5), [#6](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/6) - `iso8601DurationToNumber` polynomial ReDoS
The unanchored `/([.,\d]+)H|M|S/` patterns rescan from every start position, going quadratic on long digit/comma runs. Each pattern now carries a `(?:^|[^.,\d])` prefix that pins matches to the start of a number run, keeping the scan linear. Regexes are also hoisted to module-level constants.

### [Alert #3](https://github.com/streaming-video-technology-alliance/common-media-library/security/code-scanning/3) - `uuid` insecure randomness
The last-resort fallback built v4 UUIDs from `Math.random()`. It now uses `crypto.getRandomValues` with RFC 4122 version/variant bits, formatted via the existing `arrayBufferToUuid` helper; the blob URL trick remains as the final fallback. This also fixes the non-`randomUUID` path in Node, where blob URLs contain no `/` and the old code returned the entire `blob:nodedata:...` string.

## Behavior equivalence

- Exhaustive sweep of all 3,906 strings up to length 5 over `{a . - ! 1}`: old and new `isCmcdCustomKey` agree on every input.
- Exhaustive sweep of all 37,449 strings up to length 5 over `{1 . , H M S P T}`: old and new duration parsing agree on every input (NaN-aware).
- Adversarial 50k-char inputs drop from 4.7s / 14.2s to <2ms and scale linearly (10M chars in ~40ms).

## Test plan

- [x] New `isCmcdCustomKey` test suite (accept/reject cases + linear-time guard)
- [x] Extended `iso8601DurationToNumber` coverage (hours/fractions/full designators/no-match + linear-time guard)
- [x] New `uuid` fallback test stubbing out `crypto.randomUUID` (failed before the fix, passes after)
- [x] `npm run pretest` (lint, build, typecheck) exit 0
- [x] Full `npm test` across all workspaces: 2,696 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)