### PR TITLE
ci: update actions targeting deprecated Node.js runtimes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build -w docs
 
       - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_dir: ./docs/dist/
           personal_token: ${{ secrets.GH_ACTIONS }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -16,10 +16,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: "npm"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm run build -w docs
 
       - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_dir: ./docs/dist/
           personal_token: ${{ secrets.GH_ACTIONS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run build -w docs
 
       - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_dir: ./docs/dist/
           personal_token: ${{ secrets.GH_ACTIONS }}


### PR DESCRIPTION
## Summary

GitHub deprecated the Node.js 20 (and earlier) action runtimes and now forces affected actions onto Node 24, with a warning on every run. Our Publish runs warn about `peaceiris/actions-gh-pages@v3`, which declares node16.

- Bump `peaceiris/actions-gh-pages` from v3 to v4 (node24) in `publish.yml`, `docs.yml`, and `publish-package.yml`. v4 keeps the `publish_dir` and `personal_token` inputs, so it is a drop-in change.
- Bump `actions/checkout` and `actions/setup-node` from v3 to v5 (node24) in `draft-release.yml`, matching the versions the other workflows already use.

## Notes for reviewers

- The runner warning that names `actions/checkout@v4` and `actions/upload-artifact@v4` comes from `pages-build-deployment`, the GitHub-managed Pages workflow. Its pins belong to GitHub and the warning clears when they update it.
- All four changed workflows run on workflow_dispatch, so PR CI does not exercise them. Each new version declares `runs.using: node24` in its action.yml, and all workflow files still parse.
- `draft-release.yml` also uses the archived `actions/create-release@v1`. Replacing it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)