### PR TITLE
docs: apply the writing style rules to the package READMEs and guides

### DIFF
--- a/libs/608/CHANGELOG.md
+++ b/libs/608/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- README: the prose is rewritten for readers who do not read English as a first language. The extractor table and the code examples are unchanged.
+
 ## [1.1.0] - 2026-08-13
 
 ### Added

--- a/libs/608/README.md
+++ b/libs/608/README.md
@@ -16,17 +16,19 @@ import { CaptionScreen, Row } from "@svta/cml-608";
 
 ### Extracting captions from a media sample
 
-CTA-608 captions ride inside the video elementary stream as an ATSC A/53 `cc_data()`
-payload. The payload is the same for every codec; only the envelope around it differs, so
-pick the extractor that matches the sample entry type:
+CTA-608 captions are embedded in the video elementary stream as an ATSC A/53 `cc_data()`
+payload. Only the envelope around the payload differs by codec. The envelope is either a
+supplemental enhancement information (SEI) message in a network abstraction layer (NAL)
+unit, or an open bitstream unit (OBU). Choose the extractor that matches the sample entry
+type:
 
 | Sample entry            | Envelope                          | Extractor                          |
 | ----------------------- | --------------------------------- | ---------------------------------- |
 | `avc1` / `hvc1` / `vvc1` | `itu_t_t35` SEI message in a NAL  | `extractCta608DataFromSample`      |
 | `av01`                  | `metadata_itu_t_t35` OBU          | `extractCta608DataFromAv1Sample`   |
 
-Both return the same `[field1, field2]` byte arrays, which `Cta608Parser` turns into
-rendered caption screens:
+Both extractors return the same `[field1, field2]` byte arrays. `Cta608Parser` renders
+them as caption screens:
 
 ```typescript
 import { Cta608Parser, extractCta608DataFromAv1Sample } from "@svta/cml-608";
@@ -43,10 +45,9 @@ if (field1.length) {
 }
 ```
 
-These are separate functions rather than one auto-detecting call because the two carriages
-are framed differently and neither sample announces which it is. A NAL unit sample puts a
-fixed-width big-endian length in front of each unit, and that width is only known from
-`lengthSizeMinusOne` in the `avcC`/`hvcC` config. An AV1 sample uses the low-overhead
-format, where each OBU carries its own `obu_size` after the header — and may omit it on
-the last OBU. Either way the framing has to come from the sample entry, so pass the bytes
-to the extractor that matches it.
+The two extractors are separate because the two envelopes are framed differently, and a
+sample does not announce its framing. A NAL unit sample puts a fixed-width big-endian
+length before each unit. Only `lengthSizeMinusOne` in the `avcC` or `hvcC` config gives
+that width. An AV1 sample uses the low-overhead format. Each OBU has its own `obu_size`
+after the header, and the last OBU may omit it. In both cases the sample entry gives the
+framing.

--- a/libs/608/test/fixtures/README.md
+++ b/libs/608/test/fixtures/README.md
@@ -2,16 +2,16 @@
 
 ## `608_av1.mp4`
 
-A real, decodable AV1 fragmented mp4 carrying CTA-608 captions in
-`metadata_itu_t_t35` OBUs — 256x144, 30 fps, 40 frames, Main profile
-(`av01.0.00M.08`), one fragment.
+A real, decodable AV1 fragmented mp4 with CTA-608 captions in `metadata_itu_t_t35` open
+bitstream units (OBUs): 256x144, 30 fps, 40 frames, Main profile (`av01.0.00M.08`), one
+fragment.
 
-The caption is `HELLO WORLD` as a pop-on on row 15, with each control code doubled: 14
-field 1 byte pairs across frames 0-13, then `EDM` across frames 30-31. One pair per
-frame, which is what an SCC source specifies.
+The caption is `HELLO WORLD` as a pop-on on row 15, with each control code doubled.
+Frames 0-13 contain 14 field 1 byte pairs. Frames 30-31 contain `EDM`. One pair per frame
+is what a Scenarist Closed Caption (SCC) source specifies.
 
-Regenerate in two steps. First the clean AV1 bitstream, with `+bitexact` so the encode is
-byte-reproducible:
+Regenerate in two steps. First, encode the clean AV1 bitstream with `+bitexact` for a
+byte-reproducible encode:
 
 ```sh
 ffmpeg -y -fflags +bitexact -f lavfi -i "testsrc2=size=256x144:rate=30" -frames:v 40 \
@@ -22,8 +22,8 @@ ffmpeg -y -fflags +bitexact -f lavfi -i "testsrc2=size=256x144:rate=30" -frames:
   av01-clean.mp4
 ```
 
