### PR TITLE
fix(cmcd): accept player customData on recordResponseReceived

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `CmcdReporter.recordResponseReceived` no longer rejects a request whose `customData` carries only the player's own fields. The parameter pinned `customData` to `{ cmcd?: Cmcd }`, a TypeScript weak type, so passing `{ requestType: 'segment' }` failed with `'requestType' does not exist in type '{ cmcd?: Cmcd | undefined; }'` because the source and target share no properties. Callers had to declare a `cmcd` key they do not own, or cast. The type is widened to `{ cmcd?: Cmcd } & Record<string, unknown>`; the reporter still reads `customData.cmcd` as `Cmcd | undefined`, and existing callers, including those annotating the previous narrower type, are unaffected
+
 ### Added
 
 - `CmcdReporterConfig.customHeaderMap` — routes custom keys into specific CMCD header shards (`CMCD-Session`, `CMCD-Object`, `CMCD-Status`) when the transmission mode is `HEADERS`. Custom keys not listed in any shard still default to `CMCD-Request`; standard keys keep their spec-defined shards and cannot be re-routed. The option previously existed on `CmcdEncodeOptions` but was not reachable through `CmcdReporter`

--- a/libs/cmcd/config/cml-cmcd.api.md
+++ b/libs/cmcd/config/cml-cmcd.api.md
@@ -366,7 +366,7 @@ export class CmcdReporter {
     recordEvent(type: CmcdEventType, data?: Partial<Cmcd>): void;
     recordResponseReceived(response: HttpResponse<HttpRequest<{
         cmcd?: Cmcd;
-    }>>, data?: Partial<Cmcd>): void;
+    } & Record<string, unknown>>>, data?: Partial<Cmcd>): void;
     start(): void;
     stop(flush?: boolean): void;
     update(data: Partial<Cmcd>): void;

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -444,11 +444,14 @@ export class CmcdReporter {
 	 * Additional keys like `ttfbb`, `cmsdd`, `cmsds`, and `smrt` can be
 	 * supplied via the `data` parameter if the player has access to them.
 	 *
-	 * @param response - The HTTP response received.
+	 * @param response - The HTTP response received. The request's
+	 *                   `customData` may carry the player's own fields
+	 *                   alongside the `cmcd` key the reporter reads back;
+	 *                   it does not have to declare `cmcd` at all.
 	 * @param data - Additional CMCD data to include with the event.
 	 *               Values provided here override any auto-derived values.
 	 */
-	recordResponseReceived(response: HttpResponse<HttpRequest<{ cmcd?: Cmcd }>>, data: Partial<Cmcd> = {}): void {
+	recordResponseReceived(response: HttpResponse<HttpRequest<{ cmcd?: Cmcd; } & Record<string, unknown>>>, data: Partial<Cmcd> = {}): void {
 		const { request } = response
 
 		const url = data.url ?? request?.url

--- a/libs/cmcd/test/CmcdReporter.test.ts
+++ b/libs/cmcd/test/CmcdReporter.test.ts
@@ -964,6 +964,48 @@ describe('CmcdReporter', () => {
 			ok(body.includes('cmsdd="abc123"'))
 		})
 
+		it('accepts a request carrying only player-specific customData', async () => {
+			const { requester, requests } = createMockRequester()
+			const reporter = new CmcdReporter(createRrConfig(), requester)
+
+			// Compile-time regression guard as much as a runtime one: a player
+			// whose customData holds only its own fields must not need a cast or
+			// a placeholder `cmcd` key to call this. Narrowing the parameter back
+			// to `{ cmcd?: Cmcd }` makes this file fail to typecheck, because a
+			// source with no properties in common with a weak target is rejected.
+			reporter.recordResponseReceived({
+				request: {
+					url: 'https://cdn.example.com/segment.mp4',
+					customData: { requestType: 'segment' },
+				},
+				status: 200,
+			})
+
+			await new Promise(resolve => setTimeout(resolve, 10))
+
+			equal(requests.length, 1)
+			const body = requests[0].body as string
+			ok(body.includes('url="https://cdn.example.com/segment.mp4"'))
+			ok(body.includes('rc=200'))
+		})
+
+		it('still reads the cmcd key back from customData', async () => {
+			const { requester, requests } = createMockRequester()
+			const reporter = new CmcdReporter(createRrConfig(), requester)
+
+			reporter.recordResponseReceived({
+				request: {
+					url: 'https://cdn.example.com/segment.mp4',
+					customData: { cmcd: { sid: 'request-scoped' }, requestType: 'segment' },
+				},
+				status: 200,
+			})
+
+			await new Promise(resolve => setTimeout(resolve, 10))
+
+			ok((requests[0].body as string)?.includes('sid="request-scoped"'))
+		})
+
 		it('does not send if no event target is configured for rr', async () => {
 			const { requester, requests } = createMockRequester()
 			const reporter = new CmcdReporter(createConfig(), requester)


### PR DESCRIPTION
## Description

Bug fix: `CmcdReporter.recordResponseReceived` rejected a request whose `customData` carried only the player's own fields.

The parameter pinned `customData` to `{ cmcd?: Cmcd }`. Every property on that type is optional, which makes it a TypeScript *weak type*, and TypeScript rejects a source object that shares no properties with a weak target. So the ordinary case failed to compile:

```ts
reporter.recordResponseReceived({
	request: { url: 'https://cdn.example.com/seg.mp4', customData: { requestType: 'segment' } },
	status: 200,
})
// error TS2353: Object literal may only specify known properties,
// and 'requestType' does not exist in type '{ cmcd?: Cmcd | undefined; }'
```

Callers had to either declare a `cmcd` key they do not own or cast. That is backwards: `customData` is precisely where player-specific fields belong, and the reporter only ever reads one key out of it.

This matters beyond ergonomics because reading those fields back is how per-target report transforms (#399) filter `RESPONSE_RECEIVED` events by request type, which is the dash.js case that motivated that feature. The workaround currently lives in that PR's tests as a `PlayerRequest` type alias.

### Fix

Widened to `{ cmcd?: Cmcd } & Record<string, unknown>`. The index signature stops the target being a weak type, while the `cmcd` member stays declared, so the reporter still reads `request.customData?.cmcd` as `Cmcd | undefined` with no cast and no `any`.

Rejected alternatives:

- **Bare `HttpResponse`.** Simplest, but `HttpRequest<D = any>` means `customData` becomes `any` and the internal read loses its type, against the repo's "avoid `any`" rule.
- **Generic over the customData type** (`<D>(response: HttpResponse<HttpRequest<D & { cmcd?: Cmcd }>>)`). More machinery for the same result, and inference from a fresh object literal needs verifying to be sure it doesn't reintroduce the weak-type rejection.

### Non-breaking

Verified by compiling each caller shape before committing, not by inspection: player-only `customData`, `cmcd`-only `customData`, no `customData` at all, a bare `HttpResponse` variable as the existing test helpers build, both keys together, and a caller who had already annotated the previous narrower type. Parameter widening is also still assignable where the old signature was expected, so a consumer holding a reference typed against the old shape keeps compiling.

The public API surface change is one line; see the `cml-cmcd.api.md` diff.

### Note for reviewers

Per `rfc/README.md` this did not go through an RFC. It changes a public signature, but it is a type correction that removes a rejection of input the method already handled correctly at runtime, and adds no API surface, so it lands under the "bug fixes" exemption rather than the public-API rule. If that reads as too fine a distinction, the skip list could be sharpened to say "bug fixes, including type corrections that do not add API surface" — happy to do that separately.

Once this and #399 are both in, the `PlayerRequest` alias in #399's transform tests becomes unnecessary and should be dropped by whichever rebases second.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated
- [x] Changelog updated

Docs note: the TSDoc for `response` now states that `customData` may carry the player's own fields and need not declare `cmcd`. The user guide is unchanged because it does not document `customData` anywhere, so there was nothing stale to correct.

Validation: `npm run lint` clean, `npm run typecheck` clean, `npm test -w libs/cmcd` 396 passing / 0 failing (2 pre-existing todos), including two new tests — one that fails to typecheck if the parameter is ever narrowed again, and one asserting the `cmcd` key is still read back when both it and player fields are present. `libs/cmcd/package.json` untouched.
