### PR TITLE
chore: sync package-lock for 608 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 		},
 		"libs/608": {
 			"name": "@svta/cml-608",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"


### PR DESCRIPTION
## Description

Release #392 bumped `@svta/cml-608` to 1.0.3 in `libs/608/package.json` but did not refresh `package-lock.json`, so the `libs/608` workspace entry still recorded 1.0.2. This PR regenerates the lockfile with `npm install` (Node 24).

Verified:

- The diff is a single line: the `libs/608` workspace entry version, 1.0.2 → 1.0.3.
- A scan of every workspace entry against its `package.json` reports no other stale versions.
- A follow-up `npm install --package-lock-only` produces no further changes.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed (N/A: lockfile metadata only, no code change)
- [x] Docs/guides updated (N/A: lockfile metadata only)
- [x] Changelog updated (N/A: the 608 1.0.3 changelog entry landed in #392; this PR only syncs the lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)