### PR TITLE
chore: prepare 608 1.0.3 release

### DIFF
--- a/libs/608/CHANGELOG.md
+++ b/libs/608/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-07-22
+
 ### Fixed
 
-- A CTA-608 mid-row style code now advances the cursor by one column. A mid-row code is a spacing attribute: it occupies one on-screen cell (a space carrying the new pen) and advances the cursor, so following text starts one column to the right. Previously `ccMIDROW` only set the pen and did not advance the cursor, so colored/italic text was rendered one column too far left.
+- A CTA-608 mid-row style code now advances the cursor by one column. A mid-row code is a spacing attribute: it occupies one on-screen cell (a space carrying the new pen) and advances the cursor, so following text starts one column to the right. Previously `ccMIDROW` only set the pen and did not advance the cursor, so colored/italic text was rendered one column too far left. ([#391](https://github.com/streaming-video-technology-alliance/common-media-library/issues/391))
 
 ## [1.0.2] - 2026-02-13
 
@@ -33,7 +35,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.2...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.3...HEAD
+[1.0.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.2...608-v1.0.3
 [1.0.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.1...608-v1.0.2
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.0...608-v1.0.1
 [1.0.0]: https://github.com/streaming-video-technology-alliance/common-media-library/tree/608-v1.0.0

--- a/libs/608/package.json
+++ b/libs/608/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-608",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "CTA-608/CEA-608 closed captioning functionality",
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
## Description

Prepare the `@svta/cml-608` 1.0.3 patch release, picking up the mid-row cursor-advance bug fix from #391:

- Bump `@svta/cml-608` from 1.0.2 to 1.0.3 (npm confirms 1.0.2 is the currently published version).
- Move the `[Unreleased]` changelog entry into a dated `## [1.0.3] - 2026-07-22` section, add the #391 issue link to match house style, and update the compare links.
- `npm run prepare-release` confirms no other package peer-depends on `@svta/cml-608`, so no cascading patch bumps are needed — this release touches only the 608 package.

Validation on Node 24: `npm run build -w libs/608` (tsdown + api-extractor) completes cleanly and all 54 tests in `npm test -w libs/608` pass.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed — no test changes needed; the fix and its tests landed in #391, and the full 608 suite passes
- [x] Docs/guides updated — no doc changes needed for a version bump
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FioLUKQms45cMHmJzUuoom

---
_Generated by [Claude Code](https://claude.ai/code/session_01FioLUKQms45cMHmJzUuoom)_