### PR TITLE
fix(xml): stop parseXml hanging on truncated declaration or close tag

### DIFF
--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
 - `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
+- `parseXml` no longer hangs (or, inside nested elements, overflows the call stack) on input that ends inside a matching close tag, such as `<MPD><Period></Period`. The element keeps the children parsed so far.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
+- `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -70,8 +70,11 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 						)
 					}
 
-					if (pos + 1) {
-						pos += 1
+					if (pos === -1) {
+						pos = length
+					}
+					else {
+						pos++
 					}
 
 					return children

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -79,6 +79,9 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 				else if (next === QUESTION_CC) {
 					// xml declaration
 					pos = input.indexOf('>', pos)
+					if (pos === -1) {
+						pos = length
+					}
 					pos++
 					continue
 				}

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -305,4 +305,26 @@ describe('parseXml', () => {
 			equal(a.childNodes[0].nodeValue, 't')
 		})
 	})
+
+	describe('truncated input', () => {
+		it('parses a complete XML declaration followed by markup', async () => {
+			const doc = await parseXmlGuarded('<?xml version="1.0" encoding="UTF-8"?><a b="1"><c/>text</a>')
+			deepStrictEqual(doc.childNodes, [{
+				nodeName: 'a',
+				nodeValue: null,
+				attributes: { b: '1' },
+				childNodes: [
+					{ nodeName: 'c', nodeValue: null, attributes: {}, childNodes: [], prefix: null, localName: 'c' },
+					{ nodeName: '#text', nodeValue: 'text', attributes: {}, childNodes: [] },
+				],
+				prefix: null,
+				localName: 'a',
+			}])
+		})
+
+		it('returns an empty document when the input ends inside the XML declaration', async () => {
+			const doc = await parseXmlGuarded('<?xml version="1.0" encoding="UTF-8"')
+			deepStrictEqual(doc.childNodes, [])
+		})
+	})
 })

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -1,8 +1,91 @@
-import { parseXml } from '@svta/cml-xml'
-import assert, { deepStrictEqual, equal, strictEqual, throws } from 'node:assert'
+import { parseXml, type XmlNode, type XmlParseOptions } from '@svta/cml-xml'
+import assert, { deepStrictEqual, equal, rejects, strictEqual } from 'node:assert'
 import { promises as fs } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, it } from 'node:test'
