### PR TITLE
fix(608): advance cursor on mid-row code (spacing attribute)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ Please add entries to the bottom of the list in the following format:
 - @dsilhavy [Daniel Silhavy, Fraunhofer FOKUS]
 - @N1Knight [Nicolás Caballero, Qualabs]
 - @valentinamgiusti [Valentina Giusti, Qualabs]
+- @tobbee [Torbjörn Einarsson, Eyevinn]

--- a/libs/608/CHANGELOG.md
+++ b/libs/608/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- A CTA-608 mid-row style code now advances the cursor by one column. A mid-row code is a spacing attribute: it occupies one on-screen cell (a space carrying the new pen) and advances the cursor, so following text starts one column to the right. Previously `ccMIDROW` only set the pen and did not advance the cursor, so colored/italic text was rendered one column too far left.
+
 ## [1.0.2] - 2026-02-13
 
 ### Fixed

--- a/libs/608/src/Cta608Channel.ts
+++ b/libs/608/src/Cta608Channel.ts
@@ -284,6 +284,10 @@ export class Cta608Channel {
 		}
 		this.logger.log(VerboseLevel.INFO, 'MIDROW: ' + JSON.stringify(styles))
 		this.writeScreen.setPen(styles)
+		// A mid-row code is a spacing attribute: it occupies one cell (shown as a
+		// space carrying the new pen) and advances the cursor, so text following
+		// the code starts one column to the right (CTA-608).
+		this.writeScreen.moveCursor(1)
 	}
 
 	outputDataUpdate(dispatch: boolean = false): void {

--- a/libs/608/test/Cta608Channel.test.ts
+++ b/libs/608/test/Cta608Channel.test.ts
@@ -44,4 +44,16 @@ describe('Cea608Channel Tests', () => {
 		channel.setMode(captionModeRollUp)
 		equal(channel.mode, captionModeRollUp)
 	})
+
+	it('ccMIDROW is a spacing attribute: it advances the cursor one column', () => {
+		const NR_ROWS = 15
+		const row: any = channel.writeScreen.rows[NR_ROWS - 1]
+		row.setCursor(8)
+		channel.ccMIDROW(0x20) // white mid-row style code
+		// The mid-row code occupies the cell at column 8, so the cursor advances
+		// and following text starts at column 9 (CTA-608).
+		equal(row.pos, 9)
+		channel.writeScreen.insertChar(0x41) // 'A'
+		equal(row.chars[9].uchar, 'A')
+	})
 })


### PR DESCRIPTION
## Bug

A CTA-608 mid-row style code is a spacing attribute — per the standard it occupies one on-screen cell (a space carrying the new pen) and advances the cursor, so text following the code starts one column to the right. Cta608Channel.ccMIDROW only applied the pen via setPen and never advanced the cursor. As a result, colored/italic text positioned by an encoder that (correctly) accounts for the mid-row cell is rendered one column too far left. It's visible as a colored caption line drifting left of a white line on the same centered screen (white lines are unaffected because they use an indent PAC and need no mid-row code).

## Fix

Advance the write cursor by one column after applying the mid-row pen. Adds a regression test.

## Context

I found this when working on automatically generating colored wall-clock-time 608 captions in livesim2.
There will be a visible test vector from livesim2 relatively soon, but the regression test should be enough
for this project.