### PR TITLE
fix(iso-bmff): write the null terminator for empty terminated strings

### DIFF
--- a/libs/iso-bmff/CHANGELOG.md
+++ b/libs/iso-bmff/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `writeTerminatedString` now writes the null terminator for empty strings, so `writeEmsg` output with an empty `value` or `schemeIdUri` no longer misaligns the fields that follow (version 1 `messageData` lost its head to the `value` read; version 0 numeric fields were garbled) ([#411](https://github.com/streaming-video-technology-alliance/common-media-library/issues/411))
+
 ## [1.0.4] - 2026-07-28
 
 ### Changed

--- a/libs/iso-bmff/src/IsoBoxWriteView.ts
+++ b/libs/iso-bmff/src/IsoBoxWriteView.ts
@@ -145,10 +145,6 @@ export class IsoBoxWriteView {
 	 * @param value - The value to write.
 	 */
 	writeTerminatedString = (value: string): void => {
-		if (value.length === 0) {
-			return
-		}
-
 		for (let c = 0, len = value.length; c < len; c++) {
 			this.writeUint(value.charCodeAt(c), 1)
 		}

--- a/libs/iso-bmff/test/writers/writeEmsg.test.ts
+++ b/libs/iso-bmff/test/writers/writeEmsg.test.ts
@@ -1,0 +1,111 @@
+import { assert, describe, it, readEmsg, readIsoBoxes, writeEmsg } from '../util/box.ts'
+
+describe('writeEmsg', function () {
+	it('should write a version 1 EventMessageBox that can be read back correctly', function () {
+		const box = {
+			type: 'emsg' as const,
+			version: 1,
+			flags: 0,
+			timescale: 90000,
+			presentationTime: 900000,
+			eventDuration: 0,
+			id: 1,
+			schemeIdUri: 'urn:test:scheme',
+			value: '1',
+			messageData: new Uint8Array([0x49, 0x44, 0x33, 0x04, 0x00, 0x01])
+		}
+
+		const writer = writeEmsg(box)
+		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
+
+		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].schemeIdUri, 'urn:test:scheme')
+		assert.strictEqual(boxes[0].value, '1')
+		assert.strictEqual(boxes[0].timescale, 90000)
+		assert.strictEqual(boxes[0].presentationTime, 900000)
+		assert.deepEqual(new Uint8Array(boxes[0].messageData), box.messageData)
+	})
+
+	it('should encode an empty value as a lone null terminator', function () {
+		const box = {
+			type: 'emsg' as const,
+			version: 1,
+			flags: 0,
+			timescale: 1,
+			presentationTime: 0,
+			eventDuration: 0,
+			id: 0,
+			schemeIdUri: 'a',
+			value: '',
+			messageData: new Uint8Array([0xff])
+		}
+
+		const writer = writeEmsg(box)
+		const buffer = new Uint8Array(writer.buffer)
+
+		assert.strictEqual(Buffer.compare(buffer, new Uint8Array([
+			0x00, 0x00, 0x00, 0x24, // size
+			0x65, 0x6d, 0x73, 0x67, // type
+			0x01, 0x00, 0x00, 0x00, // version + flags
+			0x00, 0x00, 0x00, 0x01, // timescale
+			0x00, 0x00, 0x00, 0x00, // presentationTime (hi)
+			0x00, 0x00, 0x00, 0x00, // presentationTime (lo)
+			0x00, 0x00, 0x00, 0x00, // eventDuration
+			0x00, 0x00, 0x00, 0x00, // id
+			0x61, 0x00,             // schemeIdUri 'a' + terminator
+			0x00,                   // value '' + terminator
+			0xff,                   // messageData
+		])), 0)
+	})
+
+	it('should preserve messageData through a version 1 round trip when value is empty', function () {
+		const messageData = new Uint8Array([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x01])
+		const box = {
+			type: 'emsg' as const,
+			version: 1,
+			flags: 0,
+			timescale: 90000,
+			presentationTime: 900000,
+			eventDuration: 0,
+			id: 1,
+			schemeIdUri: 'https://aomedia.org/emsg/ID3',
+			value: '',
+			messageData
+		}
+
+		const writer = writeEmsg(box)
+		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
+
+		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].value, '')
+		assert.deepEqual(new Uint8Array(boxes[0].messageData), messageData)
+	})
+
+	it('should preserve the fixed fields through a version 0 round trip when the strings are empty', function () {
+		const messageData = new Uint8Array([0x01, 0x02, 0x03])
+		const box = {
+			type: 'emsg' as const,
+			version: 0,
+			flags: 0,
+			timescale: 48000,
+			presentationTimeDelta: 96000,
+			eventDuration: 5,
+			id: 7,
+			schemeIdUri: '',
+			value: '',
+			messageData
+		}
+
+		const writer = writeEmsg(box)
+		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
+
+		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].schemeIdUri, '')
+		assert.strictEqual(boxes[0].value, '')
+		assert.strictEqual(boxes[0].timescale, 48000)
+		assert.strictEqual(boxes[0].presentationTimeDelta, 96000)
+		assert.strictEqual(boxes[0].eventDuration, 5)
+		assert.strictEqual(boxes[0].id, 7)
+		assert.deepEqual(new Uint8Array(boxes[0].messageData), messageData)
+	})
+})

