### PR TITLE
docs(cmcd): correct CmcdEncodeOptions.version default to CMCD_V2

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the `CmcdEncodeOptions.version` documentation, which still claimed a default of `1`. Encoding has defaulted to `CMCD_V2` since 2.0.0: when `version` is not set, the version is inferred from the data's `v` key, falling back to `CMCD_V2`, which is why `encodeCmcd({ br: 1000 })` emits `br=1000,v=2`. Documentation-only change; runtime behavior is unchanged
+
 ## [2.5.0] - 2026-07-28
 
 ### Added

--- a/libs/cmcd/src/CmcdEncodeOptions.ts
+++ b/libs/cmcd/src/CmcdEncodeOptions.ts
@@ -11,9 +11,10 @@ import type { CmcdVersion } from './CmcdVersion.ts'
  */
 export type CmcdEncodeOptions = {
 	/**
-	 * The version of the CMCD specification to use.
+	 * The version of the CMCD specification to use. If not provided, the version
+	 * is inferred from the data's `v` key, defaulting to `CMCD_V2`.
 	 *
-	 * @defaultValue `1`
+	 * @defaultValue `CMCD_V2`
 	 */
 	version?: CmcdVersion;
 


### PR DESCRIPTION
## Summary

- The TSDoc for `CmcdEncodeOptions.version` still claimed a default of `1`, but encoding has defaulted to CMCD v2 since #302 (cmcd 2.0.0): `prepareCmcdData` resolves `options.version || obj['v'] || CMCD_V2`, which is why `encodeCmcd({ br: 1000 })` emits `br=1000,v=2`.
- The runtime behavior is intentional and consistent with `CmcdReporter` and the report config types (which already document `CMCD_V2`), so this corrects the doc rather than the code. The validation path (`CmcdValidationOptions`) keeps its documented v1 default, which is correct there since encoded v2 payloads always carry `v=2`.
- The updated TSDoc also explains the `v`-key fallback so the full resolution order is visible from the type.
- Documentation-only change; no runtime or API surface change (`cml-cmcd.api.md` is unchanged after rebuild).

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-cmcd | 2.5.0 | docs |

## Test Plan

- [x] `npm run build -w libs/cmcd` — succeeds, API report unchanged
- [x] `npm test -w libs/cmcd` — 450 pass, 0 fail
- [x] `npm run typecheck` — clean
- [x] `npm run build -w docs` — 0 errors
- [x] Changelog updated under `## [Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)