### PR TITLE
chore: prepare release of 16 packages

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-21
+
 ### Added
 
 - Custom continuity method support in manifest-box validation (C2PA §19.3.2 / §19.7.2): `validateC2paManifestBoxSegment` accepts an optional `continuityValidator` to verify implementer-defined continuity methods; segments declaring an unregistered method keep failing with `livevideo.continuityMethod.invalid` per spec
@@ -54,6 +56,7 @@ and this project adheres to
 - `validateC2paManifestBoxSegment(bytes, lastId, state?)` — validate manifest-box segment (§19.7.2)
 - All validation results return `isValid` + `errorCodes` with C2PA failure codes
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.1...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.0...HEAD
+[1.1.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.1...c2pa-v1.1.0
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.0...c2pa-v1.0.1
 [1.0.0]: https://github.com/streaming-video-technology-alliance/common-media-library/tree/c2pa-v1.0.0

--- a/libs/c2pa/package.json
+++ b/libs/c2pa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-c2pa",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "C2PA (Coalition for Content Provenance and Authenticity) live video validation for BMFF/MP4 containers",
 	"license": "Apache-2.0",
 	"authors": [

--- a/libs/cmaf-ham/CHANGELOG.md
+++ b/libs/cmaf-ham/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-07-21
+
+### Fixed
+
+- The ISO 8601 duration regexes in the DASH converter no longer rescan quadratically on long digit runs (CodeQL polynomial ReDoS); matches and captures are unchanged ([#388](https://github.com/streaming-video-technology-alliance/common-media-library/issues/388))
+
 ## [0.24.4] - 2026-05-13
 
 ### Changed
@@ -58,7 +64,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.4...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.5...HEAD
+[0.24.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.4...cmaf-ham-v0.24.5
 [0.24.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.3...cmaf-ham-v0.24.4
 [0.24.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.2...cmaf-ham-v0.24.3
 [0.24.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.1...cmaf-ham-v0.24.2

--- a/libs/cmaf-ham/package.json
+++ b/libs/cmaf-ham/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmaf-ham",
-	"version": "0.24.4",
+	"version": "0.24.5",
 	"description": "CMAF Hypothetical Application Model (HAM) functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-07-21
+
 ### Fixed
 
 - Module-scope key-table `Set`/`Map` initializers (and the `CmcdReporter` state-field tables) are now marked side-effect free so consumer bundlers can drop them when unused; a bare import of the package previously retained ~4.9 KB of eagerly-built tables (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
+- `isCmcdCustomKey` no longer backtracks quadratically on hostile inputs (CodeQL polynomial ReDoS): the ambiguous regex was replaced with an unambiguous character-class check plus an interior-hyphen test; accepted inputs are unchanged ([#388](https://github.com/streaming-video-technology-alliance/common-media-library/issues/388))
 
 ### Documentation
 
@@ -179,7 +182,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.0...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.1...HEAD
+[2.4.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.0...cmcd-v2.4.1
 [2.4.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.3.2...cmcd-v2.4.0
 [2.3.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.3.1...cmcd-v2.3.2
 [2.3.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.3.0...cmcd-v2.3.1

--- a/libs/cmcd/package.json
+++ b/libs/cmcd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmcd",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Common Media Client Data (CMCD) encoding and decoding",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/cmsd/CHANGELOG.md
+++ b/libs/cmsd/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-cta` to 1.0.7
+- Update `@svta/cml-structured-field-values` to 1.1.4
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.0.6] - 2026-05-13
 
 ### Changed
@@ -60,7 +68,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.7...HEAD
+[1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.6...cmsd-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.5...cmsd-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.4...cmsd-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.3...cmsd-v1.0.4

--- a/libs/cmsd/package.json
+++ b/libs/cmsd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmsd",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "Common Media Server Data (CMSD) encoding and decoding",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/cta/CHANGELOG.md
+++ b/libs/cta/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.5.1
+- Update `@svta/cml-structured-field-values` to 1.1.4
+
 ## [1.0.6] - 2026-05-13
 
 ### Changed
@@ -56,7 +63,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.7...HEAD
+[1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.6...cta-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.5...cta-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.4...cta-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.3...cta-v1.0.4

--- a/libs/cta/package.json
+++ b/libs/cta/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cta",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "Common functionality for CTA standards including CTA-608/CEA-608",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/dash/CHANGELOG.md
+++ b/libs/dash/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.0.6] - 2026-05-13
 
 ### Changed
@@ -54,7 +60,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.7...HEAD
+[1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.6...dash-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.5...dash-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.4...dash-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.3...dash-v1.0.4

--- a/libs/dash/package.json
+++ b/libs/dash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-dash",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "DASH manifest parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.7] - 2026-07-21
+
 ### Fixed
 
 - `ensureEncryptedInit`'s sample-entry reader/writer tables are now built inside side-effect-free (`/* @__PURE__ */`) initializers so consumer bundlers can drop the tables (and their `@svta/cml-iso-bmff` factory imports) when `ensureEncryptedInit` is unused; runtime import behavior is unchanged (follow-up to the module-scope side-effect audit in [#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
@@ -84,7 +86,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.7...HEAD
+[1.1.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.6...drm-v1.1.7
 [1.1.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.5...drm-v1.1.6
 [1.1.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.4...drm-v1.1.5
 [1.1.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.3...drm-v1.1.4

--- a/libs/drm/package.json
+++ b/libs/drm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-drm",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "Digital Rights Management (DRM) functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/id3/CHANGELOG.md
+++ b/libs/id3/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.0.6] - 2026-05-13
 
 ### Changed
@@ -57,7 +63,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.7...HEAD
+[1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.6...id3-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.5...id3-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.4...id3-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.3...id3-v1.0.4

--- a/libs/id3/package.json
+++ b/libs/id3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-id3",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "ID3 tag parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/iso-8601/CHANGELOG.md
+++ b/libs/iso-8601/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-07-21
+
+### Changed
+
+- Promote the package API from `@beta` to `@public`: `decodeIso8601Duration` and `encodeIso8601Duration` are now documented as stable ([#288](https://github.com/streaming-video-technology-alliance/common-media-library/issues/288))
+
 ## [1.0.1] - 2025-12-22
 
 ### Fixed
@@ -22,6 +28,7 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-8601-v1.0.1...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-8601-v1.0.2...HEAD
+[1.0.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-8601-v1.0.1...iso-8601-v1.0.2
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-8601-v1.0.0...iso-8601-v1.0.1
 [1.0.0]: https://github.com/streaming-video-technology-alliance/common-media-library/tree/iso-8601-v1.0.0

--- a/libs/iso-8601/package.json
+++ b/libs/iso-8601/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-iso-8601",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "ISO 8601 date/time handling functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/iso-bmff/CHANGELOG.md
+++ b/libs/iso-bmff/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-07-21
+
 ### Fixed
 
 - `IsoBoxReadableStream` no longer reads the bare `ReadableStream` global at module scope: importing the package never throws on runtimes without the Web Streams API. Instantiating `IsoBoxReadableStream` on such runtimes throws a descriptive error instead ([#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
@@ -163,7 +165,8 @@ Official stable release. No changes since 1.0.0-beta.2.
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.2...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.3...HEAD
+[1.0.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.2...iso-bmff-v1.0.3
 [1.0.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.1...iso-bmff-v1.0.2
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.0...iso-bmff-v1.0.1
 [1.0.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.0-beta.2...iso-bmff-v1.0.0

--- a/libs/iso-bmff/package.json
+++ b/libs/iso-bmff/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-iso-bmff",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "ISO Base Media File Format (ISOBMFF) parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/request/CHANGELOG.md
+++ b/libs/request/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.14] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-cmcd` to 2.4.1
+- Update `@svta/cml-xml` to 1.1.5
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.0.13] - 2026-05-23
 
 ### Changed
@@ -105,7 +113,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.13...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.14...HEAD
+[1.0.14]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.13...request-v1.0.14
 [1.0.13]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.12...request-v1.0.13
 [1.0.12]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.11...request-v1.0.12
 [1.0.11]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.10...request-v1.0.11

--- a/libs/request/package.json
+++ b/libs/request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-request",
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"description": "Common Media Request and Response types",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/structured-field-values/CHANGELOG.md
+++ b/libs/structured-field-values/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.1.3] - 2026-05-13
 
 ### Changed
@@ -52,7 +58,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.3...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.4...HEAD
+[1.1.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.3...structured-field-values-v1.1.4
 [1.1.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.2...structured-field-values-v1.1.3
 [1.1.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.1...structured-field-values-v1.1.2
 [1.1.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.0...structured-field-values-v1.1.1

--- a/libs/structured-field-values/package.json
+++ b/libs/structured-field-values/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-structured-field-values",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "RFC8941 Structured Field Values implementation",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/throughput/CHANGELOG.md
+++ b/libs/throughput/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.0.6] - 2026-05-13
 
 ### Changed
@@ -52,7 +58,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.7...HEAD
+[1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.6...throughput-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.5...throughput-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.4...throughput-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.3...throughput-v1.0.4

--- a/libs/throughput/package.json
+++ b/libs/throughput/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-throughput",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "Throughput estimation functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/utils/CHANGELOG.md
+++ b/libs/utils/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-21
+
+### Fixed
+
+- `uuid` no longer falls back to `Math.random`: when `crypto.randomUUID` is unavailable it derives the UUID from `crypto.getRandomValues` with RFC 4122 version/variant bits, keeping the blob-URL trick only as a last resort ([#388](https://github.com/streaming-video-technology-alliance/common-media-library/issues/388))
+
 ## [1.5.0] - 2026-05-13
 
 ### Added
@@ -70,7 +76,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.5.0...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.5.1...HEAD
+[1.5.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.5.0...utils-v1.5.1
 [1.5.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.4.0...utils-v1.5.0
 [1.4.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.3.0...utils-v1.4.0
 [1.3.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.2.0...utils-v1.3.0

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-utils",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "Common utility functions for media processing",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/webvtt/CHANGELOG.md
+++ b/libs/webvtt/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-21
+
 ### Fixed
 
 - `WebVttTransformStream` no longer reads the bare `TransformStream` global at module scope: importing only non-stream exports is now fully tree-shakeable, and importing the package never throws on runtimes without the Web Streams API. Instantiating `WebVttTransformStream` on such runtimes throws a descriptive error instead ([#382](https://github.com/streaming-video-technology-alliance/common-media-library/issues/382))
@@ -58,7 +60,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.7...HEAD
+[1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-vtt-v1.0.6...webvtt-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.5...webvtt-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.4...webvtt-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.3...webvtt-v1.0.4

--- a/libs/webvtt/package.json
+++ b/libs/webvtt/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-webvtt",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "WebVTT parsing and rendering functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-07-21
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.5.1
+
 ## [1.1.4] - 2026-05-13
 
 ### Changed
@@ -63,7 +69,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.4...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.5...HEAD
+[1.1.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.4...xml-v1.1.5
 [1.1.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.3...xml-v1.1.4
 [1.1.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.2...xml-v1.1.3
 [1.1.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.1...xml-v1.1.2

--- a/libs/xml/package.json
+++ b/libs/xml/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-xml",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "XML parsing utilities",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"libs/c2pa": {
 			"name": "@svta/cml-c2pa",
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -66,7 +66,7 @@
 		},
 		"libs/cmaf-ham": {
 			"name": "@svta/cml-cmaf-ham",
-			"version": "0.24.4",
+			"version": "0.24.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@types/m3u8-parser": "7.2.5",
@@ -83,7 +83,7 @@
 		},
 		"libs/cmcd": {
 			"name": "@svta/cml-cmcd",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -95,7 +95,7 @@
 		},
 		"libs/cmsd": {
 			"name": "@svta/cml-cmsd",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -116,7 +116,7 @@
 		},
 		"libs/cta": {
 			"name": "@svta/cml-cta",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -128,7 +128,7 @@
 		},
 		"libs/dash": {
 			"name": "@svta/cml-dash",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -139,7 +139,7 @@
 		},
 		"libs/drm": {
 			"name": "@svta/cml-drm",
-			"version": "1.1.6",
+			"version": "1.1.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -152,7 +152,7 @@
 		},
 		"libs/id3": {
 			"name": "@svta/cml-id3",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -163,7 +163,7 @@
 		},
 		"libs/iso-8601": {
 			"name": "@svta/cml-iso-8601",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -171,7 +171,7 @@
 		},
 		"libs/iso-bmff": {
 			"name": "@svta/cml-iso-bmff",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -190,7 +190,7 @@
 		},
 		"libs/request": {
 			"name": "@svta/cml-request",
-			"version": "1.0.13",
+			"version": "1.0.14",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -203,7 +203,7 @@
 		},
 		"libs/structured-field-values": {
 			"name": "@svta/cml-structured-field-values",
-			"version": "1.1.3",
+			"version": "1.1.4",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -214,7 +214,7 @@
 		},
 		"libs/throughput": {
 			"name": "@svta/cml-throughput",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -225,7 +225,7 @@
 		},
 		"libs/utils": {
 			"name": "@svta/cml-utils",
-			"version": "1.5.0",
+			"version": "1.5.1",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -233,7 +233,7 @@
 		},
 		"libs/webvtt": {
 			"name": "@svta/cml-webvtt",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -244,7 +244,7 @@
 		},
 		"libs/xml": {
 			"name": "@svta/cml-xml",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"


### PR DESCRIPTION
## Summary

Prepares new releases for every package with unreleased shipped changes since the last tags, plus the peer-dependency cascade required by the pinned-peer publish flow.

### Direct bumps (8)

| Package | Version | Changes |
| --- | --- | --- |
| `@svta/cml-utils` | 1.5.0 → 1.5.1 | Secure `uuid` fallback via `crypto.getRandomValues` (#388) |
| `@svta/cml-cmcd` | 2.4.0 → 2.4.1 | `isCmcdCustomKey` ReDoS fix (#388), side-effect-free key tables (#384), `CmcdReporter` event-firing docs (#375) |
| `@svta/cml-iso-8601` | 1.0.1 → 1.0.2 | Promote API from `@beta` to `@public` (#288, previously unreleased) |
| `@svta/cml-iso-bmff` | 1.0.2 → 1.0.3 | Guard module-scope `ReadableStream` read (#383) |
| `@svta/cml-webvtt` | 1.0.6 → 1.0.7 | Guard module-scope `TransformStream` read (#383) |
| `@svta/cml-drm` | 1.1.6 → 1.1.7 | Side-effect-free sample-entry tables and `MediaKeys` probe (#383, #384) |
| `@svta/cml-cmaf-ham` | 0.24.4 → 0.24.5 | ISO 8601 duration ReDoS fix (#388) |
| `@svta/cml-c2pa` | 1.0.1 → 1.1.0 | Custom continuity methods (#379), VOD Merkle segment validation (#378), 8-byte offset-prefix enforcement (#380, #381), side-effect-free initializers (#383, #384) |

### Cascaded patches via `prepare-release` (8)

`xml` 1.1.5, `structured-field-values` 1.1.4, `cta` 1.0.7, `cmsd` 1.0.7, `request` 1.0.14, `dash` 1.0.7, `id3` 1.0.7, `throughput` 1.0.7

### Excluded after verification

- `608`, and all other zero-change packages: no commits since their tags
- `content-steering`: only changelog-link fixes and a stale generated API report since its tag; nothing shipped changes
- `mse`: unpublished, excluded from `projects.ts`

Also backfills the missing changelog entries for #388's fixes (`utils`, `cmcd`, `cmaf-ham`) and iso-8601's `@public` promotion.

## Verification

- `npm test` (lint + build + typecheck + all workspace tests): pass, exit 0
- `npm run prepare-release` re-run output matched the expected dependency cascade exactly
- Release-notes extraction: each new version section carries its changes (required by `publish.ts` `getChanges`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)