### PR TITLE
chore: prepare release of 15 packages

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-iso-bmff` to 1.0.4
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.1.0] - 2026-07-21
 
 ### Added
@@ -56,7 +63,8 @@ and this project adheres to
 - `validateC2paManifestBoxSegment(bytes, lastId, state?)` — validate manifest-box segment (§19.7.2)
 - All validation results return `isValid` + `errorCodes` with C2PA failure codes
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.0...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.1...HEAD
+[1.1.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.0...c2pa-v1.1.1
 [1.1.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.1...c2pa-v1.1.0
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.0...c2pa-v1.0.1
 [1.0.0]: https://github.com/streaming-video-technology-alliance/common-media-library/tree/c2pa-v1.0.0

--- a/libs/c2pa/package.json
+++ b/libs/c2pa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-c2pa",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "C2PA (Coalition for Content Provenance and Authenticity) live video validation for BMFF/MP4 containers",
 	"license": "Apache-2.0",
 	"authors": [

--- a/libs/cmaf-ham/CHANGELOG.md
+++ b/libs/cmaf-ham/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.24.6] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [0.24.5] - 2026-07-21
 
 ### Fixed
@@ -64,7 +70,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.5...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.6...HEAD
+[0.24.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.5...cmaf-ham-v0.24.6
 [0.24.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.4...cmaf-ham-v0.24.5
 [0.24.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.3...cmaf-ham-v0.24.4
 [0.24.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmaf-ham-v0.24.2...cmaf-ham-v0.24.3

--- a/libs/cmaf-ham/package.json
+++ b/libs/cmaf-ham/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmaf-ham",
-	"version": "0.24.5",
+	"version": "0.24.6",
 	"description": "CMAF Hypothetical Application Model (HAM) functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-07-28
+
 ### Added
 
 - `transform` on the request-report config and on each event-target config: a synchronous `(data, request) => Cmcd | null` hook that modifies a single CMCD report before it goes to the wire, or cancels it by returning `null`. Placement scopes the hook the same way `enabledKeys` does — the top-level `transform` applies to `createRequestReport()` reports, and each event target's `transform` applies to that target's event reports, so targets sharing a collector URL can filter independently. For `RESPONSE_RECEIVED` events the transform also receives the request that triggered them, which is how a player filters reports by its own request taxonomy on `customData`. Implements the accepted RFC in `rfc/cmcd-reporter-middleware.md` ([#390](https://github.com/streaming-video-technology-alliance/common-media-library/pull/390))
@@ -216,7 +218,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.1...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.5.0...HEAD
+[2.5.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.1...cmcd-v2.5.0
 [2.4.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.0...cmcd-v2.4.1
 [2.4.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.3.2...cmcd-v2.4.0
 [2.3.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.3.1...cmcd-v2.3.2

--- a/libs/cmcd/package.json
+++ b/libs/cmcd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmcd",
-	"version": "2.4.1",
+	"version": "2.5.0",
 	"description": "Common Media Client Data (CMCD) encoding and decoding",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/cmsd/CHANGELOG.md
+++ b/libs/cmsd/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-28
+
 ### Added
 
 - `isCmsdCustomKey`: runtime check for valid custom keys (a lowercase first letter, then characters from `a-z 0-9 . -`, with a hyphen that is neither the first nor the last character), the subset of hyphenated key names that survives RFC 8941 key serialization
@@ -76,7 +78,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.1.0...HEAD
+[1.1.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.7...cmsd-v1.1.0
 [1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.6...cmsd-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.5...cmsd-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmsd-v1.0.4...cmsd-v1.0.5

--- a/libs/cmsd/package.json
+++ b/libs/cmsd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmsd",
-	"version": "1.0.7",
+	"version": "1.1.0",
 	"description": "Common Media Server Data (CMSD) encoding and decoding",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/cta/CHANGELOG.md
+++ b/libs/cta/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+- Update `@svta/cml-structured-field-values` to 1.1.5
+
 ## [1.0.7] - 2026-07-21
 
 ### Changed
@@ -63,7 +70,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.8...HEAD
+[1.0.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.7...cta-v1.0.8
 [1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.6...cta-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.5...cta-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cta-v1.0.4...cta-v1.0.5

--- a/libs/cta/package.json
+++ b/libs/cta/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cta",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "Common functionality for CTA standards including CTA-608/CEA-608",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/dash/CHANGELOG.md
+++ b/libs/dash/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.0.7] - 2026-07-21
 
 ### Changed
@@ -60,7 +66,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.8...HEAD
+[1.0.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.7...dash-v1.0.8
 [1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.6...dash-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.5...dash-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/dash-v1.0.4...dash-v1.0.5

--- a/libs/dash/package.json
+++ b/libs/dash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-dash",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "DASH manifest parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.8] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-iso-bmff` to 1.0.4
+- Update `@svta/cml-utils` to 1.6.0
+- Update `@svta/cml-xml` to 1.1.6
+
 ## [1.1.7] - 2026-07-21
 
 ### Fixed
