### PR TITLE
fix(xml): stop parseXml hanging and reject malformed markup

### DIFF
--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to
 
 ### Fixed
 
-- `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
+- `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>`, `<a b=c/>`, or input truncated mid-attribute. It now throws an error that names the attribute and reports the line and column, matching the XML 1.0 `Attribute ::= Name Eq AttValue` production.
 - `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
 - `parseXml` no longer hangs (or, inside nested elements, overflows the call stack) on input that ends inside a matching close tag, such as `<MPD><Period></Period`. The element keeps the children parsed so far.
 - `parseXml` throws `Unexpected close tag` when a close tag's name only starts with the open tag's name, such as `<ab>text</abc>` or `</ab>` closing `<a>`, and when a close tag appears at the document level with no open element. Previously both were accepted. A close tag whose exact name is followed by whitespace, such as `</a >`, still closes the element (XML 1.0 `ETag ::= '</' Name S? '>'`).
+
+### Changed
+
+- `parseXml` throws on a quoted attribute value with no `=` (`<a b "c"/>`), which previously parsed leniently as `b="c"`.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
 - `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
+- `parseXml` no longer hangs (or, inside nested elements, overflows the call stack) on input that ends inside a matching close tag, such as `<MPD><Period></Period`. The element keeps the children parsed so far.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
 - `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
 - `parseXml` no longer hangs (or, inside nested elements, overflows the call stack) on input that ends inside a matching close tag, such as `<MPD><Period></Period`. The element keeps the children parsed so far.
+- `parseXml` throws `Unexpected close tag` when a close tag's name only starts with the open tag's name, such as `<ab>text</abc>` or `</ab>` closing `<a>`, and when a close tag appears at the document level with no open element. Previously both were accepted. A close tag whose exact name is followed by whitespace, such as `</a >`, still closes the element (XML 1.0 `ETag ::= '</' Name S? '>'`).
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>`, `<a b=c/>`, or input truncated mid-attribute. It now throws an error that names the attribute and reports the line and column, matching the XML 1.0 `Attribute ::= Name Eq AttValue` production.
 - `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
 - `parseXml` no longer hangs (or, inside nested elements, overflows the call stack) on input that ends inside a matching close tag, such as `<MPD><Period></Period`. The element keeps the children parsed so far.
-- `parseXml` throws `Unexpected close tag` when a close tag's name only starts with the open tag's name, such as `<ab>text</abc>` or `</ab>` closing `<a>`, and when a close tag appears at the document level with no open element. Previously both were accepted. A close tag whose exact name is followed by whitespace, such as `</a >`, still closes the element (XML 1.0 `ETag ::= '</' Name S? '>'`).
+- `parseXml` throws `Unexpected close tag` when a close tag's name only starts with the open tag's name, such as `<ab>text</abc>` or `</ab>` closing `<a>`, and when a close tag appears at the document level with no open element, including an empty `</>`. Previously both were accepted. A close tag whose exact name is followed by whitespace, such as `</a >`, still closes the element (XML 1.0 `ETag ::= '</' Name S? '>'`).
 - `Unexpected close tag` reports the line, column, and `Char: end of input` when the mismatched close tag is cut off by the end of the input, such as `<a>text</b`. Previously it reported `Line: 0`, `Column: 1`, `Char: undefined`.
 
 ### Changed

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>` or input truncated mid-attribute. The attribute yields an empty string and parsing resumes at the closing `>`.
+- `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
 
 ## [1.1.6] - 2026-07-28
 

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - `parseXml` no longer hangs on input that ends inside the XML declaration, such as `<?xml version="1.0"`. Parsing stops at the end of the input.
 - `parseXml` no longer hangs (or, inside nested elements, overflows the call stack) on input that ends inside a matching close tag, such as `<MPD><Period></Period`. The element keeps the children parsed so far.
 - `parseXml` throws `Unexpected close tag` when a close tag's name only starts with the open tag's name, such as `<ab>text</abc>` or `</ab>` closing `<a>`, and when a close tag appears at the document level with no open element. Previously both were accepted. A close tag whose exact name is followed by whitespace, such as `</a >`, still closes the element (XML 1.0 `ETag ::= '</' Name S? '>'`).
+- `Unexpected close tag` reports the line, column, and `Char: end of input` when the mismatched close tag is cut off by the end of the input, such as `<a>text</b`. Previously it reported `Line: 0`, `Column: 1`, `Char: undefined`.
 
 ### Changed
 

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -80,9 +80,11 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 					const closeStart = pos + 2
 					const nameEnd = closeStart + tagName.length
 					const afterName = input.charCodeAt(nameEnd)
