### PR TITLE
fix(xml): bound the attribute quote scan so parseXml cannot loop forever

### DIFF
--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `parseXml` no longer loops forever on an attribute with no quoted value, such as `<a b>`, `<a b=c/>`, or a document truncated inside an attribute name or after `=`. The attribute now yields an empty string, and the attribute scan stops at `>` so following markup is no longer swallowed into the value.
+
 ## [1.1.6] - 2026-07-28
 
 ### Changed

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Fixed
 
-- `parseXml` no longer loops forever on an attribute with no quoted value, such as `<a b>`, `<a b=c/>`, or a document truncated inside an attribute name or after `=`. The attribute now yields an empty string, and the attribute scan stops at `>` so following markup is no longer swallowed into the value.
+- `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -196,7 +196,7 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 				let value: string = ''
 				// search beginning of the string
 				let code = input.charCodeAt(pos)
-				while (code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC) {
+				while (pos < length && code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC && code !== CLOSE_BRACKET_CC) {
 					pos++
 					code = input.charCodeAt(pos)
 				}

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -1,5 +1,5 @@
 import { parseXml } from '@svta/cml-xml'
-import assert, { equal, strictEqual } from 'node:assert'
+import assert, { deepStrictEqual, equal, strictEqual, throws } from 'node:assert'
 import { promises as fs } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, it } from 'node:test'
@@ -135,6 +135,91 @@ describe('parseXml', () => {
 			strictEqual(b.parentElement, a)
 			strictEqual(c.parentElement, b)
 			strictEqual(d.parentElement, c)
+		})
+	})
+
+	describe('malformed attributes', () => {
+		it('parses a valueless attribute as an empty string', () => {
+			const doc = parseXml('<a b>')
+			const a = doc.childNodes[0]
+
+			equal(a.nodeName, 'a')
+			deepStrictEqual(a.attributes, { b: '' })
+			equal(a.childNodes.length, 0)
+		})
+
+		it('parses a valueless attribute after a quoted attribute', () => {
+			const doc = parseXml('<a b="c" d>')
+			deepStrictEqual(doc.childNodes[0].attributes, { b: 'c', d: '' })
+		})
+
+		it('parses a valueless attribute in a self-closing child', () => {
+			const doc = parseXml('<a b="c"><d e/></a>')
+			const a = doc.childNodes[0]
+
+			equal(a.childNodes.length, 1)
+			equal(a.childNodes[0].nodeName, 'd')
+			deepStrictEqual(a.childNodes[0].attributes, { e: '' })
+			equal(a.childNodes[0].childNodes.length, 0)
+		})
+
+		it('does not swallow markup following a valueless attribute', () => {
+			const doc = parseXml('<a b><c d="1"/></a>')
+			const a = doc.childNodes[0]
+
+			deepStrictEqual(a.attributes, { b: '' })
+			equal(a.childNodes.length, 1)
+			equal(a.childNodes[0].nodeName, 'c')
+			deepStrictEqual(a.childNodes[0].attributes, { d: '1' })
+		})
+
+		it('parses an unquoted attribute value as an empty string', () => {
+			const doc = parseXml('<a b=c/>')
+			const a = doc.childNodes[0]
+
+			equal(a.nodeName, 'a')
+			deepStrictEqual(a.attributes, { b: '' })
+			equal(a.childNodes.length, 0)
+		})
+
+		it('terminates when the input ends inside an attribute name', () => {
+			const doc = parseXml('<MPD><Period><SegmentTimeline><S d="180000" r')
+			const s = doc.childNodes[0].childNodes[0].childNodes[0].childNodes[0]
+
+			equal(s.nodeName, 'S')
+			deepStrictEqual(s.attributes, { d: '180000', r: '' })
+		})
+
+		it('terminates when the input ends after an attribute equals sign', () => {
+			const doc = parseXml('<a b=')
+			deepStrictEqual(doc.childNodes[0].attributes, { b: '' })
+		})
+
+		it('throws when the input ends inside a quoted attribute value', () => {
+			throws(() => parseXml('<MPD><Period><S d="1'), /Missing closing quote/)
+		})
+	})
+
+	describe('well-formed attributes', () => {
+		it('parses double- and single-quoted values', () => {
+			const doc = parseXml(`<a b="c" d='e'>text</a>`)
+			const a = doc.childNodes[0]
+
+			deepStrictEqual(a.attributes, { b: 'c', d: 'e' })
+			equal(a.childNodes[0].nodeValue, 'text')
+		})
+
+		it('allows whitespace around the equals sign', () => {
+			const doc = parseXml('<a b = "c"\n\td\t=\n"e"/>')
+			deepStrictEqual(doc.childNodes[0].attributes, { b: 'c', d: 'e' })
+		})
+
+		it('preserves markup characters inside quoted values', () => {
+			const doc = parseXml(`<a b="x/>y" c='p>q'>t</a>`)
+			const a = doc.childNodes[0]
+
+			deepStrictEqual(a.attributes, { b: 'x/>y', c: 'p>q' })
+			equal(a.childNodes[0].nodeValue, 't')
 		})
 	})
 })


### PR DESCRIPTION
## Description

`parseXml()` hangs forever on any attribute that has no quoted value. In `parseAttributes()`, the loop that looks for the opening quote after an attribute name has no bounds check. When no quote follows, `pos` runs past the end of the input, `charCodeAt` returns `NaN` on every iteration, and the loop never exits. The parser is synchronous, so a player that feeds it a partially received DASH manifest blocks its main thread.

Inputs that hung before this change:

- `<a b>` (valueless attribute)
- `<a b=c/>` (unquoted value)
- `<a b="c" d>`
- `<S d="180000" r` (manifest cut off inside an attribute name)
- `<a b=` (cut off after the equals sign)
- `<a b="c"><d e/></a>`

The same loop also skipped over `>` and `<`, so `<a b><c d="1"/></a>` assigned `"1"` to `b` and dropped the `<c>` element.

The fix is one condition in `libs/xml/src/parseXml.ts`: the scan now stops at end of input and at `>`. A valueless attribute yields an empty string through the `pos--` branch, which was unreachable before, and parsing resumes at the closing `>`. Well-formed input is unaffected, because a well-formed attribute always reaches its opening quote before either new stop condition. To confirm that, I ran the parser from `main` and the fixed parser over all 15 XML fixtures in the repo plus 11 hand-written well-formed samples, with default and full options. All 52 outputs were identical.

Known limitation left as is: a valueless or unquoted attribute followed by a quoted one in the same tag still misattributes. `<a b c="d"/>` gives `b="d"` and drops `c`. Stopping the scan at whitespace would break the well-formed `b = "c"` form, so that needs an `=`-aware scan and a separate change.

Tests: 11 new tests in `libs/xml/test/parseXml.test.ts`. Against the code on `main`, six of them hang (killed by an external alarm), one fails on the swallowed-markup assertion, and four pass as guards for existing behavior (a missing closing quote still throws, whitespace around `=`, and `>` or `/>` inside quoted values). Root `npm test` (lint, build, typecheck, all package tests) passes.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated (none needed: no public API change, `cml-xml.api.md` is unchanged)
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