@@ -86,7 +94,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.8...HEAD
+[1.1.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.7...drm-v1.1.8
 [1.1.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.6...drm-v1.1.7
 [1.1.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.5...drm-v1.1.6
 [1.1.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.4...drm-v1.1.5

--- a/libs/drm/package.json
+++ b/libs/drm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-drm",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"description": "Digital Rights Management (DRM) functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/id3/CHANGELOG.md
+++ b/libs/id3/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.0.7] - 2026-07-21
 
 ### Changed
@@ -63,7 +69,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.8...HEAD
+[1.0.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.7...id3-v1.0.8
 [1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.6...id3-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.5...id3-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/id3-v1.0.4...id3-v1.0.5

--- a/libs/id3/package.json
+++ b/libs/id3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-id3",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "ID3 tag parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/iso-bmff/CHANGELOG.md
+++ b/libs/iso-bmff/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.0.3] - 2026-07-21
 
 ### Fixed
@@ -165,7 +171,8 @@ Official stable release. No changes since 1.0.0-beta.2.
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.3...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.4...HEAD
+[1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.3...iso-bmff-v1.0.4
 [1.0.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.2...iso-bmff-v1.0.3
 [1.0.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.1...iso-bmff-v1.0.2
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.0...iso-bmff-v1.0.1

--- a/libs/iso-bmff/package.json
+++ b/libs/iso-bmff/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-iso-bmff",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "ISO Base Media File Format (ISOBMFF) parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/request/CHANGELOG.md
+++ b/libs/request/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.15] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-cmcd` to 2.5.0
+- Update `@svta/cml-xml` to 1.1.6
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.0.14] - 2026-07-21
 
 ### Changed
@@ -113,7 +121,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.14...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.15...HEAD
+[1.0.15]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.14...request-v1.0.15
 [1.0.14]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.13...request-v1.0.14
 [1.0.13]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.12...request-v1.0.13
 [1.0.12]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.11...request-v1.0.12

--- a/libs/request/package.json
+++ b/libs/request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-request",
-	"version": "1.0.14",
+	"version": "1.0.15",
 	"description": "Common Media Request and Response types",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/structured-field-values/CHANGELOG.md
+++ b/libs/structured-field-values/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-07-28
+
 ### Fixed
 
 - `encodeSfDict` and `encodeSfList` no longer drop the whitespace RFC 8941 emits after each comma when they are given a partial options object. `whitespace` was applied via a default parameter, so any options object without that property (for example `encodeSfDict(data, {})`) silently produced compact output; it is now treated as `true` unless explicitly set to `false`. Callers that passed an options object without `whitespace` and relied on compact output must now pass `whitespace: false`
@@ -62,7 +64,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.4...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.5...HEAD
+[1.1.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.4...structured-field-values-v1.1.5
 [1.1.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.3...structured-field-values-v1.1.4
 [1.1.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.2...structured-field-values-v1.1.3
 [1.1.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/structured-field-values-v1.1.1...structured-field-values-v1.1.2

--- a/libs/structured-field-values/package.json
+++ b/libs/structured-field-values/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-structured-field-values",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "RFC8941 Structured Field Values implementation",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/throughput/CHANGELOG.md
+++ b/libs/throughput/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.0.7] - 2026-07-21
 
 ### Changed
@@ -58,7 +64,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.8...HEAD
+[1.0.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.7...throughput-v1.0.8
 [1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.6...throughput-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.5...throughput-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/throughput-v1.0.4...throughput-v1.0.5

--- a/libs/throughput/package.json
+++ b/libs/throughput/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-throughput",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "Throughput estimation functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/utils/CHANGELOG.md
+++ b/libs/utils/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-28
+
 ### Added
 
 - `DeepReadonly<T>` — marks every property of `T` as `readonly`, recursively. `Readonly<T>` stops at the top level, so a nested object stays writable and `value.nested.field = …` still compiles; this applies at every depth, including through arrays. Functions are left unchanged so callbacks carried on a value stay callable, and primitives are returned as they are
@@ -80,7 +82,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.5.1...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.6.0...HEAD
+[1.6.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.5.1...utils-v1.6.0
 [1.5.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.5.0...utils-v1.5.1
 [1.5.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.4.0...utils-v1.5.0
 [1.4.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/utils-v1.3.0...utils-v1.4.0

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-utils",
-	"version": "1.5.1",
+	"version": "1.6.0",
 	"description": "Common utility functions for media processing",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/webvtt/CHANGELOG.md
+++ b/libs/webvtt/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.0.7] - 2026-07-21
 
 ### Fixed
@@ -60,7 +66,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.7...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.8...HEAD
+[1.0.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.7...webvtt-v1.0.8
 [1.0.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-vtt-v1.0.6...webvtt-v1.0.7
 [1.0.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.5...webvtt-v1.0.6
 [1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/webvtt-v1.0.4...webvtt-v1.0.5

--- a/libs/webvtt/package.json
+++ b/libs/webvtt/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-webvtt",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "WebVTT parsing and rendering functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.6] - 2026-07-28
+
+### Changed
+
+- Update `@svta/cml-utils` to 1.6.0
+
 ## [1.1.5] - 2026-07-21
 
 ### Changed
@@ -69,7 +75,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.5...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.6...HEAD
+[1.1.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.5...xml-v1.1.6
 [1.1.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.4...xml-v1.1.5
 [1.1.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.3...xml-v1.1.4
 [1.1.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.2...xml-v1.1.3

--- a/libs/xml/package.json
+++ b/libs/xml/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-xml",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"description": "XML parsing utilities",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"libs/c2pa": {
 			"name": "@svta/cml-c2pa",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -66,7 +66,7 @@
 		},
 		"libs/cmaf-ham": {
 			"name": "@svta/cml-cmaf-ham",
-			"version": "0.24.5",
+			"version": "0.24.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@types/m3u8-parser": "7.2.5",
@@ -83,7 +83,7 @@
 		},
 		"libs/cmcd": {
 			"name": "@svta/cml-cmcd",
-			"version": "2.4.1",
+			"version": "2.5.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -95,7 +95,7 @@
 		},
 		"libs/cmsd": {
 			"name": "@svta/cml-cmsd",
-			"version": "1.0.7",
+			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -116,7 +116,7 @@
 		},
 		"libs/cta": {
 			"name": "@svta/cml-cta",
-			"version": "1.0.7",
+			"version": "1.0.8",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -128,7 +128,7 @@
 		},
 		"libs/dash": {
 			"name": "@svta/cml-dash",
-			"version": "1.0.7",
+			"version": "1.0.8",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -139,7 +139,7 @@
 		},
 		"libs/drm": {
 			"name": "@svta/cml-drm",
-			"version": "1.1.7",
+			"version": "1.1.8",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -152,7 +152,7 @@
 		},
 		"libs/id3": {
 			"name": "@svta/cml-id3",
-			"version": "1.0.7",
+			"version": "1.0.8",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -171,7 +171,7 @@
 		},
 		"libs/iso-bmff": {
 			"name": "@svta/cml-iso-bmff",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -190,7 +190,7 @@
 		},
 		"libs/request": {
 			"name": "@svta/cml-request",
-			"version": "1.0.14",
+			"version": "1.0.15",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -203,7 +203,7 @@
 		},
 		"libs/structured-field-values": {
 			"name": "@svta/cml-structured-field-values",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -214,7 +214,7 @@
 		},
 		"libs/throughput": {
 			"name": "@svta/cml-throughput",
-			"version": "1.0.7",
+			"version": "1.0.8",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -225,7 +225,7 @@
 		},
 		"libs/utils": {
 			"name": "@svta/cml-utils",
-			"version": "1.5.1",
+			"version": "1.6.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -233,7 +233,7 @@
 		},
 		"libs/webvtt": {
 			"name": "@svta/cml-webvtt",
-			"version": "1.0.7",
+			"version": "1.0.8",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -244,7 +244,7 @@
 		},
 		"libs/xml": {
 			"name": "@svta/cml-xml",
-			"version": "1.1.5",
+			"version": "1.1.6",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -23,22 +23,25 @@ const sections = changelog.split(/^## /m)
 sections.splice(2, 0, `[${ver}] - ????-??-??\n\n`)
 
 const version = `${pkg}-v${ver}`
-// Anchored on the package's own tag prefix so a `v` inside the package name
+// Matched on the package's own tag prefix so a `v` inside the package name
 // (structured-field-values, webvtt) cannot be mistaken for the version's `v`.
-const head = new RegExp(`${pkg}-v([0-9a-zA-Z.-]+)\\.\\.\\.HEAD`)
+// Plain string search rather than a regex: `pkg` is a command-line argument.
+const tagPrefix = `${pkg}-v`
+const headSuffix = '...HEAD'
 const linkBreak = '\n'
 const last = sections.length - 1
 const links = sections[last].split(linkBreak)
-const index = links.findIndex((link) => head.test(link))
+const index = links.findIndex((link) => link.endsWith(headSuffix) && link.includes(tagPrefix))
 
 if (index < 0) {
-	throw new Error(`Missing ${pkg}-v<version>...HEAD compare link in ${folder}/CHANGELOG.md`)
+	throw new Error(`Missing ${tagPrefix}<version>${headSuffix} compare link in ${folder}/CHANGELOG.md`)
 }
 
 const unreleased = links[index]
-const previous = unreleased.match(head)?.[1]
-links[index] = unreleased.replace(head, `${version}...HEAD`)
-links.splice(index + 1, 0, `[${ver}]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/${pkg}-v${previous}...${version}`)
+const tagStart = unreleased.lastIndexOf(tagPrefix)
+const previous = unreleased.slice(tagStart + tagPrefix.length, unreleased.length - headSuffix.length)
+links[index] = unreleased.slice(0, tagStart) + version + headSuffix
+links.splice(index + 1, 0, `[${ver}]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/${tagPrefix}${previous}...${version}`)
 sections[last] = links.join(linkBreak)
 
 await writeFile(`${folder}/CHANGELOG.md`, sections.join('## '))

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -23,14 +23,21 @@ const sections = changelog.split(/^## /m)
 sections.splice(2, 0, `[${ver}] - ????-??-??\n\n`)
 
 const version = `${pkg}-v${ver}`
-const head = /v([0-9a-zA-Z.-]+)...HEAD/
+// Anchored on the package's own tag prefix so a `v` inside the package name
+// (structured-field-values, webvtt) cannot be mistaken for the version's `v`.
+const head = new RegExp(`${pkg}-v([0-9a-zA-Z.-]+)\\.\\.\\.HEAD`)
 const linkBreak = '\n'
 const last = sections.length - 1
 const links = sections[last].split(linkBreak)
 const index = links.findIndex((link) => head.test(link))
+
+if (index < 0) {
+	throw new Error(`Missing ${pkg}-v<version>...HEAD compare link in ${folder}/CHANGELOG.md`)
+}
+
 const unreleased = links[index]
 const previous = unreleased.match(head)?.[1]
-links[index] = unreleased.replace(/\/[0-9a-z-]+v[0-9a-zA-Z.-]+...HEAD/, `/${version}...HEAD`)
+links[index] = unreleased.replace(head, `${version}...HEAD`)
 links.splice(index + 1, 0, `[${ver}]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/${pkg}-v${previous}...${version}`)
 sections[last] = links.join(linkBreak)
 


### PR DESCRIPTION
## Description

Release prep for every package with unreleased changes, plus the patch cascade to their dependents.

### Direct bumps

| Package | Version | Why |
| --- | --- | --- |
| `utils` | 1.5.1 → **1.6.0** | new `DeepReadonly<T>` export (#402) |
| `cmcd` | 2.4.1 → **2.5.0** | per-placement report transforms (#399), transform request generic over `customData` (#402), `CmcdReporterConfig.customHeaderMap`, forced `ec`/`url` on error and response-received reports, RFC 8941 custom-key narrowing (#394) |
| `cmsd` | 1.0.7 → **1.1.0** | new `isCmsdCustomKey` export, `CmsdCustomKey` narrowed to RFC 8941 serializable names (#397) |
| `structured-field-values` | 1.1.4 → **1.1.5** | Fixed-only: honor the documented `whitespace` default for partial encode options (#394) |

Minor rather than major for `cmcd` and `cmsd`: the new type parameters all default to their previous shapes, and the narrowed custom-key types reject only names the encoders already threw on.

### Cascaded patches

`xml` 1.1.6, `cta` 1.0.8, `request` 1.0.15, `dash` 1.0.8, `id3` 1.0.8, `iso-bmff` 1.0.4, `throughput` 1.0.8, `webvtt` 1.0.8, `drm` 1.1.8, `cmaf-ham` 0.24.6, `c2pa` 1.1.1 — 15 packages in total.

`608`, `content-steering`, and `iso-8601` are untouched: no unreleased changes and no CML peer dependency on a bumped package. `mse` is commented out of `scripts/projects.ts` and unpublished, so it is outside the release.

The set of packages bumped directly was cross-checked two ways — packages carrying `## [Unreleased]` entries, and packages with commits since their last version bump. The two sets matched exactly.

### Also in this PR: a `scripts/version.ts` fix

`npm run ver` located the previous release version with `/v([0-9a-zA-Z.-]+)...HEAD` — unanchored, with unescaped dots. For `structured-field-values` that matched the `v` inside "values" and emitted a compare link to the nonexistent tag `structured-field-values-values-v1.1.4`; `webvtt` would have broken the same way on its next direct bump. Both the lookup and the replacement are now anchored on the package's own `<pkg>-v` tag prefix, and a missing Unreleased compare link fails with the file and expected pattern instead of throwing on `links[-1]`. It is a separate commit (a7906ad) so it can be reviewed on its own.

`prepare-release` was never affected — its regex is escaped and it passes `previousVersion` explicitly.

### Notes for the reviewer

- `npm run ver` inserts the empty dated section *below* the `[Unreleased]` body, so the entries were moved into their dated sections by hand — the same manual step taken in the 608 1.0.3 and 16-package releases. Worth automating in `ver` eventually; left out of scope here.
- `package-lock.json` is refreshed in the release commit (15 version fields, nothing else), so no follow-up lockfile sync is needed as in #395.
- Pre-existing, not from this PR: api-extractor warns that `cmcd`'s `@link DeepReadonly` cannot resolve, since `DeepReadonly` is a `utils` export. Introduced by #402 and harmless, but it will keep printing until the reference is qualified.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed — no test changes: version/changelog edits carry no behavior, and `scripts/` has no test harness in this repo. Full root `npm test` passes: **2783 tests, 0 failures**, no `config/cml-*.api.md` drift after build
- [x] Docs/guides updated — changelog sections and compare links are the docs surface for a release-prep PR; no guide content changed
- [x] Changelog updated — each bumped package's unreleased entries moved into a dated section, cascaded dependency notes added to the 11 patched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UF2ZaXRppg5VPuPCKp2oN

---
_Generated by [Claude Code](https://claude.ai/code/session_017UF2ZaXRppg5VPuPCKp2oN)_