### PR TITLE
chore: prepare release of 3 packages

### DIFF
--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-11
+
+### Changed
+
+- Update `@svta/cml-iso-bmff` to 1.0.5
+
 ## [1.1.1] - 2026-07-28
 
 ### Changed
@@ -63,7 +69,8 @@ and this project adheres to
 - `validateC2paManifestBoxSegment(bytes, lastId, state?)` — validate manifest-box segment (§19.7.2)
 - All validation results return `isValid` + `errorCodes` with C2PA failure codes
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.1...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.2...HEAD
+[1.1.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.1...c2pa-v1.1.2
 [1.1.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.1.0...c2pa-v1.1.1
 [1.1.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.1...c2pa-v1.1.0
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/c2pa-v1.0.0...c2pa-v1.0.1

--- a/libs/c2pa/package.json
+++ b/libs/c2pa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-c2pa",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "C2PA (Coalition for Content Provenance and Authenticity) live video validation for BMFF/MP4 containers",
 	"license": "Apache-2.0",
 	"authors": [

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.9] - 2026-08-11
+
+### Changed
+
+- Update `@svta/cml-iso-bmff` to 1.0.5
+
 ## [1.1.8] - 2026-07-28
 
 ### Changed
@@ -94,7 +100,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.8...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.9...HEAD
+[1.1.9]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.8...drm-v1.1.9
 [1.1.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.7...drm-v1.1.8
 [1.1.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.6...drm-v1.1.7
 [1.1.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.5...drm-v1.1.6

--- a/libs/drm/package.json
+++ b/libs/drm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-drm",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "Digital Rights Management (DRM) functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/iso-bmff/CHANGELOG.md
+++ b/libs/iso-bmff/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-08-11
+
 ### Fixed
 
 - `writeTerminatedString` now writes the null terminator for empty strings, so `writeEmsg` output with an empty `value` or `schemeIdUri` no longer misaligns the fields that follow (version 1 `messageData` lost its head to the `value` read; version 0 numeric fields were garbled) ([#411](https://github.com/streaming-video-technology-alliance/common-media-library/issues/411))
@@ -175,7 +177,8 @@ Official stable release. No changes since 1.0.0-beta.2.
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.4...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.5...HEAD
+[1.0.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.4...iso-bmff-v1.0.5
 [1.0.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.3...iso-bmff-v1.0.4
 [1.0.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.2...iso-bmff-v1.0.3
 [1.0.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/iso-bmff-v1.0.1...iso-bmff-v1.0.2

--- a/libs/iso-bmff/package.json
+++ b/libs/iso-bmff/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-iso-bmff",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "ISO Base Media File Format (ISOBMFF) parsing functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"libs/c2pa": {
 			"name": "@svta/cml-c2pa",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -139,7 +139,7 @@
 		},
 		"libs/drm": {
 			"name": "@svta/cml-drm",
-			"version": "1.1.8",
+			"version": "1.1.9",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -171,7 +171,7 @@
 		},
 		"libs/iso-bmff": {
 			"name": "@svta/cml-iso-bmff",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"


### PR DESCRIPTION
## Description

Release prep for the #411 fix, merged in #412. One direct bump, two cascaded.

- iso-bmff 1.0.5 (patch): `writeTerminatedString` now writes the null terminator for empty strings, so `writeEmsg` output with an empty `value` or `schemeIdUri` no longer misaligns the fields that follow.
- drm 1.1.9 and c2pa 1.1.2: cascaded patch bumps from `npm run prepare-release`. Both declare a peer dependency on iso-bmff. The changes are version and changelog only, since their peer ranges (`*`, `>=1.0.1`) already cover 1.0.5.

The remaining packages have no unreleased changelog content and no dependency on iso-bmff. The two dependabot merges since #403 (fast-uri, js-yaml) touched only the lockfile, so nothing else needs a bump.

Validated with root `npm test` (lint, build, typecheck, and every package's tests).

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (n/a: version bumps and changelogs only)
- [ ] Docs/guides updated (n/a)
- [x] Changelog updated