### PR TITLE
chore: replace archived create-release action with gh release create

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -36,13 +36,6 @@ jobs:
         run: npm run notes
 
       - name: Draft Release
-        uses: actions/create-release@v1
+        run: gh release create "v${PKG_VERSION}" --draft --target main --title "${PKG_VERSION}" --notes-file ./RELEASE.md
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS }}
-        with:
-          tag_name: v${{ env.PKG_VERSION }}
-          release_name: ${{ env.PKG_VERSION }}
-          commitish: main
-          body_path: ./RELEASE.md
-          draft: true
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GH_ACTIONS }}


### PR DESCRIPTION
## Description

Replaces `actions/create-release@v1` in the Draft Release workflow with a direct `gh release create` call. The action has been archived and unmaintained since 2021, and GitHub force-migrates its node12 runtime onto newer Node versions. The gh CLI is preinstalled on GitHub-hosted runners.

Behavior is unchanged:

- tag: `v${PKG_VERSION}`
- release title: `${PKG_VERSION}`
- target: `main`
- notes: the `RELEASE.md` generated by `npm run notes`
- draft release, no prerelease flag

Auth keeps the `GH_ACTIONS` secret the step already used, now passed via the `GH_TOKEN` env var the gh CLI reads (publish.yml uses the same env-var wiring, with a different secret). Sticking with the PAT keeps the workflow's `contents: read` permissions block unchanged: the ambient `GITHUB_TOKEN` would need `contents: write` to create a release. `PKG_VERSION` comes from `GITHUB_ENV`, so the run command reads it as a shell variable with no `${{ }}` interpolation.

One note for review: the workflow is `workflow_dispatch` only, so this path first runs for real on the next release draft.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed (n/a: workflow-only change)
- [x] Docs/guides updated (n/a: workflow-only change)
- [x] Changelog updated (n/a: no package affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
