### PR TITLE
fix(xml): throw on malformed attributes instead of tolerating them

### DIFF
--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to
 
 ### Fixed
 
-- `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
+- `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>`, `<a b=c/>`, or input truncated mid-attribute. It now throws an error that names the attribute and reports the line and column, matching the XML 1.0 `Attribute ::= Name Eq AttValue` production.
+
+### Changed
+
+- `parseXml` throws on a quoted attribute value with no `=` (`<a b "c"/>`), which previously parsed leniently as `b="c"`.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -13,6 +13,11 @@ const SINGLE_QUOTE_CC = 39            // "'"
 const DOUBLE_QUOTE_CC = 34            // '"'
 const OPEN_CORNER_BRACKET_CC = 91     // '['
 const CLOSE_CORNER_BRACKET_CC = 93    // ']'
+const EQUALS_CC = 61                  // '='
+const SPACE_CC = 32                   // ' '
+const TAB_CC = 9                      // '\t'
+const CR_CC = 13                      // '\r'
+const LF_CC = 10                      // '\n'
 
 // Set for fast name delimiter lookup: \r \n \t > / = space
 const NAME_SPACER_SET = new Set([13, 10, 9, 62, 47, 61, 32])
@@ -23,6 +28,7 @@ const NAME_SPACER_SET = new Set([13, 10, 9, 62, 47, 61, 32])
  * @param input - The input XML string
  * @param options - Optional parsing options
  * @returns The parsed XML
+ * @throws If an attribute is not `name="value"` or `name='value'`, if a quoted value is not closed, or if a close tag does not match its open tag
  *
  * @public
  *
@@ -50,6 +56,18 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 	}
 
 	/**
+	 * Creates an error that reports the line and column of the current position
+	 */
+	function syntaxError(message: string): Error {
+		const parsedText = input.substring(0, pos).split('\n')
+		return new Error(
+			message + '\nLine: ' + (parsedText.length - 1) +
+			'\nColumn: ' + (parsedText[parsedText.length - 1].length + 1) +
+			'\nChar: ' + (pos < length ? input[pos] : 'end of input'),
+		)
+	}
+
+	/**
 	 * Parses a list of entries
 	 */
 	function parseChildren(tagName: string = ''): XmlNode[] {
@@ -62,12 +80,7 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 					const closeStart = pos + 2
 					pos = input.indexOf('>', pos)
 					if (!input.startsWith(tagName, closeStart)) {
-						const parsedText = input.substring(0, pos).split('\n')
-						throw new Error(
-							'Unexpected close tag\nLine: ' + (parsedText.length - 1) +
-							'\nColumn: ' + (parsedText[parsedText.length - 1].length + 1) +
-							'\nChar: ' + input[pos],
-						)
+						throw syntaxError('Unexpected close tag')
 					}
 
 					if (pos + 1) {
@@ -183,34 +196,41 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 	}
 
 	/**
+	 * Advances past XML whitespace: space, tab, CR, LF
+	 */
+	function skipWhitespace(): void {
+		let c = input.charCodeAt(pos)
+		while (c === SPACE_CC || c === TAB_CC || c === CR_CC || c === LF_CC) {
+			pos++
+			c = input.charCodeAt(pos)
+		}
+	}
+
+	/**
 	 * Parses the attributes of a node
 	 */
 	function parseAttributes(): Record<string, string> {
 		const attributes: Record<string, string> = {}
 
-		// parsing attributes
+		// Attribute ::= Name Eq AttValue, Eq ::= S? '=' S? (XML 1.0 §3.1, §2.3)
 		while (pos < length && input.charCodeAt(pos) !== CLOSE_BRACKET_CC) {
 			const c = input.charCodeAt(pos)
 			if ((c > 64 && c < 91) || (c > 96 && c < 123)) {
 				const name = parseName()
-				let value: string = ''
-				// search beginning of the string
-				let code = input.charCodeAt(pos)
-				while (pos < length && code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC && code !== CLOSE_BRACKET_CC) {
-					pos++
-					code = input.charCodeAt(pos)
+				skipWhitespace()
+				if (input.charCodeAt(pos) !== EQUALS_CC) {
+					throw syntaxError('Malformed attribute "' + name + '": expected "=" after name')
 				}
-
-				if (code === SINGLE_QUOTE_CC || code === DOUBLE_QUOTE_CC) {
-					value = parseString()
-					if (pos === -1) {
-						throw new Error('Missing closing quote')
-					}
+				pos++
+				skipWhitespace()
+				const code = input.charCodeAt(pos)
+				if (code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC) {
+					throw syntaxError('Malformed attribute "' + name + '": expected quoted value after "="')
 				}
-				else {
-					pos--
+				const value = parseString()
+				if (pos === -1) {
+					throw new Error('Missing closing quote')
 				}
-
 				attributes[name] = unescapeHtml(value)
 			}
 			pos++

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -139,60 +139,46 @@ describe('parseXml', () => {
 	})
 
 	describe('malformed attributes', () => {
-		it('parses a valueless attribute as an empty string', () => {
-			const doc = parseXml('<a b>')
-			const a = doc.childNodes[0]
-
-			equal(a.nodeName, 'a')
-			deepStrictEqual(a.attributes, { b: '' })
-			equal(a.childNodes.length, 0)
+		it('throws on a valueless attribute', () => {
+			throws(() => parseXml('<a b>'), { message: /^Malformed attribute "b": expected "=" after name/ })
 		})
 
-		it('parses a valueless attribute after a quoted attribute', () => {
-			const doc = parseXml('<a b="c" d>')
-			deepStrictEqual(doc.childNodes[0].attributes, { b: 'c', d: '' })
+		it('throws on a valueless attribute in a self-closing tag', () => {
+			throws(() => parseXml('<a b/>'), { message: /^Malformed attribute "b": expected "=" after name/ })
 		})
 
-		it('parses a valueless attribute in a self-closing child', () => {
-			const doc = parseXml('<a b="c"><d e/></a>')
-			const a = doc.childNodes[0]
-
-			equal(a.childNodes.length, 1)
-			equal(a.childNodes[0].nodeName, 'd')
-			deepStrictEqual(a.childNodes[0].attributes, { e: '' })
-			equal(a.childNodes[0].childNodes.length, 0)
+		it('throws on a valueless attribute after a quoted attribute', () => {
+			throws(() => parseXml('<a b="c" d>'), { message: /^Malformed attribute "d": expected "=" after name/ })
 		})
 
-		it('does not swallow markup following a valueless attribute', () => {
-			const doc = parseXml('<a b><c d="1"/></a>')
-			const a = doc.childNodes[0]
-
-			deepStrictEqual(a.attributes, { b: '' })
-			equal(a.childNodes.length, 1)
-			equal(a.childNodes[0].nodeName, 'c')
-			deepStrictEqual(a.childNodes[0].attributes, { d: '1' })
+		it('throws on an unquoted attribute value', () => {
+			throws(() => parseXml('<a b=c/>'), { message: /^Malformed attribute "b": expected quoted value after "="/ })
 		})
 
-		it('parses an unquoted attribute value as an empty string', () => {
-			const doc = parseXml('<a b=c/>')
-			const a = doc.childNodes[0]
-
-			equal(a.nodeName, 'a')
-			deepStrictEqual(a.attributes, { b: '' })
-			equal(a.childNodes.length, 0)
+		it('throws on a quoted value with no equals sign', () => {
+			throws(() => parseXml('<a b "c"/>'), { message: /^Malformed attribute "b": expected "=" after name/ })
 		})
 
-		it('terminates when the input ends inside an attribute name', () => {
-			const doc = parseXml('<MPD><Period><SegmentTimeline><S d="180000" r')
-			const s = doc.childNodes[0].childNodes[0].childNodes[0].childNodes[0]
-
-			equal(s.nodeName, 'S')
-			deepStrictEqual(s.attributes, { d: '180000', r: '' })
+		it('reports the valueless attribute, not the element that follows it', () => {
+			throws(() => parseXml('<a b><c d="1"/></a>'), { message: /^Malformed attribute "b"/ })
 		})
 
-		it('terminates when the input ends after an attribute equals sign', () => {
-			const doc = parseXml('<a b=')
-			deepStrictEqual(doc.childNodes[0].attributes, { b: '' })
+		it('throws when the input ends inside an attribute name', () => {
+			throws(
+				() => parseXml('<MPD><Period><SegmentTimeline><S d="180000" r'),
+				{ message: /^Malformed attribute "r": expected "=" after name\n.*\n.*\nChar: end of input$/ },
+			)
+		})
+
+		it('throws when the input ends after the equals sign', () => {
+			throws(
+				() => parseXml('<a b='),
+				{ message: /^Malformed attribute "b": expected quoted value after "="\nLine: 0\nColumn: 6\nChar: end of input$/ },
+			)
+		})
+
+		it('reports the line and column of the malformed attribute', () => {
+			throws(() => parseXml('<root>\n\t<a b>'), { message: /\nLine: 1\nColumn: 6\nChar: >$/ })
 		})
 
 		it('throws when the input ends inside a quoted attribute value', () => {


### PR DESCRIPTION
## Description

Follow-up to #425. That PR stopped `parseXml()` from looping forever on an attribute with no quoted value, but it resolved those attributes leniently: a valueless or unquoted attribute became an empty string and parsing carried on. That is HTML behavior. In XML 1.0 an attribute is `Attribute ::= Name Eq AttValue` with `Eq ::= S? '=' S?` (§3.1, §2.3), and `AttValue` has no unquoted form. Unquoted values, valueless attributes, and a missing `=` are well-formedness violations that a conforming processor must report as fatal errors (§1.2, §2.1, §5.1).

`parseAttributes()` now walks that grammar instead of scanning forward for the next quote. Anything else throws an error that names the attribute and reports the line, column, and offending character, with `end of input` for truncated documents:

```
Malformed attribute "r": expected "=" after name
Line: 0
Column: 46
Char: end of input
```

Inputs that now throw (all hung before #425, all returned an empty-string attribute after it):

- `<a b>` and `<a b/>` (valueless attribute)
- `<a b=c/>` (unquoted value)
- `<a b="c" d>`
- `<S d="180000" r` (manifest cut off inside an attribute name)
- `<a b=` (cut off after the equals sign)

The forward scan also misattributed values across attributes. `<a b c="d"/>` assigned `"d"` to `b` and dropped `c`. The grammar walk fails at `b` instead.

One input that parsed on `main` before #425 changes behavior: `<a b "c"/>` (quoted value, no `=`) used to parse as `b="c"` and now throws. It is listed under Changed in the changelog.

The existing "Unexpected close tag" error now shares its position formatting through a small `syntaxError()` helper. Its text is unchanged. The `pos--` / `pos++` dance that #425 relied on is gone.

Well-formed input is unaffected. A well-formed attribute reaches its quote through exactly `S? = S?`, so the new walk consumes the same bytes as the old scan. I ran the parser from `main` and this branch over all 15 XML fixtures in the repo plus 14 hand-written samples (well-formed input, and malformed close tags to cover the error text), with default and full options. All 58 outputs were identical.

Tests: the malformed-attribute tests from #425 now assert the thrown message and the line and column reporting (10 tests), and the 3 well-formed guards are unchanged. Nine of the ten failed before the parser change. Root `npm test` (lint, build, typecheck, all package tests) passes, including the 47 drm tests that consume the parser.

For reviewers: `origin/issue/xml-parse-hang` (unmerged) fixes two more truncation hangs, an unterminated `<?xml` and an unterminated close tag, by returning the partial tree, and it rewrites the same malformed-attribute tests to run in a worker. The two branches conflict in `libs/xml/test/parseXml.test.ts`, and they disagree on policy: this PR throws on non-well-formed input, that one tolerates it. Whichever lands second needs its attribute tests re-aligned, and if the direction is spec compliance, those two fixes should throw through `syntaxError()` as well.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated (`@throws` added to the `parseXml` TSDoc; no public API change, `cml-xml.api.md` is unchanged)
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
