### PR TITLE
chore: prepare release of 608 1.1.0

### DIFF
--- a/libs/608/CHANGELOG.md
+++ b/libs/608/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-13
+
 ### Added
 
 - `extractCta608DataFromAv1Sample` extracts CTA-608 field data from AV1 (`av01`) samples, where captions are carried in a `metadata_itu_t_t35` OBU rather than in an SEI message. The `cc_data()` payload is identical to the SEI path, so the result feeds `Cta608Parser` unchanged. Select on the sample entry type: NAL unit and AV1 samples are framed differently and neither is self-identifying, so the framing has to come from the sample entry rather than from the bytes.
@@ -48,7 +50,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.3...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.1.0...HEAD
+[1.1.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.3...608-v1.1.0
 [1.0.3]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.2...608-v1.0.3
 [1.0.2]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.1...608-v1.0.2
 [1.0.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/608-v1.0.0...608-v1.0.1

--- a/libs/608/package.json
+++ b/libs/608/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-608",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"description": "CTA-608/CEA-608 closed captioning functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 		},
 		"libs/608": {
 			"name": "@svta/cml-608",
-			"version": "1.0.3",
+			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"


### PR DESCRIPTION
## Description

Release prep for #407, the CTA-608-from-AV1 feature. One direct bump, no cascades.

- 608 1.1.0 (minor): adds `extractCta608DataFromAv1Sample`, which reads CTA-608 caption data from the `metadata_itu_t_t35` OBU in AV1 samples. The same change shared the `cc_data()` parser between the SEI and OBU carriage paths and bounds it by the enclosing structure, which fixes two malformed-input bugs (reads past the payload on a wrong `cc_count`, and a `RangeError` on an identifier-only T.35 payload).

`npm run prepare-release` cascaded nothing: no package declares a CML dependency on cml-608. No other package has unreleased changelog content, so this release is 608 only.

Validated with root `npm test` (lint, build, typecheck, and every package's tests).

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (n/a: version bump and changelog only)
- [ ] Docs/guides updated (n/a)
- [x] Changelog updated