### PR TITLE
fix(xml): require an exact name match when parseXml closes a tag

### DIFF
--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
+- `parseXml` throws `Unexpected close tag` when a close tag's name only starts with the open tag's name, such as `<ab>text</abc>` or `</ab>` closing `<a>`, and when a close tag appears at the document level with no open element. Previously both were accepted. A close tag whose exact name is followed by whitespace, such as `</a >`, still closes the element (XML 1.0 `ETag ::= '</' Name S? '>'`).
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -13,6 +13,10 @@ const SINGLE_QUOTE_CC = 39            // "'"
 const DOUBLE_QUOTE_CC = 34            // '"'
 const OPEN_CORNER_BRACKET_CC = 91     // '['
 const CLOSE_CORNER_BRACKET_CC = 93    // ']'
+const SPACE_CC = 32                   // ' '
+const TAB_CC = 9                      // '\t'
+const CR_CC = 13                      // '\r'
+const LF_CC = 10                      // '\n'
 
 // Set for fast name delimiter lookup: \r \n \t > / = space
 const NAME_SPACER_SET = new Set([13, 10, 9, 62, 47, 61, 32])
@@ -60,8 +64,13 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 				const next = input.charCodeAt(pos + 1)
 				if (next === SLASH_CC) {
 					const closeStart = pos + 2
+					const nameEnd = closeStart + tagName.length
+					const afterName = input.charCodeAt(nameEnd)
+					// ETag ::= '</' Name S? '>' (XML 1.0 §3.1)
+					const closesTag = input.startsWith(tagName, closeStart) &&
+						(nameEnd >= length || afterName === CLOSE_BRACKET_CC || afterName === SPACE_CC || afterName === TAB_CC || afterName === CR_CC || afterName === LF_CC)
 					pos = input.indexOf('>', pos)
-					if (!input.startsWith(tagName, closeStart)) {
+					if (!closesTag) {
 						const parsedText = input.substring(0, pos).split('\n')
 						throw new Error(
 							'Unexpected close tag\nLine: ' + (parsedText.length - 1) +

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -61,6 +61,47 @@ describe('parseXml', () => {
 		equal(namespace.localName, `Text`)
 	})
 
+	describe('close tags', () => {
+		it('throws on a close tag whose name differs from the open tag', () => {
+			throws(() => parseXml('<a>text</b>'), /Unexpected close tag/)
+		})
+
+		it('throws on a close tag whose name extends the open tag name', () => {
+			throws(() => parseXml('<ab>text</abc>'), /Unexpected close tag/)
+		})
+
+		it('does not let a longer close tag close a shorter open tag', () => {
+			throws(() => parseXml('<a>text</ab>'), /Unexpected close tag/)
+		})
+
+		it('throws on a close tag with no open element', () => {
+			throws(() => parseXml('<a/></b>'), /Unexpected close tag/)
+		})
+
+		it('closes an element when a space precedes the closing bracket', () => {
+			const doc = parseXml('<a>text</a >')
+			const a = doc.childNodes[0]
+
+			equal(doc.childNodes.length, 1)
+			equal(a.nodeName, 'a')
+			equal(a.childNodes[0].nodeValue, 'text')
+		})
+
+		it('closes an element when tabs and line breaks precede the closing bracket', () => {
+			const doc = parseXml('<a>text</a\t\r\n>')
+			equal(doc.childNodes[0].childNodes[0].nodeValue, 'text')
+		})
+
+		it('closes nested elements whose names share a prefix', () => {
+			const doc = parseXml('<a><ab>text</ab></a>')
+			const a = doc.childNodes[0]
+
+			equal(a.nodeName, 'a')
+			equal(a.childNodes[0].nodeName, 'ab')
+			equal(a.childNodes[0].childNodes[0].nodeValue, 'text')
+		})
+	})
+
 	describe('includeParentElement option', () => {
 		it('does not include parentElement by default', () => {
 			const doc = parseXml('<root><child/></root>')


### PR DESCRIPTION
## Description

`parseXml()` compared a close tag to its open tag with `startsWith`, so any close tag whose name merely began with the open tag's name was accepted. `<ab>text</abc>` parsed as well-formed and `</ab>` closed `<a>`. At the document level the open tag name is empty, so every close tag matched. A stray `</b>` after the root element ended parsing and silently dropped whatever followed it. XML 1.0 section 3.1 defines `ETag ::= '</' Name S? '>'`, and the parser already throws `Unexpected close tag` for other mismatches, so this fixes the existing check instead of adding a new one.

The check now also requires the character after the matched name to be `>` or XML whitespace (space, tab, CR, LF). `<a>text</a >` still closes the element. A name that matches exactly but is cut off by the end of the input is left to the existing truncation handling, so this change does not decide what truncated input should do.

### Notes for review

- Behavior change: a close tag at the document level with nothing open now throws instead of ending the document early. A conforming XML processor rejects that input, so no valid manifest is affected. Both fixtures (`bbb_30fps.mpd`, `node_types.xml`) parse as before.
- Not an RFC: `rfc/README.md` exempts bug fixes, and the check and its error already existed. Rejecting constructs the parser tolerates by design stays with the well-formedness RFC. One such construct remains: `</a x>` still closes `<a>` because only the first character after the name is checked.
- PR #427 (truncation hangs): `parseXml.ts` and the test file auto-merge, only `CHANGELOG.md` conflicts. I built the auto-merged source and ran both branches' test files against it: 59 pass, including the "keeps the parsed children when the input ends inside the root close tag" cases.
- PR #428 (malformed attributes): conflicts in `CHANGELOG.md`, the constants block (keep `EQUALS_CC` beside the four whitespace constants, which are identical on both sides) and the close-tag `if`. Resolve as `if (!closesTag) { throw syntaxError('Unexpected close tag') }`.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-xml | 1.1.6 (no bump, changelog under Unreleased) | fix |

## Test Plan

- [x] `npm run build -w libs/utils -w libs/xml` then `npm test -w libs/xml`: 31 tests pass
- [x] The three mismatch tests (`<ab>text</abc>`, `<a>text</ab>`, `<a/></b>`) failed with "Missing expected exception" before the fix and pass after. The whitespace and nested-prefix tests pass before and after, as guards against over-restricting.
- [x] `npm run typecheck` and `npm run lint` pass
- [x] `cml-xml.api.md` unchanged after the build

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [ ] Docs/guides updated (not needed: no public API or documentation change)
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