+import { Worker } from 'node:worker_threads'
+
+const PARSE_XML_URL = import.meta.resolve('@svta/cml-xml')
+const PARSE_TIMEOUT_MS = 2000
+
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require('node:worker_threads')
+import(workerData.url).then(({ parseXml }) => {
+	workerData.inputs.forEach((input, index) => {
+		parentPort.postMessage({ index })
+		try {
+			parentPort.postMessage({ index, result: parseXml(input, workerData.options) })
+		}
+		catch (error) {
+			parentPort.postMessage({ index, error: error.message })
+		}
+	})
+})
+`
+
+type ParseOutcome = { result: XmlNode } | { error: string }
+
+type ParseMessage = {
+	index: number;
+	result?: XmlNode;
+	error?: string;
+}
+
+/**
+ * Parses each input in a worker thread so that a parser that never returns fails the test
+ * instead of hanging the test runner.
+ */
+function parseXmlInWorker(inputs: string[], options?: XmlParseOptions): Promise<ParseOutcome[]> {
+	return new Promise((done, fail) => {
+		const worker = new Worker(WORKER_SOURCE, { eval: true, execArgv: [], workerData: { url: PARSE_XML_URL, inputs, options } })
+		const outcomes: ParseOutcome[] = []
+		let current = 0
+		let timer: ReturnType<typeof setTimeout>
+
+		const settle = (callback: () => void) => {
+			clearTimeout(timer)
+			void worker.terminate()
+			callback()
+		}
+
+		const watch = () => {
+			clearTimeout(timer)
+			timer = setTimeout(() => {
+				settle(() => fail(new Error(`parseXml did not return within ${PARSE_TIMEOUT_MS}ms for ${JSON.stringify(inputs[current])}`)))
+			}, PARSE_TIMEOUT_MS)
+		}
+
+		worker.on('message', (message: ParseMessage) => {
+			current = message.index
+			if (message.error !== undefined) {
+				outcomes.push({ error: message.error })
+			}
+			else if (message.result !== undefined) {
+				outcomes.push({ result: message.result })
+			}
+
+			if (outcomes.length === inputs.length) {
+				settle(() => done(outcomes))
+			}
+			else {
+				watch()
+			}
+		})
+		worker.on('error', (error) => settle(() => fail(error)))
+		watch()
+	})
+}
+
+/**
+ * Parses a single input in a worker thread, rethrowing any parse error.
+ */
+async function parseXmlGuarded(input: string, options?: XmlParseOptions): Promise<XmlNode> {
+	const [outcome] = await parseXmlInWorker([input], options)
+	if ('error' in outcome) {
+		throw new Error(outcome.error)
+	}
+	return outcome.result
+}
 
 describe('parseXml', () => {
 	it('provides a valid example', async () => {
@@ -139,8 +222,8 @@ describe('parseXml', () => {
 	})
 
 	describe('malformed attributes', () => {
-		it('parses a valueless attribute as an empty string', () => {
-			const doc = parseXml('<a b>')
+		it('parses a valueless attribute as an empty string', async () => {
+			const doc = await parseXmlGuarded('<a b>')
 			const a = doc.childNodes[0]
 
 			equal(a.nodeName, 'a')
@@ -148,13 +231,13 @@ describe('parseXml', () => {
 			equal(a.childNodes.length, 0)
 		})
 
-		it('parses a valueless attribute after a quoted attribute', () => {
-			const doc = parseXml('<a b="c" d>')
+		it('parses a valueless attribute after a quoted attribute', async () => {
+			const doc = await parseXmlGuarded('<a b="c" d>')
 			deepStrictEqual(doc.childNodes[0].attributes, { b: 'c', d: '' })
 		})
 
-		it('parses a valueless attribute in a self-closing child', () => {
-			const doc = parseXml('<a b="c"><d e/></a>')
+		it('parses a valueless attribute in a self-closing child', async () => {
+			const doc = await parseXmlGuarded('<a b="c"><d e/></a>')
 			const a = doc.childNodes[0]
 
 			equal(a.childNodes.length, 1)
@@ -163,8 +246,8 @@ describe('parseXml', () => {
 			equal(a.childNodes[0].childNodes.length, 0)
 		})
 
-		it('does not swallow markup following a valueless attribute', () => {
-			const doc = parseXml('<a b><c d="1"/></a>')
+		it('does not swallow markup following a valueless attribute', async () => {
+			const doc = await parseXmlGuarded('<a b><c d="1"/></a>')
 			const a = doc.childNodes[0]
 
 			deepStrictEqual(a.attributes, { b: '' })
@@ -173,8 +256,8 @@ describe('parseXml', () => {
 			deepStrictEqual(a.childNodes[0].attributes, { d: '1' })
 		})
 
-		it('parses an unquoted attribute value as an empty string', () => {
-			const doc = parseXml('<a b=c/>')
+		it('parses an unquoted attribute value as an empty string', async () => {
+			const doc = await parseXmlGuarded('<a b=c/>')
 			const a = doc.childNodes[0]
 
 			equal(a.nodeName, 'a')
@@ -182,21 +265,21 @@ describe('parseXml', () => {
 			equal(a.childNodes.length, 0)
 		})
 
-		it('terminates when the input ends inside an attribute name', () => {
-			const doc = parseXml('<MPD><Period><SegmentTimeline><S d="180000" r')
+		it('terminates when the input ends inside an attribute name', async () => {
+			const doc = await parseXmlGuarded('<MPD><Period><SegmentTimeline><S d="180000" r')
 			const s = doc.childNodes[0].childNodes[0].childNodes[0].childNodes[0]
 
 			equal(s.nodeName, 'S')
 			deepStrictEqual(s.attributes, { d: '180000', r: '' })
 		})
 
-		it('terminates when the input ends after an attribute equals sign', () => {
-			const doc = parseXml('<a b=')
+		it('terminates when the input ends after an attribute equals sign', async () => {
+			const doc = await parseXmlGuarded('<a b=')
 			deepStrictEqual(doc.childNodes[0].attributes, { b: '' })
 		})
 
-		it('throws when the input ends inside a quoted attribute value', () => {
-			throws(() => parseXml('<MPD><Period><S d="1'), /Missing closing quote/)
+		it('throws when the input ends inside a quoted attribute value', async () => {
+			await rejects(parseXmlGuarded('<MPD><Period><S d="1'), /Missing closing quote/)
 		})
 	})
 

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -326,5 +326,47 @@ describe('parseXml', () => {
 			const doc = await parseXmlGuarded('<?xml version="1.0" encoding="UTF-8"')
 			deepStrictEqual(doc.childNodes, [])
 		})
+
+		it('keeps the parsed children when the input ends inside the root close tag', async () => {
+			const doc = await parseXmlGuarded('<a>text</a')
+			deepStrictEqual(doc.childNodes, [{
+				nodeName: 'a',
+				nodeValue: null,
+				attributes: {},
+				childNodes: [{ nodeName: '#text', nodeValue: 'text', attributes: {}, childNodes: [] }],
+				prefix: null,
+				localName: 'a',
+			}])
+		})
+
+		it('keeps the parsed children when the input ends inside a nested close tag', async () => {
+			const doc = await parseXmlGuarded('<MPD><Period><S d="1"/></Period')
+			deepStrictEqual(doc.childNodes, [{
+				nodeName: 'MPD',
+				nodeValue: null,
+				attributes: {},
+				childNodes: [{
+					nodeName: 'Period',
+					nodeValue: null,
+					attributes: {},
+					childNodes: [{ nodeName: 'S', nodeValue: null, attributes: { d: '1' }, childNodes: [], prefix: null, localName: 'S' }],
+					prefix: null,
+					localName: 'Period',
+				}],
+				prefix: null,
+				localName: 'MPD',
+			}])
+		})
+
+		it('terminates on every truncation of the fixtures', async () => {
+			for (const fixture of ['./test/fixtures/node_types.xml', './test/fixtures/bbb_30fps.mpd']) {
+				const xml = await fs.readFile(resolve(fixture), 'utf8')
+				const prefixes = Array.from({ length: xml.length + 1 }, (_, end) => xml.slice(0, end))
+				const outcomes = await parseXmlInWorker(prefixes)
+
+				equal(outcomes.length, prefixes.length)
+				assert('result' in outcomes[prefixes.length - 1], `${fixture} did not parse in full`)
+			}
+		})
 	})
 })


### PR DESCRIPTION
## Description

`parseXml()` could loop forever on a document that ends in the wrong place. PR #425 fixed the attribute case. This PR fixes the two remaining cases and adds a test guard so a future hang fails CI instead of stalling it.

Fixed hangs:

- Unterminated XML declaration, for example `<?xml version="1.0" encoding="UTF-8"` with no `>`. `indexOf` returned -1, `pos` became 0, and parsing restarted from the top of the document forever. The declaration opens virtually every manifest, so a response cut off in its first few dozen bytes hung the caller's thread.
- Unterminated matching close tag, for example `<a>text</a`. `indexOf` returned -1 and the function returned with `pos` still -1. The enclosing loop then re-read the document from index 0. At the document level that looped forever. Inside a nested element it re-parsed the document as a new child on every pass until the call stack overflowed.

Both fixes consume the rest of the input when the `>` is missing, so the parser returns the partial tree it has. That matches what it already does for `<a>text` or an unterminated CDATA section. Well-formed input is unaffected because the new branches only run when `indexOf` returns -1. The previous build and this one produce identical output for the 15 XML and MPD fixtures in the repo plus 37 inline inputs, each under 4 option sets.

The new tests run `parseXml` in a worker thread. The parser is synchronous, so the node:test timeout cannot interrupt an infinite loop. The worker posts progress before each parse, and the test fails after 2 seconds of silence and names the input. The malformed-attribute tests from #425 now use the same guard. A sweep test parses every prefix of both fixtures.

The close-tag hang was not in the original report. A sweep over every prefix of a synthetic document found it, and it has its own commit.

### Notes for review

- The branch `fix/xml-throw-on-malformed-attributes` (no PR yet) rewrites the #425 attribute tests to expect throws. A dry-run merge with this branch conflicts only in `parseXml.test.ts` and `CHANGELOG.md`. Whichever lands second needs to wrap the throw expectations in the worker guard and keep both sets of changelog bullets.
- Making truncated input throw instead of returning a partial tree would be a behavior change beyond attributes. It is left for the well-formedness RFC.
- Pre-existing and out of scope: the close-tag check is a prefix match, so `</abc>` closes `<ab>`.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-xml | 1.1.6 (no bump, changelog under Unreleased) | fix |

## Test Plan

- [x] `npm run build -w libs/utils -w libs/xml` then `npm test -w libs/xml`: 29 tests pass
- [x] Each new test failed before its fix (guard timeout for the two hangs, "Maximum call stack size exceeded" for the nested close tag) and passes after
- [x] `npm run typecheck` and `npm run lint` pass
- [x] `cml-xml.api.md` unchanged after the build
- [x] Every-prefix truncation sweeps of `node_types.xml`, `bbb_30fps.mpd`, a synthetic document with every construct, and a 9.6 KB cmaf-ham manifest: 0 hangs

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [ ] Docs/guides updated (not needed: no public API or documentation change)
- [x] Changelog updated

Refs: #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
