### PR TITLE
fix(cmcd): accept player-owned customData in recordResponseReceived

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Changed
 
+- `CmcdReporter.recordResponseReceived()` is now generic over the request's `customData`, so a player can pass a request carrying only its own keys (e.g. `{ requestType: 'segment' }`) without declaring a `cmcd` key it does not own and without a cast. The parameter was previously pinned to `HttpResponse<HttpRequest<{ cmcd?: Cmcd }>>`; because `{ cmcd?: Cmcd }` is a weak type (every property optional), a `customData` sharing no properties with it was rejected outright. This pairs with the per-target `transform`, which reads the player's taxonomy off the triggering request. Type-only widening: the reporter still reads just `customData.cmcd`, and existing callers passing `HttpRequest<{ cmcd?: Cmcd }>` continue to compile
 - `isCmcdCustomKey` and the `CmcdCustomKey` type now only accept custom keys that survive RFC 8941 key serialization: a lowercase first letter, then characters from `a-z 0-9 . -`, with a hyphen that is neither the first nor the last character. Uppercase and digit-leading names were never serializable as CMCD; they are now rejected by the type, the validators, and key filtering instead of being dropped at encode preparation
 
 ### Documentation

--- a/libs/cmcd/config/cml-cmcd.api.md
+++ b/libs/cmcd/config/cml-cmcd.api.md
@@ -368,7 +368,7 @@ export class CmcdReporter {
     flush(): void;
     isRequestReportingEnabled(): boolean;
     recordEvent(type: CmcdEventType, data?: Partial<Cmcd>): void;
-    recordResponseReceived(response: HttpResponse<HttpRequest<{
+    recordResponseReceived<C>(response: HttpResponse<HttpRequest<C & {
         cmcd?: Cmcd;
     }>>, data?: Partial<Cmcd>): void;
     start(): void;

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -600,11 +600,18 @@ export class CmcdReporter {
 	 * Additional keys like `ttfbb`, `cmsdd`, `cmsds`, and `smrt` can be
 	 * supplied via the `data` parameter if the player has access to them.
 	 *
+	 * The request's `customData` is generic, so a player can pass a request
+	 * carrying its own taxonomy (e.g. `{ requestType: 'segment' }`) without a
+	 * cast. The reporter only reads the optional `cmcd` key that
+	 * {@link CmcdReporter.createRequestReport} writes there; every other key is
+	 * left untouched and stays visible to an event target's `transform` via
+	 * its `request` argument.
+	 *
 	 * @param response - The HTTP response received.
 	 * @param data - Additional CMCD data to include with the event.
 	 *               Values provided here override any auto-derived values.
 	 */
-	recordResponseReceived(response: HttpResponse<HttpRequest<{ cmcd?: Cmcd }>>, data: Partial<Cmcd> = {}): void {
+	recordResponseReceived<C>(response: HttpResponse<HttpRequest<C & { cmcd?: Cmcd }>>, data: Partial<Cmcd> = {}): void {
 		const { request } = response
 
 		const url = data.url ?? request?.url

--- a/libs/cmcd/test/CmcdReporter.test.ts
+++ b/libs/cmcd/test/CmcdReporter.test.ts
@@ -1058,9 +1058,9 @@ describe('CmcdReporter', () => {
 		})
 
 		describe('triggering request', () => {
-			// A player's request carries its own taxonomy on customData
-			// alongside the cmcd key the reporter reads back.
-			type PlayerRequest = HttpRequest<{ cmcd?: Cmcd; requestType: string; }>
+			// A player's request carries only its own taxonomy on customData.
+			// It does not have to declare the reporter's `cmcd` key.
+			type PlayerRequest = HttpRequest<{ requestType: string; }>
 
 			it('passes the triggering request to the transform for response-received events', async () => {
 				const { requester, requests } = createMockRequester()
@@ -1139,6 +1139,48 @@ describe('CmcdReporter', () => {
 				equal(requests.length, 1)
 				ok((requests[0].body as string)?.includes('segment.mp4'))
 				ok((requests[0].body as string)?.includes('sn=0'))
+			})
+
+			it('accepts a request whose customData has only player-specific keys', async () => {
+				const { requester, requests } = createMockRequester()
+				const seen: string[] = []
+
+				const reporter = new CmcdReporter({
+					sid: 'test-session',
+					enabledKeys: [...RR_KEYS],
+					eventTargets: [
+						{
+							url: 'https://example.com/cmcd',
+							events: [CmcdEventType.RESPONSE_RECEIVED],
+							enabledKeys: [...RR_KEYS],
+							batchSize: 1,
+							transform: (data, request) => {
+								const customData = request?.customData as { requestType?: string; } | undefined
+								if (customData?.requestType) {
+									seen.push(customData.requestType)
+								}
+								return data
+							},
+						},
+					],
+				}, requester)
+
+				// A bare object literal with no `cmcd` key and no helper type
+				// alias: this is the shape a player passes, and it must compile
+				// without a cast. `customData` is inferred, not pinned.
+				reporter.recordResponseReceived({
+					request: {
+						url: 'https://cdn.example.com/segment.mp4',
+						customData: { requestType: 'segment' },
+					},
+					status: 200,
+				})
+
+				await new Promise(resolve => setTimeout(resolve, 10))
+
+				deepEqual(seen, ['segment'])
+				equal(requests.length, 1)
+				ok((requests[0].body as string)?.includes('segment.mp4'))
 			})
 		})
 


### PR DESCRIPTION
## Problem

`recordResponseReceived` pinned its parameter to `HttpResponse<HttpRequest<{ cmcd?: Cmcd }>>`. Because `{ cmcd?: Cmcd }` has only optional properties it is a TypeScript **weak type**, so a request whose `customData` carries only the player's own keys shared no properties with the target and was rejected outright:

```
Type '{ requestType: string; }' has no properties in common with type '{ cmcd?: Cmcd | undefined; }'
```

Integrators had to declare a `cmcd` key they don't own, or cast. This became load-bearing with the per-target report transforms in this stack: the motivating dash.js case reads `request?.customData?.requestType` to filter `RESPONSE_RECEIVED` reports by player request type, so the player's taxonomy *has* to live on `customData`.

## Fix

Make the method generic over `customData`:

```ts
recordResponseReceived<C>(response: HttpResponse<HttpRequest<C & { cmcd?: Cmcd }>>, data: Partial<Cmcd> = {}): void
```

Inference from a plain object literal resolves `C` to the player's shape, so the weak-type check no longer applies, while `C & { cmcd?: Cmcd }` keeps `customData.cmcd` typed as `Cmcd` inside the method with no cast and no `any`.

## Why not the looser options

Both alternatives compile every caller shape but collapse `customData` to `any`, so the reporter's own `request.customData?.cmcd` read stops being checked at all. Measured against the strict repo config:

| | player-only literal | player-only declared var | back-compat | `interface` customData | internal `.cmcd` |
|---|---|---|---|---|---|
| current (pinned) | ✗ TS2353 | ✗ TS2322 | ✓ | ✗ TS2322 | `Cmcd` |
| bare `HttpResponse` | ✓ | ✓ | ✓ | ✓ | **`any`** |
| index signature | ✓ | ✓ | ✓ | **✗** | `Cmcd` |
| **generic `C & { cmcd? }`** | ✓ | ✓ | ✓ | ✓ | **`Cmcd`** |
| generic over `R` | ✓ | ✓ | ✓ | ✓ | `any` |

Note the two distinct failure modes of the status quo: inline literals fail with TS2353 (excess property), a pre-declared request with TS2322 (weak type). Both have the same root cause.

## Not a breaking change

Type-only widening. Verified still compiling: existing callers passing `HttpRequest<{ cmcd?: Cmcd }>`, bare `HttpResponse`, absent `customData`, `interface`-declared `customData`, and `cmcd` present alongside player keys. The runtime body is untouched — the reporter still reads only `request.customData?.cmcd`.

The type parameter is named `C` rather than `D` because `D` collides with `CmcdRequestReport<D>` in the api-extractor rollup, which renamed it to `D$1` in the shipped `dist/index.d.ts`. With `C`, the `.api.md` diff is a single line and `CmcdRequestReport` is untouched.

## Tests

- New: `accepts a request whose customData has only player-specific keys` — a bare object literal with no `cmcd` key and no helper alias, asserted to reach an event target's `transform` and emit.
- The `PlayerRequest` alias drops the `cmcd` key it only declared to work around this, so the existing transform tests now exercise a genuine player-only shape too.

Confirmed the new test is a real guard, not vacuous: temporarily restoring the old signature produces 4 errors, including the exact TS2322 above and a TS2353 on the new literal.

## Verification

`npm run typecheck`, `npm test -w libs/cmcd` (439 tests, 437 pass, 0 fail, 2 pre-existing todo), and `npm run lint` all exit 0, re-run after rebasing onto the current base tip.

Base is `feat/cmcd-report-transforms` (the RFC stack, [#390](https://github.com/streaming-video-technology-alliance/common-media-library/pull/390)), not `main`, since the `transform` hook this pairs with isn't on `main` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)