-					// ETag ::= '</' Name S? '>' (XML 1.0 §3.1)
-					const closesTag = input.startsWith(tagName, closeStart) &&
-						(nameEnd >= length || afterName === CLOSE_BRACKET_CC || afterName === SPACE_CC || afterName === TAB_CC || afterName === CR_CC || afterName === LF_CC)
+					// ETag ::= '</' Name S? '>' (XML 1.0 §3.1); nothing is open at the document level
+					const closesTag = input.startsWith(tagName, closeStart) && (
+						nameEnd >= length ||
+						(tagName !== '' && (afterName === CLOSE_BRACKET_CC || afterName === SPACE_CC || afterName === TAB_CC || afterName === CR_CC || afterName === LF_CC))
+					)
 					pos = input.indexOf('>', pos)
 					if (pos === -1) {
 						pos = length

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -23,12 +23,16 @@ const LF_CC = 10                      // '\n'
 const NAME_SPACER_SET = new Set([13, 10, 9, 62, 47, 61, 32])
 
 /**
- * Parse XML into a JS object with no validation and some failure tolerance
+ * Parse XML into a JS object
+ *
+ * The parser does not validate against a DTD or schema, and it does not check every
+ * well-formedness constraint; the errors it does report are listed below under Throws.
+ * Input cut off between tags yields the nodes parsed so far.
  *
  * @param input - The input XML string
  * @param options - Optional parsing options
  * @returns The parsed XML
- * @throws If an attribute is not `name="value"` or `name='value'`, if a quoted value is not closed, or if a close tag does not match its open tag
+ * @throws If an attribute is not `name="value"` or `name='value'`, if a quoted value is not closed, if a close tag does not match its open tag, or if a close tag appears with no element open
  *
  * @public
  *

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -13,6 +13,10 @@ const SINGLE_QUOTE_CC = 39            // "'"
 const DOUBLE_QUOTE_CC = 34            // '"'
 const OPEN_CORNER_BRACKET_CC = 91     // '['
 const CLOSE_CORNER_BRACKET_CC = 93    // ']'
+const SPACE_CC = 32                   // ' '
+const TAB_CC = 9                      // '\t'
+const CR_CC = 13                      // '\r'
+const LF_CC = 10                      // '\n'
 
 // Set for fast name delimiter lookup: \r \n \t > / = space
 const NAME_SPACER_SET = new Set([13, 10, 9, 62, 47, 61, 32])
@@ -60,8 +64,13 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 				const next = input.charCodeAt(pos + 1)
 				if (next === SLASH_CC) {
 					const closeStart = pos + 2
+					const nameEnd = closeStart + tagName.length
+					const afterName = input.charCodeAt(nameEnd)
+					// ETag ::= '</' Name S? '>' (XML 1.0 §3.1)
+					const closesTag = input.startsWith(tagName, closeStart) &&
+						(nameEnd >= length || afterName === CLOSE_BRACKET_CC || afterName === SPACE_CC || afterName === TAB_CC || afterName === CR_CC || afterName === LF_CC)
 					pos = input.indexOf('>', pos)
-					if (!input.startsWith(tagName, closeStart)) {
+					if (!closesTag) {
 						const parsedText = input.substring(0, pos).split('\n')
 						throw new Error(
 							'Unexpected close tag\nLine: ' + (parsedText.length - 1) +

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -214,17 +214,6 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 	}
 
 	/**
-	 * Advances past XML whitespace: space, tab, CR, LF
-	 */
-	function skipWhitespace(): void {
-		let c = input.charCodeAt(pos)
-		while (c === SPACE_CC || c === TAB_CC || c === CR_CC || c === LF_CC) {
-			pos++
-			c = input.charCodeAt(pos)
-		}
-	}
-
-	/**
 	 * Parses the attributes of a node
 	 */
 	function parseAttributes(): Record<string, string> {
@@ -235,15 +224,26 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 			const c = input.charCodeAt(pos)
 			if ((c > 64 && c < 91) || (c > 96 && c < 123)) {
 				const name = parseName()
-				skipWhitespace()
-				if (input.charCodeAt(pos) !== EQUALS_CC) {
-					throw syntaxError('Malformed attribute "' + name + '": expected "=" after name')
+				let code = input.charCodeAt(pos)
+				if (code !== EQUALS_CC) {
+					while (code === SPACE_CC || code === TAB_CC || code === CR_CC || code === LF_CC) {
+						pos++
+						code = input.charCodeAt(pos)
+					}
+					if (code !== EQUALS_CC) {
+						throw syntaxError('Malformed attribute "' + name + '": expected "=" after name')
+					}
 				}
 				pos++
-				skipWhitespace()
-				const code = input.charCodeAt(pos)
+				code = input.charCodeAt(pos)
 				if (code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC) {
-					throw syntaxError('Malformed attribute "' + name + '": expected quoted value after "="')
+					while (code === SPACE_CC || code === TAB_CC || code === CR_CC || code === LF_CC) {
+						pos++
+						code = input.charCodeAt(pos)
+					}
+					if (code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC) {
+						throw syntaxError('Malformed attribute "' + name + '": expected quoted value after "="')
+					}
 				}
 				const value = parseString()
 				if (pos === -1) {

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -84,14 +84,13 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 					const closesTag = input.startsWith(tagName, closeStart) &&
 						(nameEnd >= length || afterName === CLOSE_BRACKET_CC || afterName === SPACE_CC || afterName === TAB_CC || afterName === CR_CC || afterName === LF_CC)
 					pos = input.indexOf('>', pos)
-					if (!closesTag) {
-						throw syntaxError('Unexpected close tag')
-					}
-
 					if (pos === -1) {
 						pos = length
 					}
-					else {
+					if (!closesTag) {
+						throw syntaxError('Unexpected close tag')
+					}
+					if (pos < length) {
 						pos++
 					}
 
@@ -103,7 +102,9 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 					if (pos === -1) {
 						pos = length
 					}
-					pos++
+					else {
+						pos++
+					}
 					continue
 				}
 				else if (next === EXCLAMATION_CC) {

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -70,8 +70,11 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 						)
 					}
 
-					if (pos + 1) {
-						pos += 1
+					if (pos === -1) {
+						pos = length
+					}
+					else {
+						pos++
 					}
 
 					return children

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -79,6 +79,9 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 				else if (next === QUESTION_CC) {
 					// xml declaration
 					pos = input.indexOf('>', pos)
+					if (pos === -1) {
+						pos = length
+					}
 					pos++
 					continue
 				}

--- a/libs/xml/src/parseXml.ts
+++ b/libs/xml/src/parseXml.ts
@@ -13,6 +13,7 @@ const SINGLE_QUOTE_CC = 39            // "'"
 const DOUBLE_QUOTE_CC = 34            // '"'
 const OPEN_CORNER_BRACKET_CC = 91     // '['
 const CLOSE_CORNER_BRACKET_CC = 93    // ']'
+const EQUALS_CC = 61                  // '='
 const SPACE_CC = 32                   // ' '
 const TAB_CC = 9                      // '\t'
 const CR_CC = 13                      // '\r'
@@ -27,6 +28,7 @@ const NAME_SPACER_SET = new Set([13, 10, 9, 62, 47, 61, 32])
  * @param input - The input XML string
  * @param options - Optional parsing options
  * @returns The parsed XML
+ * @throws If an attribute is not `name="value"` or `name='value'`, if a quoted value is not closed, or if a close tag does not match its open tag
  *
  * @public
  *
@@ -54,6 +56,18 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 	}
 
 	/**
+	 * Creates an error that reports the line and column of the current position
+	 */
+	function syntaxError(message: string): Error {
+		const parsedText = input.substring(0, pos).split('\n')
+		return new Error(
+			message + '\nLine: ' + (parsedText.length - 1) +
+			'\nColumn: ' + (parsedText[parsedText.length - 1].length + 1) +
+			'\nChar: ' + (pos < length ? input[pos] : 'end of input'),
+		)
+	}
+
+	/**
 	 * Parses a list of entries
 	 */
 	function parseChildren(tagName: string = ''): XmlNode[] {
@@ -71,12 +85,7 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 						(nameEnd >= length || afterName === CLOSE_BRACKET_CC || afterName === SPACE_CC || afterName === TAB_CC || afterName === CR_CC || afterName === LF_CC)
 					pos = input.indexOf('>', pos)
 					if (!closesTag) {
-						const parsedText = input.substring(0, pos).split('\n')
-						throw new Error(
-							'Unexpected close tag\nLine: ' + (parsedText.length - 1) +
-							'\nColumn: ' + (parsedText[parsedText.length - 1].length + 1) +
-							'\nChar: ' + input[pos],
-						)
+						throw syntaxError('Unexpected close tag')
 					}
 
 					if (pos === -1) {
@@ -198,34 +207,41 @@ export function parseXml(input: string, options: XmlParseOptions = {}): XmlNode 
 	}
 
 	/**
+	 * Advances past XML whitespace: space, tab, CR, LF
+	 */
+	function skipWhitespace(): void {
+		let c = input.charCodeAt(pos)
+		while (c === SPACE_CC || c === TAB_CC || c === CR_CC || c === LF_CC) {
+			pos++
+			c = input.charCodeAt(pos)
+		}
+	}
+
+	/**
 	 * Parses the attributes of a node
 	 */
 	function parseAttributes(): Record<string, string> {
 		const attributes: Record<string, string> = {}
 
-		// parsing attributes
+		// Attribute ::= Name Eq AttValue, Eq ::= S? '=' S? (XML 1.0 §3.1, §2.3)
 		while (pos < length && input.charCodeAt(pos) !== CLOSE_BRACKET_CC) {
 			const c = input.charCodeAt(pos)
 			if ((c > 64 && c < 91) || (c > 96 && c < 123)) {
 				const name = parseName()
-				let value: string = ''
-				// search beginning of the string
-				let code = input.charCodeAt(pos)
-				while (pos < length && code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC && code !== CLOSE_BRACKET_CC) {
-					pos++
-					code = input.charCodeAt(pos)
+				skipWhitespace()
+				if (input.charCodeAt(pos) !== EQUALS_CC) {
+					throw syntaxError('Malformed attribute "' + name + '": expected "=" after name')
 				}
-
-				if (code === SINGLE_QUOTE_CC || code === DOUBLE_QUOTE_CC) {
-					value = parseString()
-					if (pos === -1) {
-						throw new Error('Missing closing quote')
-					}
+				pos++
+				skipWhitespace()
+				const code = input.charCodeAt(pos)
+				if (code !== SINGLE_QUOTE_CC && code !== DOUBLE_QUOTE_CC) {
+					throw syntaxError('Malformed attribute "' + name + '": expected quoted value after "="')
 				}
-				else {
-					pos--
+				const value = parseString()
+				if (pos === -1) {
+					throw new Error('Missing closing quote')
 				}
-
 				attributes[name] = unescapeHtml(value)
 			}
 			pos++

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -305,4 +305,26 @@ describe('parseXml', () => {
 			equal(a.childNodes[0].nodeValue, 't')
 		})
 	})
+
+	describe('truncated input', () => {
+		it('parses a complete XML declaration followed by markup', async () => {
+			const doc = await parseXmlGuarded('<?xml version="1.0" encoding="UTF-8"?><a b="1"><c/>text</a>')
+			deepStrictEqual(doc.childNodes, [{
+				nodeName: 'a',
+				nodeValue: null,
+				attributes: { b: '1' },
+				childNodes: [
+					{ nodeName: 'c', nodeValue: null, attributes: {}, childNodes: [], prefix: null, localName: 'c' },
+					{ nodeName: '#text', nodeValue: 'text', attributes: {}, childNodes: [] },
+				],
+				prefix: null,
+				localName: 'a',
+			}])
+		})
+
+		it('returns an empty document when the input ends inside the XML declaration', async () => {
+			const doc = await parseXmlGuarded('<?xml version="1.0" encoding="UTF-8"')
+			deepStrictEqual(doc.childNodes, [])
+		})
+	})
 })

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -1,5 +1,5 @@
 import { parseXml, type XmlNode, type XmlParseOptions } from '@svta/cml-xml'
-import assert, { deepStrictEqual, equal, rejects, strictEqual } from 'node:assert'
+import assert, { deepStrictEqual, equal, rejects, strictEqual, throws } from 'node:assert'
 import { promises as fs } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, it } from 'node:test'
@@ -142,6 +142,47 @@ describe('parseXml', () => {
 		equal(namespace.nodeName, `tt:Text`)
 		equal(namespace.prefix, `tt`)
 		equal(namespace.localName, `Text`)
+	})
+
+	describe('close tags', () => {
+		it('throws on a close tag whose name differs from the open tag', () => {
+			throws(() => parseXml('<a>text</b>'), /Unexpected close tag/)
+		})
+
+		it('throws on a close tag whose name extends the open tag name', () => {
+			throws(() => parseXml('<ab>text</abc>'), /Unexpected close tag/)
+		})
+
+		it('does not let a longer close tag close a shorter open tag', () => {
+			throws(() => parseXml('<a>text</ab>'), /Unexpected close tag/)
+		})
+
+		it('throws on a close tag with no open element', () => {
+			throws(() => parseXml('<a/></b>'), /Unexpected close tag/)
+		})
+
+		it('closes an element when a space precedes the closing bracket', () => {
+			const doc = parseXml('<a>text</a >')
+			const a = doc.childNodes[0]
+
+			equal(doc.childNodes.length, 1)
+			equal(a.nodeName, 'a')
+			equal(a.childNodes[0].nodeValue, 'text')
+		})
+
+		it('closes an element when tabs and line breaks precede the closing bracket', () => {
+			const doc = parseXml('<a>text</a\t\r\n>')
+			equal(doc.childNodes[0].childNodes[0].nodeValue, 'text')
+		})
+
+		it('closes nested elements whose names share a prefix', () => {
+			const doc = parseXml('<a><ab>text</ab></a>')
+			const a = doc.childNodes[0]
+
+			equal(a.nodeName, 'a')
+			equal(a.childNodes[0].nodeName, 'ab')
+			equal(a.childNodes[0].childNodes[0].nodeValue, 'text')
+		})
 	})
 
 	describe('includeParentElement option', () => {

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -161,6 +161,11 @@ describe('parseXml', () => {
 			throws(() => parseXml('<a/></b>'), /Unexpected close tag/)
 		})
 
+		it('throws on an empty close tag with no open element', () => {
+			throws(() => parseXml('<a/></>'), /Unexpected close tag/)
+			throws(() => parseXml('<a/></ ><b/>'), /Unexpected close tag/)
+		})
+
 		it('closes an element when a space precedes the closing bracket', () => {
 			const doc = parseXml('<a>text</a >')
 			const a = doc.childNodes[0]
@@ -383,6 +388,11 @@ describe('parseXml', () => {
 				prefix: null,
 				localName: 'MPD',
 			}])
+		})
+
+		it('keeps the parsed children when the input ends right after `</` at the document level', async () => {
+			const doc = await parseXmlGuarded('<a/></')
+			deepStrictEqual(doc.childNodes, [{ nodeName: 'a', nodeValue: null, attributes: {}, childNodes: [], prefix: null, localName: 'a' }])
 		})
 
 		it('reports end of input when a mismatched close tag is cut off', async () => {

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -385,6 +385,13 @@ describe('parseXml', () => {
 			}])
 		})
 
+		it('reports end of input when a mismatched close tag is cut off', async () => {
+			await rejects(
+				parseXmlGuarded('<a>text</b'),
+				{ message: /^Unexpected close tag\nLine: 0\nColumn: 11\nChar: end of input$/ },
+			)
+		})
+
 		it('terminates on every truncation of the fixtures', async () => {
 			for (const fixture of ['./test/fixtures/node_types.xml', './test/fixtures/bbb_30fps.mpd']) {
 				const xml = await fs.readFile(resolve(fixture), 'utf8')

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -11,34 +11,45 @@ const PARSE_TIMEOUT_MS = 2000
 const WORKER_SOURCE = `
 const { parentPort, workerData } = require('node:worker_threads')
 import(workerData.url).then(({ parseXml }) => {
-	workerData.inputs.forEach((input, index) => {
+	const { inputs, prefixesOf, options } = workerData
+	const count = inputs ? inputs.length : prefixesOf.length + 1
+	for (let index = 0; index < count; index++) {
 		parentPort.postMessage({ index })
 		try {
-			parentPort.postMessage({ index, result: parseXml(input, workerData.options) })
+			const result = parseXml(inputs ? inputs[index] : prefixesOf.slice(0, index), options)
+			parentPort.postMessage({ index, result: inputs ? result : true })
 		}
 		catch (error) {
-			parentPort.postMessage({ index, error: error.message })
+			parentPort.postMessage({ index, error: error instanceof Error ? error.message : String(error) })
 		}
-	})
+	}
 })
 `
 
-type ParseOutcome = { result: XmlNode } | { error: string }
+type ParseJob = { inputs: string[] } | { prefixesOf: string }
+
+type ParseOutcome<T> = { result: T } | { error: string }
 
 type ParseMessage = {
 	index: number;
-	result?: XmlNode;
+	result?: unknown;
 	error?: string;
 }
 
 /**
- * Parses each input in a worker thread so that a parser that never returns fails the test
- * instead of hanging the test runner.
+ * Parses each input, or each prefix of a document, in a worker thread so that a parser that
+ * never returns fails the test instead of hanging the test runner. A prefix sweep reports only
+ * whether each parse returned; the parsed trees stay in the worker.
  */
-function parseXmlInWorker(inputs: string[], options?: XmlParseOptions): Promise<ParseOutcome[]> {
+function runParseWorker(job: { inputs: string[] }, options?: XmlParseOptions): Promise<ParseOutcome<XmlNode>[]>
+function runParseWorker(job: { prefixesOf: string }, options?: XmlParseOptions): Promise<ParseOutcome<true>[]>
+function runParseWorker(job: ParseJob, options?: XmlParseOptions): Promise<ParseOutcome<unknown>[]> {
+	const count = 'inputs' in job ? job.inputs.length : job.prefixesOf.length + 1
+	const inputAt = (index: number): string => 'inputs' in job ? job.inputs[index] : job.prefixesOf.slice(0, index)
+
 	return new Promise((done, fail) => {
-		const worker = new Worker(WORKER_SOURCE, { eval: true, execArgv: [], workerData: { url: PARSE_XML_URL, inputs, options } })
-		const outcomes: ParseOutcome[] = []
+		const worker = new Worker(WORKER_SOURCE, { eval: true, execArgv: [], workerData: { url: PARSE_XML_URL, options, ...job } })
+		const outcomes: ParseOutcome<unknown>[] = []
 		let current = 0
 		let timer: ReturnType<typeof setTimeout>
 
@@ -51,7 +62,7 @@ function parseXmlInWorker(inputs: string[], options?: XmlParseOptions): Promise<
 		const watch = () => {
 			clearTimeout(timer)
 			timer = setTimeout(() => {
-				settle(() => fail(new Error(`parseXml did not return within ${PARSE_TIMEOUT_MS}ms for ${JSON.stringify(inputs[current])}`)))
+				settle(() => fail(new Error(`parseXml did not return within ${PARSE_TIMEOUT_MS}ms for ${JSON.stringify(inputAt(current))}`)))
 			}, PARSE_TIMEOUT_MS)
 		}
 
@@ -64,7 +75,7 @@ function parseXmlInWorker(inputs: string[], options?: XmlParseOptions): Promise<
 				outcomes.push({ result: message.result })
 			}
 
-			if (outcomes.length === inputs.length) {
+			if (outcomes.length === count) {
 				settle(() => done(outcomes))
 			}
 			else {
@@ -80,7 +91,7 @@ function parseXmlInWorker(inputs: string[], options?: XmlParseOptions): Promise<
  * Parses a single input in a worker thread, rethrowing any parse error.
  */
 async function parseXmlGuarded(input: string, options?: XmlParseOptions): Promise<XmlNode> {
-	const [outcome] = await parseXmlInWorker([input], options)
+	const [outcome] = await runParseWorker({ inputs: [input] }, options)
 	if ('error' in outcome) {
 		throw new Error(outcome.error)
 	}
@@ -405,11 +416,10 @@ describe('parseXml', () => {
 		it('terminates on every truncation of the fixtures', async () => {
 			for (const fixture of ['./test/fixtures/node_types.xml', './test/fixtures/bbb_30fps.mpd']) {
 				const xml = await fs.readFile(resolve(fixture), 'utf8')
-				const prefixes = Array.from({ length: xml.length + 1 }, (_, end) => xml.slice(0, end))
-				const outcomes = await parseXmlInWorker(prefixes)
+				const outcomes = await runParseWorker({ prefixesOf: xml })
 
-				equal(outcomes.length, prefixes.length)
-				assert('result' in outcomes[prefixes.length - 1], `${fixture} did not parse in full`)
+				equal(outcomes.length, xml.length + 1)
+				assert('result' in outcomes[xml.length], `${fixture} did not parse in full`)
 			}
 		})
 	})

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -1,8 +1,91 @@
-import { parseXml } from '@svta/cml-xml'
-import assert, { deepStrictEqual, equal, strictEqual, throws } from 'node:assert'
+import { parseXml, type XmlNode, type XmlParseOptions } from '@svta/cml-xml'
+import assert, { deepStrictEqual, equal, rejects, strictEqual } from 'node:assert'
 import { promises as fs } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, it } from 'node:test'
+import { Worker } from 'node:worker_threads'
+
+const PARSE_XML_URL = import.meta.resolve('@svta/cml-xml')
+const PARSE_TIMEOUT_MS = 2000
+
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require('node:worker_threads')
+import(workerData.url).then(({ parseXml }) => {
+	workerData.inputs.forEach((input, index) => {
+		parentPort.postMessage({ index })
+		try {
+			parentPort.postMessage({ index, result: parseXml(input, workerData.options) })
+		}
+		catch (error) {
+			parentPort.postMessage({ index, error: error.message })
+		}
+	})
+})
+`
+
+type ParseOutcome = { result: XmlNode } | { error: string }
+
+type ParseMessage = {
+	index: number;
+	result?: XmlNode;
+	error?: string;
+}
+
+/**
+ * Parses each input in a worker thread so that a parser that never returns fails the test
+ * instead of hanging the test runner.
+ */
+function parseXmlInWorker(inputs: string[], options?: XmlParseOptions): Promise<ParseOutcome[]> {
+	return new Promise((done, fail) => {
+		const worker = new Worker(WORKER_SOURCE, { eval: true, execArgv: [], workerData: { url: PARSE_XML_URL, inputs, options } })
+		const outcomes: ParseOutcome[] = []
+		let current = 0
+		let timer: ReturnType<typeof setTimeout>
+
+		const settle = (callback: () => void) => {
+			clearTimeout(timer)
+			void worker.terminate()
+			callback()
+		}
+
+		const watch = () => {
+			clearTimeout(timer)
+			timer = setTimeout(() => {
+				settle(() => fail(new Error(`parseXml did not return within ${PARSE_TIMEOUT_MS}ms for ${JSON.stringify(inputs[current])}`)))
+			}, PARSE_TIMEOUT_MS)
+		}
+
+		worker.on('message', (message: ParseMessage) => {
+			current = message.index
+			if (message.error !== undefined) {
+				outcomes.push({ error: message.error })
+			}
+			else if (message.result !== undefined) {
+				outcomes.push({ result: message.result })
+			}
+
+			if (outcomes.length === inputs.length) {
+				settle(() => done(outcomes))
+			}
+			else {
+				watch()
+			}
+		})
+		worker.on('error', (error) => settle(() => fail(error)))
+		watch()
+	})
+}
+
+/**
+ * Parses a single input in a worker thread, rethrowing any parse error.
+ */
+async function parseXmlGuarded(input: string, options?: XmlParseOptions): Promise<XmlNode> {
+	const [outcome] = await parseXmlInWorker([input], options)
+	if ('error' in outcome) {
+		throw new Error(outcome.error)
+	}
+	return outcome.result
+}
 
 describe('parseXml', () => {
 	it('provides a valid example', async () => {
@@ -139,8 +222,8 @@ describe('parseXml', () => {
 	})
 
 	describe('malformed attributes', () => {
-		it('parses a valueless attribute as an empty string', () => {
-			const doc = parseXml('<a b>')
+		it('parses a valueless attribute as an empty string', async () => {
+			const doc = await parseXmlGuarded('<a b>')
 			const a = doc.childNodes[0]
 
 			equal(a.nodeName, 'a')
@@ -148,13 +231,13 @@ describe('parseXml', () => {
 			equal(a.childNodes.length, 0)
 		})
 
-		it('parses a valueless attribute after a quoted attribute', () => {
-			const doc = parseXml('<a b="c" d>')
+		it('parses a valueless attribute after a quoted attribute', async () => {
+			const doc = await parseXmlGuarded('<a b="c" d>')
 			deepStrictEqual(doc.childNodes[0].attributes, { b: 'c', d: '' })
 		})
 
-		it('parses a valueless attribute in a self-closing child', () => {
-			const doc = parseXml('<a b="c"><d e/></a>')
+		it('parses a valueless attribute in a self-closing child', async () => {
+			const doc = await parseXmlGuarded('<a b="c"><d e/></a>')
 			const a = doc.childNodes[0]
 
 			equal(a.childNodes.length, 1)
@@ -163,8 +246,8 @@ describe('parseXml', () => {
 			equal(a.childNodes[0].childNodes.length, 0)
 		})
 
-		it('does not swallow markup following a valueless attribute', () => {
-			const doc = parseXml('<a b><c d="1"/></a>')
+		it('does not swallow markup following a valueless attribute', async () => {
+			const doc = await parseXmlGuarded('<a b><c d="1"/></a>')
 			const a = doc.childNodes[0]
 
 			deepStrictEqual(a.attributes, { b: '' })
@@ -173,8 +256,8 @@ describe('parseXml', () => {
 			deepStrictEqual(a.childNodes[0].attributes, { d: '1' })
 		})
 
-		it('parses an unquoted attribute value as an empty string', () => {
-			const doc = parseXml('<a b=c/>')
+		it('parses an unquoted attribute value as an empty string', async () => {
+			const doc = await parseXmlGuarded('<a b=c/>')
 			const a = doc.childNodes[0]
 
 			equal(a.nodeName, 'a')
@@ -182,21 +265,21 @@ describe('parseXml', () => {
 			equal(a.childNodes.length, 0)
 		})
 
-		it('terminates when the input ends inside an attribute name', () => {
-			const doc = parseXml('<MPD><Period><SegmentTimeline><S d="180000" r')
+		it('terminates when the input ends inside an attribute name', async () => {
+			const doc = await parseXmlGuarded('<MPD><Period><SegmentTimeline><S d="180000" r')
 			const s = doc.childNodes[0].childNodes[0].childNodes[0].childNodes[0]
 
 			equal(s.nodeName, 'S')
 			deepStrictEqual(s.attributes, { d: '180000', r: '' })
 		})
 
-		it('terminates when the input ends after an attribute equals sign', () => {
-			const doc = parseXml('<a b=')
+		it('terminates when the input ends after an attribute equals sign', async () => {
+			const doc = await parseXmlGuarded('<a b=')
 			deepStrictEqual(doc.childNodes[0].attributes, { b: '' })
 		})
 
-		it('throws when the input ends inside a quoted attribute value', () => {
-			throws(() => parseXml('<MPD><Period><S d="1'), /Missing closing quote/)
+		it('throws when the input ends inside a quoted attribute value', async () => {
+			await rejects(parseXmlGuarded('<MPD><Period><S d="1'), /Missing closing quote/)
 		})
 	})
 

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -326,5 +326,47 @@ describe('parseXml', () => {
 			const doc = await parseXmlGuarded('<?xml version="1.0" encoding="UTF-8"')
 			deepStrictEqual(doc.childNodes, [])
 		})
+
+		it('keeps the parsed children when the input ends inside the root close tag', async () => {
+			const doc = await parseXmlGuarded('<a>text</a')
+			deepStrictEqual(doc.childNodes, [{
+				nodeName: 'a',
+				nodeValue: null,
+				attributes: {},
+				childNodes: [{ nodeName: '#text', nodeValue: 'text', attributes: {}, childNodes: [] }],
+				prefix: null,
+				localName: 'a',
+			}])
+		})
+
+		it('keeps the parsed children when the input ends inside a nested close tag', async () => {
+			const doc = await parseXmlGuarded('<MPD><Period><S d="1"/></Period')
+			deepStrictEqual(doc.childNodes, [{
+				nodeName: 'MPD',
+				nodeValue: null,
+				attributes: {},
+				childNodes: [{
+					nodeName: 'Period',
+					nodeValue: null,
+					attributes: {},
+					childNodes: [{ nodeName: 'S', nodeValue: null, attributes: { d: '1' }, childNodes: [], prefix: null, localName: 'S' }],
+					prefix: null,
+					localName: 'Period',
+				}],
+				prefix: null,
+				localName: 'MPD',
+			}])
+		})
+
+		it('terminates on every truncation of the fixtures', async () => {
+			for (const fixture of ['./test/fixtures/node_types.xml', './test/fixtures/bbb_30fps.mpd']) {
+				const xml = await fs.readFile(resolve(fixture), 'utf8')
+				const prefixes = Array.from({ length: xml.length + 1 }, (_, end) => xml.slice(0, end))
+				const outcomes = await parseXmlInWorker(prefixes)
+
+				equal(outcomes.length, prefixes.length)
+				assert('result' in outcomes[prefixes.length - 1], `${fixture} did not parse in full`)
+			}
+		})
 	})
 })

--- a/libs/xml/test/parseXml.test.ts
+++ b/libs/xml/test/parseXml.test.ts
@@ -263,60 +263,46 @@ describe('parseXml', () => {
 	})
 
 	describe('malformed attributes', () => {
-		it('parses a valueless attribute as an empty string', async () => {
-			const doc = await parseXmlGuarded('<a b>')
-			const a = doc.childNodes[0]
-
-			equal(a.nodeName, 'a')
-			deepStrictEqual(a.attributes, { b: '' })
-			equal(a.childNodes.length, 0)
+		it('throws on a valueless attribute', async () => {
+			await rejects(parseXmlGuarded('<a b>'), { message: /^Malformed attribute "b": expected "=" after name/ })
 		})
 
-		it('parses a valueless attribute after a quoted attribute', async () => {
-			const doc = await parseXmlGuarded('<a b="c" d>')
-			deepStrictEqual(doc.childNodes[0].attributes, { b: 'c', d: '' })
+		it('throws on a valueless attribute in a self-closing tag', async () => {
+			await rejects(parseXmlGuarded('<a b/>'), { message: /^Malformed attribute "b": expected "=" after name/ })
 		})
 
-		it('parses a valueless attribute in a self-closing child', async () => {
-			const doc = await parseXmlGuarded('<a b="c"><d e/></a>')
-			const a = doc.childNodes[0]
-
-			equal(a.childNodes.length, 1)
-			equal(a.childNodes[0].nodeName, 'd')
-			deepStrictEqual(a.childNodes[0].attributes, { e: '' })
-			equal(a.childNodes[0].childNodes.length, 0)
+		it('throws on a valueless attribute after a quoted attribute', async () => {
+			await rejects(parseXmlGuarded('<a b="c" d>'), { message: /^Malformed attribute "d": expected "=" after name/ })
 		})
 
-		it('does not swallow markup following a valueless attribute', async () => {
-			const doc = await parseXmlGuarded('<a b><c d="1"/></a>')
-			const a = doc.childNodes[0]
-
-			deepStrictEqual(a.attributes, { b: '' })
-			equal(a.childNodes.length, 1)
-			equal(a.childNodes[0].nodeName, 'c')
-			deepStrictEqual(a.childNodes[0].attributes, { d: '1' })
+		it('throws on an unquoted attribute value', async () => {
+			await rejects(parseXmlGuarded('<a b=c/>'), { message: /^Malformed attribute "b": expected quoted value after "="/ })
 		})
 
-		it('parses an unquoted attribute value as an empty string', async () => {
-			const doc = await parseXmlGuarded('<a b=c/>')
-			const a = doc.childNodes[0]
-
-			equal(a.nodeName, 'a')
-			deepStrictEqual(a.attributes, { b: '' })
-			equal(a.childNodes.length, 0)
+		it('throws on a quoted value with no equals sign', async () => {
+			await rejects(parseXmlGuarded('<a b "c"/>'), { message: /^Malformed attribute "b": expected "=" after name/ })
 		})
 
-		it('terminates when the input ends inside an attribute name', async () => {
-			const doc = await parseXmlGuarded('<MPD><Period><SegmentTimeline><S d="180000" r')
-			const s = doc.childNodes[0].childNodes[0].childNodes[0].childNodes[0]
-
-			equal(s.nodeName, 'S')
-			deepStrictEqual(s.attributes, { d: '180000', r: '' })
+		it('reports the valueless attribute, not the element that follows it', async () => {
+			await rejects(parseXmlGuarded('<a b><c d="1"/></a>'), { message: /^Malformed attribute "b"/ })
 		})
 
-		it('terminates when the input ends after an attribute equals sign', async () => {
-			const doc = await parseXmlGuarded('<a b=')
-			deepStrictEqual(doc.childNodes[0].attributes, { b: '' })
+		it('throws when the input ends inside an attribute name', async () => {
+			await rejects(
+				parseXmlGuarded('<MPD><Period><SegmentTimeline><S d="180000" r'),
+				{ message: /^Malformed attribute "r": expected "=" after name\n.*\n.*\nChar: end of input$/ },
+			)
+		})
+
+		it('throws when the input ends after the equals sign', async () => {
+			await rejects(
+				parseXmlGuarded('<a b='),
+				{ message: /^Malformed attribute "b": expected quoted value after "="\nLine: 0\nColumn: 6\nChar: end of input$/ },
+			)
+		})
+
+		it('reports the line and column of the malformed attribute', async () => {
+			await rejects(parseXmlGuarded('<root>\n\t<a b>'), { message: /\nLine: 1\nColumn: 6\nChar: >$/ })
 		})
 
 		it('throws when the input ends inside a quoted attribute value', async () => {


### PR DESCRIPTION
## Description

Consolidates #427, #428, and #429, which all change `parseXml()` in `@svta/cml-xml` and conflict pairwise, into one branch, and addresses the Copilot review comments on each.

- Truncated input no longer hangs `parseXml()`. An unterminated `<?xml` declaration and an unterminated matching close tag (`<a>text</a`) return the nodes parsed so far, which is what the parser already did for `<a>text` or an unterminated CDATA section. The tests run the parser in a worker thread so a future hang fails after 2 s instead of stalling CI, and a sweep parses every prefix of both fixtures. (#427)
- Malformed attributes throw instead of yielding an empty string. `<a b>`, `<a b=c/>`, `<a b="c" d>`, and input cut off inside an attribute raise `Malformed attribute "<name>": expected ...` with the line, column, and offending character, per XML 1.0 `Attribute ::= Name Eq AttValue`. (#428)
- Close tags must match the open tag exactly. `<ab>text</abc>`, `</ab>` closing `<a>`, and any close tag at the document level throw `Unexpected close tag`; `</a >` still closes `<a>`. (#429)
- Review follow-ups. A mismatched close tag cut off by the end of input reports its real line and column and `Char: end of input` instead of `Line: 0`, `Column: 1`, `Char: undefined` (also wrong on `main` today). An empty `</>` at the document level throws instead of silently ending the document. The truncation sweep slices prefixes inside the worker and no longer transfers a parsed tree per prefix. The worker serializes non-Error throws. The `parseXml` TSDoc says what is and is not checked.

## How the three PRs were combined

The commits from #427, #429, and #428 are cherry-picked in that order with their original messages and sign-offs. Conflicts were in `CHANGELOG.md` (every bullet kept; #428's rewrite of the #425 bullet wins), the constants block (`EQUALS_CC` plus the four whitespace constants), the close-tag check (`if (!closesTag) throw syntaxError('Unexpected close tag')`), and the malformed-attribute tests (#428's throw expectations wrapped in #427's worker guard). The auto-merged test file had also lost the `throws` import that #429's tests use. Four follow-up commits address the review comments, one per concern, so any of them can be dropped on its own.

## Review comments addressed

| PR | Comment | Disposition |
|----|---------|-------------|
| #427 | Worker `catch` assumes an `Error` | Fixed: `error instanceof Error ? error.message : String(error)` |
| #427 | Sweep is quadratic in fixture size | Fixed: the worker slices prefixes itself and posts only whether each parse returned |
| #427 | Declaration branch sets `pos = length` then `pos++` | Fixed: mirrors the close-tag branch so `pos` stays within the input |
| #428 | Close-tag branch hangs on `</a` with no `>` | Superseded by #427's fix, included here |
| #428 | `syntaxError()` reports `Char: undefined` when `pos === -1` | Fixed: the position is normalized to end of input before the check; regression test added |
| #428 | TSDoc still says "no validation and some failure tolerance" | Fixed: summary reworded; `@throws` also lists the document-level close tag |
| #429 | `</>` at the document level matches the empty tag name | Fixed: nothing closes at the document level; a trailing `</` at end of input still returns the partial tree |

## Notes for review

- Truncation policy is unchanged from the individual PRs. Structural truncation (`<?xml ...`, `</a`, `<a>text`) returns a partial tree, while truncation inside an attribute throws because #428 treats every malformed attribute the same way. Making structural truncation throw is a behavior change beyond a bug fix and belongs in the well-formedness RFC.
- Two seams remain for that RFC: `<a>text</` (close tag cut off before its name is complete) throws while `<a>text</a` returns the partial tree, and `</a x>` still closes `<a>` because only the first character after the name is checked.
- `<a b "c"/>` (quoted value, no `=`) parsed as `b="c"` on `main` and now throws; it is listed under Changed in the changelog.
- Supersedes #427, #428, and #429, which are closed with a comment pointing at this branch.

## Performance

The stricter attribute grammar from #428 originally cost about 10% of parse time on attribute-heavy manifests. Commit c8644b085 removes that: it reads the character after the attribute name first and only runs an inlined whitespace loop when it is not `=`, then does the same for the quote, instead of calling `skipWhitespace()` twice per attribute. Output and error messages are identical to the pre-fix branch on 204 well-formed and malformed input/option combinations.

Method: `main` (d74cac3ad) and this branch loaded from TypeScript source under Node v24.16.0 on an Apple M1 Pro, one process per implementation and input, 3 rounds with the implementation order alternated each round, 5 warm-up samples, natural GC, medians of per-process medians.

| Input | `main` | Branch before c8644b085 | Branch after c8644b085 |
|-------|-------:|------------------------:|-----------------------:|
| 100k `<S .../>` MPD, 3.7 MB | 34.0 ms | 37.2 ms (+9.5%) | 33.1 ms (-2.7%) |
| 100k `<S ...></S>` MPD, 4.0 MB | 35.9 ms | 40.3 ms (+12.3%) | 35.7 ms (-0.6%) |
| Live manifest, 5 Periods x 4 AdaptationSets x 200 `<S>`, 150 KB | 1.40 ms | 1.57 ms (+11.8%) | 1.39 ms (-0.5%) |
| `bbb_30fps.mpd` fixture, 3 KB | 23 µs | 25 µs (+10.5%) | 24 µs (+2.2%) |

Attribution check: the branch with `main`'s attribute loop spliced back in measured within 2% of `main` on every input, including the 100k `</S>` case, so the close-tag check, the declaration fix, and the position normalization are free. The differences after the fix are within run-to-run noise (about 2%).

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-xml | 1.1.6 (no bump, changelog under Unreleased) | fix |

## Test Plan

- [x] `npm test` at the root (lint, build, typecheck, every package's tests)
- [x] `npm test -w libs/xml`: 41 tests pass, including the worker-guarded truncation and malformed-attribute tests
- [x] Each review fix has a test that failed before it: `<a>text</b` reported `Char: undefined`, `<a/></ ><b/>` returned `[a]`
- [x] `cml-xml.api.md` unchanged after the build
- [x] `npm run build -w docs` passes
- [x] A/B benchmark against `main` on four inputs (see Performance): parse time within noise of `main` after c8644b085

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated (`parseXml` TSDoc summary and `@throws`; no public API change, `cml-xml.api.md` unchanged)
- [x] Changelog updated

Refs: #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