-Then inject the captions with [go-608](https://github.com/Eyevinn/go-608), an independent
-implementation — so these fixtures do not simply re-encode this library's own assumptions:
+Then inject the captions with [go-608](https://github.com/Eyevinn/go-608). go-608 is
+independent, so these fixtures do not re-encode this library's own assumptions:
 
 ```sh
 cat > hello.scc <<'EOF'
@@ -37,11 +37,11 @@ EOF
 go608-inject -i av01-clean.mp4 -sub hello.scc -o 608_av1.mp4 -fps 30
 ```
 
-`go608-info -i 608_av1.mp4` dumps the per-frame field pairs and the rendered screen, and
-`go608-extract` reads the captions back out as WebVTT.
+`go608-info -i 608_av1.mp4` prints the per-frame field pairs and the rendered screen.
+`go608-extract` reads the captions back as WebVTT.
 
 ## `608_h264.m4s` and `608_h265.m4s`
 
-Pre-existing fixtures carrying captions in `itu_t_t35` SEI messages, on both fields, with
-all of a caption's byte pairs packed into a single frame's `cc_data()`. Provenance is not
-recorded.
+Pre-existing fixtures with captions in `itu_t_t35` supplemental enhancement information
+(SEI) messages, on both fields. One frame's `cc_data()` packs all byte pairs of a caption.
+Their provenance is not recorded.

--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- README: the prose is rewritten for readers who do not read English as a first language. BMFF, COSE, EMSG, VOD, and JUMBF are defined at first use. The code examples are unchanged.
+
 ## [1.1.2] - 2026-08-11
 
 ### Changed

--- a/libs/c2pa/README.md
+++ b/libs/c2pa/README.md
@@ -1,12 +1,12 @@
 # @svta/cml-c2pa
 
-C2PA (Coalition for Content Provenance and Authenticity) live video validation for BMFF/MP4 containers.
+C2PA (Coalition for Content Provenance and Authenticity) live video validation for ISO Base Media File Format (BMFF) and MP4 containers.
 
-Supports the segment validation methods defined in the C2PA specification:
+Supported C2PA segment validation methods:
 
-- **§19.3 Per-segment C2PA Manifest Box**: each segment embeds a full C2PA manifest with COSE signature
-- **§19.4 Verifiable Segment Info (VSI/EMSG)**: the init segment carries the manifest and session keys; each media segment carries a lightweight signed EMSG box
-- **§15.12.2 / §18.6 VOD Merkle**: for on-demand fragmented MP4 assets, the init manifest stores one Merkle tree row per track, and each media segment carries its own leaf hash and proof
+- **§19.3 Per-segment C2PA Manifest Box**: each segment embeds a full C2PA manifest with a CBOR Object Signing and Encryption (COSE) signature
+- **§19.4 Verifiable Segment Info (VSI/EMSG)**: the init segment contains the manifest and the session keys. Each media segment contains a small signed event message (EMSG) box
+- **§15.12.2 / §18.6 VOD Merkle**: for video on demand (VOD) assets in fragmented MP4, the init manifest stores one Merkle tree row per track. Each media segment contains its own leaf hash and proof
 
 
 ## Installation
@@ -17,7 +17,7 @@ npm i @svta/cml-c2pa
 
 > **Note:** `@svta/cml-iso-bmff`, `@svta/cml-utils`, and `cbor-x` are peer dependencies. Most package managers install them automatically, but you may need to add them explicitly.
 
-> **Note:** This library uses the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (`crypto.subtle`) for COSE signature verification and BMFF hash computation. In Node.js 20+ this is available globally. In browsers, `crypto.subtle` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`).
+> **Note:** This library uses the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (`crypto.subtle`) to verify COSE signatures and compute BMFF hashes. In Node.js 20+, `crypto.subtle` is available globally. In browsers, it requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`).
 
 ## Usage
 
@@ -70,13 +70,13 @@ const { result } = await validateC2paMerkleSegment(segmentBytes, init.merkleMaps
 
 ## Docs
 
-- [VSI/EMSG Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/vsi-validation.md): Validate using Verifiable Segment Info (§19.4)
-- [Manifest Box Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/manifest-box-validation.md): Validate using per-segment manifests (§19.3)
-- [VOD Merkle Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/merkle-validation.md): Validate on-demand fragmented MP4 assets using Merkle tree proofs (§15.12.2 / §18.6)
-- [Results and Error Codes](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/results-and-error-codes.md): Interpret results, error codes, and manifest data
+- [VSI/EMSG Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/vsi-validation.md) (§19.4)
+- [Manifest Box Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/manifest-box-validation.md) (§19.3)
+- [VOD Merkle Validation](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/merkle-validation.md) (§15.12.2 / §18.6)
+- [Results and Error Codes](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/libs/c2pa/docs/results-and-error-codes.md)
 
 ## References
 
 - [C2PA Specification v2.3](https://c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html)
-- [JUMBF — ISO 19566-5](https://www.iso.org/standard/84635.html)
-- [COSE — RFC 9052](https://www.rfc-editor.org/rfc/rfc9052)
+- [JUMBF (JPEG Universal Metadata Box Format), ISO 19566-5](https://www.iso.org/standard/84635.html)
+- [COSE, RFC 9052](https://www.rfc-editor.org/rfc/rfc9052)

--- a/libs/cmaf-ham/samples/cmaf-ham-conversion/README.md
+++ b/libs/cmaf-ham/samples/cmaf-ham-conversion/README.md
@@ -1,22 +1,22 @@
 # cmaf-ham-conversion
 
-This project aims to demonstrate and explore the functionalities of the CMAF-Ham library through the manipulation and conversion of DASH and HLS manifests.
+This project demonstrates the CMAF-Ham library by converting and editing DASH and HLS manifests.
 
-When you run this project using the command `npm run dev`, different versions of the content in the `input/` folder will be created using the CMAF-Ham library. It's worth noting that it is possible to add new content to the `input` folder to transform between formats.
+When you run `npm run dev`, the CMAF-Ham library creates different versions of the content in the `input/` folder. You can add new content to the `input/` folder to convert it between formats.
 
 ## Steps to run the script
 1. Open a terminal in the **root folder** of the **common-media-library** project.
 2. Run `npm ci` and then `npm run build`.
-3. Go the cmaf-ham-conversion sample using `cd samples/cmaf-ham-conversion`.
+3. Go to the sample folder with `cd samples/cmaf-ham-conversion`.
 4. Execute `npm run dev`.
-5. Verify that a new folder called `dist/` is created with the output files created using the CMAF-Ham library. In each subfolder you will find:
+5. Check that a new `dist/` folder exists with the output files. Each subfolder contains:
    * `ham.json`: A JSON export of the Ham object.
-   * `validations.json`: A JSON file containing the results of the validation for each presentation of the content.
-   * `main.m3u8`: A the multivariant playlist of the HLS version of the content. 
-   * `main.mpd`: The MPD of the DASH version of the content. 
+   * `validations.json`: The validation results for each presentation of the content.
+   * `main.m3u8`: The multivariant playlist of the HLS version of the content.
+   * `main.mpd`: The Media Presentation Description (MPD) of the DASH version of the content.
 
 ## Play the output in a Web Player
-After executing the script, use the command `npm run serve` to launch a web server with CORS enabled to serve the created manifests. By default it will run in [`http://localhost:3000/`](http://localhost:3000/)
+After the script finishes, run `npm run serve`. It starts a web server with cross-origin resource sharing (CORS) enabled, which serves the created manifests. By default the server runs at [`http://localhost:3000/`](http://localhost:3000/).
 
 Steps to play the HLS content:
 1. Run `npm run serve`
@@ -29,7 +29,7 @@ Steps to play the DASH content:
 3. Load the URL `http://localhost:3000/<sample>/<path>/main.mpd`
 
 ## Samples
-The folder `input` has 3 CMAF HLS and 4 CMAF DASH manifests samples ready to use with the CMAF-Ham library. 
+The `input/` folder has seven CMAF sample manifests for the CMAF-Ham library. The table lists them.
 
 | Sample content | Characteristics |
 | -  | - |
@@ -42,6 +42,6 @@ The folder `input` has 3 CMAF HLS and 4 CMAF DASH manifests samples ready to use
 | HLS sample-3 | CMAF, VOD, 3 video tracks, 2 audio tracks, 2 text tracks |
 
 ## Adding new content
-1. You can add new DASH or HLS content into the `./input/dash` or `./input/hls` folders. 
-2. Each folder within `./input/dash` or `./input/hls` should contain only one content. 
-3. In the case of HLS content, the multivariant playlist must be named either `main.m3u8` or `manifest.m3u8`.
+1. Add new DASH or HLS content to the `./input/dash` or `./input/hls` folder.
+2. Each folder inside `./input/dash` or `./input/hls` should contain only one content item.
+3. For HLS content, name the multivariant playlist `main.m3u8` or `manifest.m3u8`.

--- a/libs/cmaf-ham/samples/cmaf-ham-conversion/README.md
+++ b/libs/cmaf-ham/samples/cmaf-ham-conversion/README.md
@@ -7,8 +7,8 @@ When you run `npm run dev`, the CMAF-Ham library creates different versions of t
 ## Steps to run the script
 1. Open a terminal in the **root folder** of the **common-media-library** project.
 2. Run `npm ci` and then `npm run build`.
-3. Go to the sample folder with `cd samples/cmaf-ham-conversion`.
-4. Execute `npm run dev`.
+3. Go to the sample folder with `cd libs/cmaf-ham/samples/cmaf-ham-conversion`.
+4. Execute `node src/index.ts`.
 5. Check that a new `dist/` folder exists with the output files. Each subfolder contains:
    * `ham.json`: A JSON export of the Ham object.
    * `validations.json`: The validation results for each presentation of the content.

--- a/libs/cmaf-ham/src/README.md
+++ b/libs/cmaf-ham/src/README.md
@@ -1,19 +1,19 @@
-# CMAF HAM 
+# CMAF HAM
 
-## Overview 
+## Overview
 
-HLS and DASH stand as the predominant video streaming technologies currently. Consequently, users often encounter challenges such as converting between HLS and DASH, manipulating manifests, and programmatically understanding manifest structures.
+HTTP Live Streaming (HLS) and Dynamic Adaptive Streaming over HTTP (DASH) are the two main video streaming technologies today. Users often need to convert between HLS and DASH, edit manifests, and read manifest structures in code.
 
-The Common Media Application Format (CMAF) for segmented media (ISO/IEC 23000-19) addresses these challenges by defining a universal format based on ISOBMFF. Additionally, it introduces the Hypothetical Application Model, a framework illustrating the practical usage of CMAF segments and fragments in streaming applications. This project is inspired by the principles outlined in the CMAF standard and the [Hypothetical Application Model] ([Hypothetical Application Model](https://cdn.cta.tech/cta/media/media/resources/standards/cta-5005-a-final.pdf)).
+The Common Media Application Format (CMAF) for segmented media (ISO/IEC 23000-19) defines one universal format for both. The format is based on the ISO Base Media File Format (ISO BMFF). CMAF also defines the Hypothetical Application Model (HAM), a framework that shows how streaming applications use CMAF segments and fragments. This project is based on the principles of the CMAF standard and the [Hypothetical Application Model](https://cdn.cta.tech/cta/media/media/resources/standards/cta-5005-a-final.pdf).
 
-## Features 
+## Features
 
-* Fundamental on-demand conversion between [HLS] and [DASH] manifests, covering transformations such as HLS to HAM, HAM to HLS, DASH to HAM, and HAM to DASH.
-* Elementary Media Presentation querying functionality.
+* On-demand conversion between HLS and DASH manifests through HAM: HLS to HAM, HAM to HLS, DASH to HAM, and HAM to DASH.
+* Elementary Media Presentation queries.
 
-## Usage 
+## Usage
 
-Here's a simple demonstration illustrating how to use the features of the CMAF HAM module in TypeScript:
+The examples show how to use the CMAF HAM module in TypeScript:
 
 ```typescript
 import {
@@ -40,16 +40,16 @@ const dashManifest = hamToDash(hamObject); // Convert HAM object to DASH manifes
 
 ```
 
-This example showcases how to leverage functionalities such as manifest conversion, presentation querying, and track validation offered by the CMAF HAM library in TypeScript.
+The library also offers presentation queries and track validation.
 
 ## Documentation
 
-For detailed documentation, including API reference and usage examples, please refer to the API documentation.
+For the API reference and more examples, read the API documentation.
 
 ## Contribution
 
-Contributions are welcome! If you encounter any bugs, have feature requests, or want to contribute code improvements, feel free to open an issue or submit a pull request.
+Contributions are welcome. To report a bug, request a feature, or contribute code, open an issue or a pull request.
 
 ## License
 
-This library is licensed under the Apache 2.0 License. You are free to use, modify, and distribute it for both commercial and non-commercial purposes. See the LICENSE file for details.
+This library uses the Apache 2.0 License. You may use, modify, and distribute it for commercial and non-commercial purposes. See the LICENSE file for details.

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to
 
 - `CmcdDecodeOptions.useSymbol` — controls how RFC 8941 token values are represented by `decodeCmcd` (and `fromCmcdQuery`/`fromCmcdHeaders`/`fromCmcdUrl`). When omitted, tokens reduce to plain strings as before, which cannot be told apart from string values on re-encoding. `true` decodes tokens as registry `Symbol`s, `false` as `SfToken` instances; either preserved representation re-encodes as a bare token, making the codec symmetric: `encodeCmcd(decodeCmcd(s, { useSymbol: false }))` returns the input bytes. `CmcdReporter` decodes provenance snapshots this way, so request-time token values keep their wire type on `RESPONSE_RECEIVED` reports
 
+### Changed
+
+- README: the `CmcdReportRecorder` paragraph is rewritten for readers who do not read English as a first language. The code examples are unchanged.
+
 ### Fixed
 
 - `decodeCmcd` no longer discards RFC 8941 parameters carried on a dictionary member or an inner list (`com.example-x=1;p=2`, `tab=(3000);p=2`): a params-bearing member now decodes as an `SfItem` with its value reduced as usual, matching how inner-list members with params were already preserved. The value inside a params-bearing item is also reduced consistently now (previously an inner token leaked as a raw `Symbol` instead of a string). Affects `decodeCmcd`, `fromCmcdQuery`, `fromCmcdHeaders`, and `fromCmcdUrl`

--- a/libs/cmcd/README.md
+++ b/libs/cmcd/README.md
@@ -26,11 +26,11 @@ const result = encodeCmcd(input, options);
 
 ## Testing CMCD output with `CmcdReportRecorder`
 
-`CmcdReportRecorder` captures CMCD-bearing requests emitted by a
-player under test, regardless of whether the player uses
-`XMLHttpRequest` or `fetch`. Each capture is normalized to
+`CmcdReportRecorder` captures the CMCD requests that a player under test
+sends, whether through `XMLHttpRequest` or `fetch`. Each capture is
+normalized to
 [`HttpRequest`](https://github.com/streaming-video-technology-alliance/common-media-library/tree/main/libs/utils),
-so tests work identically across transports.
+so tests work the same for both transports.
 
 ````ts
 import { CmcdReportRecorder, validateCmcdRequest } from '@svta/cml-cmcd'

--- a/libs/cta/CHANGELOG.md
+++ b/libs/cta/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- README: the description is rewritten for readers who do not read English as a first language. A typo is fixed.
+
 ## [1.0.8] - 2026-07-28
 
 ### Changed

--- a/libs/cta/README.md
+++ b/libs/cta/README.md
@@ -1,6 +1,6 @@
 # @svta/cml-cta
 
-Common functionality for CTA standards including CMCD, CMSD, and CTA-608/CEA-608. This is a utility pacakge and shouldn't be used directly. See `@svta/cml-cmcd`, `@svta/cml-cmsd` and `@svta/cml-608`.
+Common functionality for Consumer Technology Association (CTA) standards, including CMCD, CMSD, and CTA-608/CEA-608. Do not use this utility package directly. Use `@svta/cml-cmcd`, `@svta/cml-cmsd`, or `@svta/cml-608`.
 
 ## Installation
 
@@ -10,4 +10,4 @@ npm i @svta/cml-cta
 
 ## Usage
 
-This is a shared utility library for working with CTA standards.
+No direct usage. See the packages listed above.

--- a/libs/dash/CHANGELOG.md
+++ b/libs/dash/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- README: the description defines DASH at first use.
+
 ## [1.0.8] - 2026-07-28
 
 ### Changed

--- a/libs/dash/README.md
+++ b/libs/dash/README.md
@@ -1,6 +1,6 @@
 # @svta/cml-dash
 
-DASH manifest parsing functionality.
+Dynamic Adaptive Streaming over HTTP (DASH) manifest parsing functionality.
 
 ## Installation
 

--- a/libs/iso-bmff/CHANGELOG.md
+++ b/libs/iso-bmff/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- README and the Reading Boxes, Writing Boxes, and Utilities guides: the prose is rewritten for readers who do not read English as a first language. The code examples are unchanged.
+
 ## [1.0.5] - 2026-08-11
 
 ### Fixed

--- a/libs/iso-bmff/README.md
+++ b/libs/iso-bmff/README.md
@@ -1,6 +1,6 @@
 # @svta/cml-iso-bmff
 
-ISO Base Media File Format (ISOBMFF) parsing functionality.
+ISO Base Media File Format (ISO BMFF) parsing.
 
 ## Installation
 
@@ -12,4 +12,4 @@ npm i @svta/cml-iso-bmff
 
 - [Reading boxes](docs/reading-boxes.md) - Parse ISO BMFF boxes from a buffer
 - [Writing boxes](docs/writing-boxes.md) - Write boxes to byte arrays or streams
-- [Utilities](docs/utilities.md) - Traversing boxes and type guards
+- [Utilities](docs/utilities.md) - Traverse boxes and type guards

--- a/libs/iso-bmff/docs/reading-boxes.md
+++ b/libs/iso-bmff/docs/reading-boxes.md
@@ -5,14 +5,14 @@ description: Parse ISO BMFF boxes from a buffer
 
 # Reading Boxes
 
-Boxes can be read from a buffer using the `readIsoBoxes` function which returns an array of parsed boxes. By default the function will only read the box header. To parse the box content, a reader function must be provided for that box type.
+The `readIsoBoxes` function reads boxes from a buffer and returns an array of parsed boxes. By default, the function reads only the box header. To parse the content of a box, provide a reader function for that box type.
 
 > [!NOTE]
-> Container boxes are automatically parsed and do not need a reader function. All known container types are listed in the `CONTAINERS` constant.
+> The function parses container boxes automatically, so they do not need a reader function. The `CONTAINERS` constant lists all known container types.
 
 ## Using default config
 
-If tree shaking isn't a concern, use `defaultReaderConfig()` to get a configuration with all available readers pre-configured:
+If tree shaking is not a concern, use `defaultReaderConfig()`. It returns a configuration with every available reader:
 
 ```typescript
 import { defaultReaderConfig, readIsoBoxes } from "@svta/cml-iso-bmff";

--- a/libs/iso-bmff/docs/utilities.md
+++ b/libs/iso-bmff/docs/utilities.md
@@ -7,7 +7,7 @@ description: Traversing boxes and type guards
 
 ## Traversing boxes
 
-The `traverseIsoBoxes` function can be used to traverse box iterators. It returns a generator of boxes. The function takes an iterable of boxes, and optional arguments for depth-first traversal and maximum depth. By default the function will traverse the boxes depth-first with a maximum depth of infinity. A value of 0 for the maximum depth will only traverse the root boxes.
+The `traverseIsoBoxes` function traverses box iterators and returns a generator of boxes. It takes an iterable of boxes and two optional arguments: depth-first traversal and maximum depth. By default, the function traverses depth-first with a maximum depth of infinity. A maximum depth of 0 traverses only the root boxes.
 
 ```typescript
 import { traverseIsoBoxes } from "@svta/cml-iso-bmff";
@@ -17,9 +17,9 @@ const boxes = traverseIsoBoxes(buffer);
 
 ## Type guards
 
-The library provides type guards for checking if a box is a container or full box. These can be used to narrow the type of a box in TypeScript.
+The library provides type guards that check whether a box is a container box or a full box. These guards narrow the type of a box in TypeScript.
 
-The `isContainer` function can be used to check if a box is a container box.
+`isContainer` checks whether a box is a container box.
 
 ```typescript
 import { isContainer } from "@svta/cml-iso-bmff";
@@ -28,7 +28,7 @@ const box = { type: "meta", boxes: [] };
 const isContainer = isContainer(box);
 ```
 
-The `isFullBox` function can be used to check if a box is a full box.
+`isFullBox` checks whether a box is a full box.
 
 ```typescript
 import { isFullBox } from "@svta/cml-iso-bmff";

--- a/libs/iso-bmff/docs/writing-boxes.md
+++ b/libs/iso-bmff/docs/writing-boxes.md
@@ -5,19 +5,19 @@ description: Write boxes to byte arrays or streams
 
 # Writing Boxes
 
-Boxes can be written to using the `writeIsoBoxes` function. The function takes an array of streamable items and returns an array of `Uint8Array`s. Streamable items include:
+The `writeIsoBoxes` function writes boxes. It takes an array of streamable items and returns an array of `Uint8Array`s. Streamable items include:
 
-- Raw box objects (e.g. `{ type: 'ftyp', majorBrand: 'isom', minorVersion: 1, compatibleBrands: ['isom'] }`)
-- ArrayBufferViews like `Uint8Array` and `DataView` as well as the box structures returned by the `readIsoBoxes` function (they adhere to the `ArrayBufferView` interface).
+- Raw box objects, such as `{ type: 'ftyp', majorBrand: 'isom', minorVersion: 1, compatibleBrands: ['isom'] }`
+- ArrayBufferViews such as `Uint8Array` and `DataView`, and the box structures that `readIsoBoxes` returns. Those structures implement the `ArrayBufferView` interface.
 
-When providing raw box objects, a configuration object must be provided to specify the writers for those box types.
+If you provide raw box objects, also provide a configuration object that names the writers for those box types.
 
 > [!NOTE]
-> Container boxes are automatically written and do not need a writer function. All known container types are listed in the `CONTAINERS` constant.
+> The function writes container boxes automatically, so they do not need a writer function. The `CONTAINERS` constant lists all known container types.
 
 ## Using default config
 
-If tree shaking isn't a concern, use `defaultWriterConfig()` to get a configuration with all available writers pre-configured:
+If tree shaking is not a concern, use `defaultWriterConfig()`. It returns a configuration with every available writer:
 
 ```typescript
 import { defaultWriterConfig, writeIsoBoxes } from "@svta/cml-iso-bmff";
@@ -88,7 +88,7 @@ for (const byteArray of byteArrays) {
 
 ## Streaming boxes
 
-Boxes can also be written to a readable stream using the `createIsoBoxReadableStream` function. This also supports both the default config and specific writers approaches:
+The `createIsoBoxReadableStream` function writes boxes to a readable stream. It supports both the default config and specific writers:
 
 ```typescript
 import {
@@ -120,7 +120,7 @@ readableStream.pipeTo(transport.writable);
 
 ## Type safety
 
-When working with raw box objects in TypeScript, cast the objects to a box type to ensure type safety. This can be done in two ways. Either by using a box type from the library:
+In TypeScript, cast raw box objects to a box type for type safety. There are two ways. The first way uses a box type from the library:
 
 ```typescript
 import type { FileTypeBox } from "@svta/cml-iso-bmff";
@@ -133,7 +133,7 @@ const box: FileTypeBox = {
 };
 ```
 
-Or by using the `as const` operator on the `type` property:
+The second way uses the `as const` operator on the `type` property:
 
 ```typescript
 const box = {
@@ -144,7 +144,7 @@ const box = {
 };
 ```
 
-Box types can also be accessed from `IsoBoxMap` using the box's FourCC:
+You can also get a box type from `IsoBoxMap` with the box's four-character code (FourCC):
 
 ```typescript
 import type { IsoBoxMap } from "@svta/cml-iso-bmff";

--- a/plans/writing-style-compliance/inventory.md
+++ b/plans/writing-style-compliance/inventory.md
@@ -77,3 +77,22 @@ Recorded after the rewrite. Same script, same settings.
 | `.github/PULL_REQUEST_TEMPLATE.md` | 101 | 7 | 14.4 | 1 (14%) | 5.7 | none |
 | `.github/ISSUE_TEMPLATE/bug_report.md` | 82 | 6 | 13.7 | 1 (17%) | 8.7 | none |
 | `.github/ISSUE_TEMPLATE/feature_request.md` | 71 | 6 | 11.8 | 0 (0%) | 8.1 | none |
+
+## After tranche 2
+
+Twelve files changed. The other 13 files, all package READMEs of one or two sentences, already followed the rules and keep their baseline rows. The metrics script merges list items that have no final period into one sentence. So the "Over 25 words" column overstates the count for files with bullet lists. The check script counts 0 sentences over 25 words in every file.
+
+| File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
+|---|---|---|---|---|---|---|
+| `libs/608/README.md` | 149 | 13 | 11.5 | 0 (0%) | 7.6 | none |
+| `libs/608/test/fixtures/README.md` | 149 | 13 | 11.5 | 1 (8%) | 5.1 | none |
+| `libs/c2pa/README.md` | 197 | 10 | 19.7 | 3 (30%) | 10.2 | vs(2) |
+| `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md` | 250 | 27 | 9.3 | 0 (0%) | 4.5 | none |
+| `libs/cmaf-ham/src/README.md` | 205 | 17 | 12.1 | 0 (0%) | 9.0 | none |
+| `libs/cmcd/README.md` | 41 | 3 | 13.7 | 0 (0%) | 5.3 | none |
+| `libs/cta/README.md` | 36 | 5 | 7.2 | 0 (0%) | 6.9 | none |
+| `libs/dash/README.md` | 9 | 1 | 9.0 | 0 (0%) | 16.8 | none |
+| `libs/iso-bmff/README.md` | 35 | 2 | 17.5 | 1 (50%) | 6.1 | none |
+| `libs/iso-bmff/docs/reading-boxes.md` | 93 | 7 | 13.3 | 1 (14%) | 7.0 | none |
+| `libs/iso-bmff/docs/utilities.md` | 95 | 8 | 11.9 | 0 (0%) | 6.6 | none |
+| `libs/iso-bmff/docs/writing-boxes.md` | 192 | 17 | 11.3 | 1 (6%) | 6.1 | none |

--- a/plans/writing-style-compliance/overview.md
+++ b/plans/writing-style-compliance/overview.md
@@ -83,7 +83,8 @@ The readability metrics in `inventory.md` come from a second script that is not 
 
 ## Status
 
-- 2026-09-03: plan written. Tranche 1 rewritten on branch `docs/writing-style-compliance` and rebased onto `main` after #433 merged. PR pending.
+- 2026-09-03: plan written. Tranche 1 rewritten on branch `docs/writing-style-compliance` and rebased onto `main` after #433 merged. PR #434.
+- 2026-09-03: tranche 2 rewritten on branch `docs/writing-style-readmes`, stacked on the tranche 1 branch because #434 was still open. PR pending.
 
 ## Noticed, not changed (tranche 1)
 
@@ -95,3 +96,10 @@ The rewrite kept these statements as they were. Each one may need a separate fix
 - `CONTRIBUTING.md` limits new issues to "a problem with the docs". The sentence comes from the GitHub template.
 - `CONTRIBUTING.md` asks readers to keep the community "approachable and respectable". The GitHub template wording may have meant "respectful".
 - `GOVERNANCE.md` names the "Streaming Video Alliance", the former name of the organization. The file is out of scope.
+
+## Noticed, not changed (tranche 2)
+
+- `libs/cmaf-ham/src/README.md`: the code examples import from `@svta/common-media-library`, a package name that no longer exists. The first example has no comma after `hamToDash`. The Documentation section names the API documentation without a link.
+- `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md`: step 3 says `cd samples/cmaf-ham-conversion` from the repository root. The sample is at `libs/cmaf-ham/samples/cmaf-ham-conversion`.
+- `libs/cmaf-ham/README.md`, `libs/drm/README.md`, and `libs/request/README.md` have an empty Usage code block. `libs/mse/README.md` has a Usage example that imports nothing.
+- Several README examples are not complete. They use identifiers without importing or defining them: `assert` in most examples, `CMSD_STATIC_OBJ` and `SfToken` in `libs/cmsd/README.md`, `id3Data` in `libs/id3/README.md`, and `view`, `samplePos`, `sampleSize`, and `sampleTimeMs` in `libs/608/README.md`.

--- a/plans/writing-style-compliance/overview.md
+++ b/plans/writing-style-compliance/overview.md
@@ -72,7 +72,7 @@ The script prints one PASS or FAIL line per check per file and exits with status
 | links | The set of link targets and bare URLs is the same as in the base version. |
 | shorter | The prose word count did not grow. |
 
-The readability metrics in `inventory.md` come from a second script that is not in the repository. See `inventory.md` for what it measures.
+The readability metrics in `inventory.md` come from a second script that is not in the repository. See `inventory.md` for what it measures. That script excludes heading text from its prose word count. The check script includes heading text, so its shorter check reports higher counts for the same file.
 
 ## Open questions
 
@@ -100,6 +100,5 @@ The rewrite kept these statements as they were. Each one may need a separate fix
 ## Noticed, not changed (tranche 2)
 
 - `libs/cmaf-ham/src/README.md`: the code examples import from `@svta/common-media-library`, a package name that no longer exists. The first example has no comma after `hamToDash`. The Documentation section names the API documentation without a link.
-- `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md`: step 3 says `cd samples/cmaf-ham-conversion` from the repository root. The sample is at `libs/cmaf-ham/samples/cmaf-ham-conversion`.
 - `libs/cmaf-ham/README.md`, `libs/drm/README.md`, and `libs/request/README.md` have an empty Usage code block. `libs/mse/README.md` has a Usage example that imports nothing.
 - Several README examples are not complete. They use identifiers without importing or defining them: `assert` in most examples, `CMSD_STATIC_OBJ` and `SfToken` in `libs/cmsd/README.md`, `id3Data` in `libs/id3/README.md`, and `view`, `samplePos`, `sampleSize`, and `sampleTimeMs` in `libs/608/README.md`.

--- a/plans/writing-style-compliance/steps.md
+++ b/plans/writing-style-compliance/steps.md
@@ -150,14 +150,16 @@ git rebase --onto origin/main 26fd67982 docs/writing-style-compliance
 
 **Known violations at the base:** `libs/608/README.md` has 2 sentences over 25 words and the verbs "carries" and "come from". `libs/c2pa/README.md` has "carries" three times and "vs" twice. `libs/iso-bmff/README.md` has one sentence over 25 words. `libs/608/test/fixtures/README.md` has "carry" twice. `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md` has 2 sentences over 25 words. `libs/iso-bmff/docs/writing-boxes.md` has one "e.g." and one sentence over 25 words. `libs/iso-bmff/docs/reading-boxes.md` has one sentence over 25 words. The other READMEs are one to four sentences and mostly pass already.
 
-- [ ] **Step 1: Create the branch**
+- [x] **Step 1: Create the branch**
 
 ```bash
 git fetch origin
 git checkout -b docs/writing-style-readmes origin/main
 ```
 
-- [ ] **Step 2: Rewrite the 19 package READMEs by the method in `overview.md`**
+Done differently on 2026-09-03: #434 (Task 1) was still open, so the branch was created from the #434 head f848ca616 instead. The checks use `origin/main` as the base, because the `libs/` trees of both commits are identical. Rebase onto `main` after #434 merges.
+
+- [x] **Step 2: Rewrite the 19 package READMEs by the method in `overview.md`**
 
 Code examples do not change. If a code block must change, build first and run the block from the repository root:
 
@@ -211,6 +213,8 @@ git push -u origin docs/writing-style-readmes
 ```
 
 Casey creates the PR with `/create-pr`.
+
+**Outcome (2026-09-03):** twelve files changed. The other 13 files are package READMEs of one or two sentences. They already followed the rules and are unchanged, so their packages have no changelog note. The fixture, sample, and `src/` READMEs are not shipped with a package, so they have no changelog note either. `libs/dash/README.md` grew from 10 to 15 prose words because it now defines DASH. That growth is the one failed check. Every other check passed for every file.
 
 ---
 

--- a/plans/writing-style-compliance/steps.md
+++ b/plans/writing-style-compliance/steps.md
@@ -214,7 +214,7 @@ git push -u origin docs/writing-style-readmes
 
 Casey creates the PR with `/create-pr`.
 
-**Outcome (2026-09-03):** twelve files changed. The other 13 files are package READMEs of one or two sentences. They already followed the rules and are unchanged, so their packages have no changelog note. The fixture, sample, and `src/` READMEs are not shipped with a package, so they have no changelog note either. `libs/dash/README.md` grew from 10 to 15 prose words because it now defines DASH. That growth is the one failed check. Every other check passed for every file.
+**Outcome (2026-09-03):** twelve files changed. The other 13 files are package READMEs of one or two sentences. They already followed the rules and are unchanged, so their packages have no changelog note. The fixture, sample, and `src/` READMEs are not shipped with a package, so they have no changelog note either. `libs/dash/README.md` grew from 4 to 9 prose words because it now defines DASH. That growth is the one failed check. Every other check passed for every file.
 
 ---
 


### PR DESCRIPTION
## Description

Tranche 2 of the writing style compliance plan in `plans/writing-style-compliance/`, which landed with #434. This PR applies the Writing Style rules from `AGENTS.md` to the package READMEs and the short guides under `libs/`.

Twelve of the 25 files in scope changed. The other 13 are one-sentence package READMEs that already followed the rules. Six packages get a changelog note under Unreleased: 608, c2pa, cmcd, cta, dash, and iso-bmff. The fixture, sample, and `src/` READMEs are not shipped, so they get no note. Every code block, table, and link target is byte-identical to `main`.

| Twelve changed files | Before | After |
|---|---|---|
| Prose words | 1,581 | 1,452 |
| Sentences over 25 words | 4 | 0 |
| `libs/608/README.md`, average words per sentence | 19.3 | 11.5 |

One documented exception: `libs/dash/README.md` grew from 4 to 9 prose words because it now defines DASH.

The Copilot review found a wrong path in the sample README. Step 3 now uses `cd libs/cmaf-ham/samples/cmaf-ham-conversion`, and step 4 runs `node src/index.ts`. #441 replaces both steps with one npm command after it fixes the sample script.

This PR is the base of a stack of six. Merge it first.

## Test Plan

- [x] `bash plans/writing-style-compliance/check.sh origin/main <25 files>`: 174 PASS, 1 FAIL (the dash README exception above).
- [x] Markdown only. Build, tests, typecheck, and lint are not affected.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (not applicable: documentation only)
- [x] Docs/guides updated
- [x] Changelog updated

Refs: #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