--- a/libs/iso-bmff/test/writers/writeEmsg.test.ts
+++ b/libs/iso-bmff/test/writers/writeEmsg.test.ts
@@ -84,6 +84,31 @@ describe('writeEmsg', function () {
 		assert.deepEqual(new Uint8Array(boxes[0].messageData), messageData)
 	})
 
+	it('should preserve a non-empty value through a version 1 round trip when schemeIdUri is empty', function () {
+		const messageData = new Uint8Array([0xaa, 0xbb])
+		const box = {
+			type: 'emsg' as const,
+			version: 1 as const,
+			flags: 0,
+			timescale: 90000,
+			presentationTime: 900000,
+			eventDuration: 0,
+			id: 1,
+			schemeIdUri: '',
+			value: '1',
+			messageData
+		}
+
+		const writer = writeEmsg(box)
+		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
+
+		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].type, 'emsg')
+		assert.strictEqual(boxes[0].schemeIdUri, '')
+		assert.strictEqual(boxes[0].value, '1')
+		assert.deepEqual(new Uint8Array(boxes[0].messageData), messageData)
+	})
+
 	it('should preserve the fixed fields through a version 0 round trip when the strings are empty', function () {
 		const messageData = new Uint8Array([0x01, 0x02, 0x03])
 		const box = {

--- a/libs/iso-bmff/test/writers/writeEmsg.test.ts
+++ b/libs/iso-bmff/test/writers/writeEmsg.test.ts
@@ -4,7 +4,7 @@ describe('writeEmsg', function () {
 	it('should write a version 1 EventMessageBox that can be read back correctly', function () {
 		const box = {
 			type: 'emsg' as const,
-			version: 1,
+			version: 1 as const,
 			flags: 0,
 			timescale: 90000,
 			presentationTime: 900000,
@@ -19,6 +19,8 @@ describe('writeEmsg', function () {
 		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
 
 		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].type, 'emsg')
+		assert.strictEqual(boxes[0].version, 1)
 		assert.strictEqual(boxes[0].schemeIdUri, 'urn:test:scheme')
 		assert.strictEqual(boxes[0].value, '1')
 		assert.strictEqual(boxes[0].timescale, 90000)
@@ -29,7 +31,7 @@ describe('writeEmsg', function () {
 	it('should encode an empty value as a lone null terminator', function () {
 		const box = {
 			type: 'emsg' as const,
-			version: 1,
+			version: 1 as const,
 			flags: 0,
 			timescale: 1,
 			presentationTime: 0,
@@ -62,7 +64,7 @@ describe('writeEmsg', function () {
 		const messageData = new Uint8Array([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x01])
 		const box = {
 			type: 'emsg' as const,
-			version: 1,
+			version: 1 as const,
 			flags: 0,
 			timescale: 90000,
 			presentationTime: 900000,
@@ -77,6 +79,7 @@ describe('writeEmsg', function () {
 		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
 
 		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].type, 'emsg')
 		assert.strictEqual(boxes[0].value, '')
 		assert.deepEqual(new Uint8Array(boxes[0].messageData), messageData)
 	})
@@ -85,7 +88,7 @@ describe('writeEmsg', function () {
 		const messageData = new Uint8Array([0x01, 0x02, 0x03])
 		const box = {
 			type: 'emsg' as const,
-			version: 0,
+			version: 0 as const,
 			flags: 0,
 			timescale: 48000,
 			presentationTimeDelta: 96000,
@@ -100,6 +103,8 @@ describe('writeEmsg', function () {
 		const boxes = readIsoBoxes(writer.buffer, { readers: { emsg: readEmsg } })
 
 		assert.strictEqual(boxes.length, 1)
+		assert.strictEqual(boxes[0].type, 'emsg')
+		assert.strictEqual(boxes[0].version, 0)
 		assert.strictEqual(boxes[0].schemeIdUri, '')
 		assert.strictEqual(boxes[0].value, '')
 		assert.strictEqual(boxes[0].timescale, 48000)


### PR DESCRIPTION
## Description

Fixes #411.

`writeTerminatedString` returned without writing anything for an empty string, while every caller (`writeEmsg`, `writeUrl`, `writeUrn`, `writeHdlr`) budgets `length + 1` bytes for the field. The missing terminator shifted every subsequent field in the box left by one byte. This was only observable in `emsg`, where fields follow the strings: a version 1 box with an empty `value` came back from `readEmsg` with the head of `messageData` consumed by the `value` read, and a version 0 box with empty strings garbled its numeric fields. Boxes whose terminated string is the final field (`url `, `urn `, `hdlr`) round-tripped correctly by accident because the zero-initialized slack byte doubled as the terminator.

The fix removes the early return so an empty string encodes as a lone `0x00`, per ISO/IEC 14496-12, matching the callers' size math and the behavior of `writeUtf8TerminatedString`.

New `writeEmsg` tests cover a byte-exact empty-`value` encoding, version 1 round-trip preservation of `messageData` with an empty `value`, a version 0 round trip with both strings empty, and a baseline non-empty round trip. The three empty-string cases fail without the one-line fix; the full `iso-bmff` suite passes with it (106/106).

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [ ] Docs/guides updated (n/a: no API shape change)
- [x] Changelog updated
