### PR TITLE
docs(rfc): apply the writing style rules to the RFC process document

### DIFF
--- a/plans/writing-style-compliance/inventory.md
+++ b/plans/writing-style-compliance/inventory.md
@@ -137,3 +137,5 @@ Only `rfc/README.md` changed. Casey decided on 2026-09-03 that the two merged RF
 | File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
 |---|---|---|---|---|---|---|
 | `rfc/README.md` | 316 | 27 | 11.7 | 2 (7%) | 9.4 | none |
+
+The two sentences over 25 words in this row are not sentences. The metrics script joins list items that have no final period, and `rfc/README.md` has two such lists. The baseline row counts the same two joins plus one real sentence, which the rewrite split. The check script finds no sentence over 25 words in the rewritten file.

--- a/plans/writing-style-compliance/inventory.md
+++ b/plans/writing-style-compliance/inventory.md
@@ -129,3 +129,11 @@ All five files changed. Frontmatter and the shell injection lines are byte-ident
 | `.claude/skills/code-review/SKILL.md` | 100 | 12 | 8.3 | 0 (0%) | 6.2 | bar(1) |
 | `.claude/skills/create-pr/SKILL.md` | 683 | 65 | 10.5 | 3 (5%) | 5.3 | none |
 | `.claude/skills/pr-feedback/SKILL.md` | 788 | 82 | 9.6 | 2 (2%) | 5.8 | none |
+
+## After tranche 6
+
+Only `rfc/README.md` changed. Casey decided on 2026-09-03 that the two merged RFC bodies stay as records.
+
+| File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
+|---|---|---|---|---|---|---|
+| `rfc/README.md` | 316 | 27 | 11.7 | 2 (7%) | 9.4 | none |

--- a/plans/writing-style-compliance/overview.md
+++ b/plans/writing-style-compliance/overview.md
@@ -76,7 +76,7 @@ The readability metrics in `inventory.md` come from a second script that is not 
 
 ## Open questions
 
-1. Merged RFCs (tranche 6). Rewrite 12,000 words of accepted proposals, or apply the rules only to `rfc/README.md` and to new RFCs? Recommendation: `rfc/README.md` only.
+1. Merged RFCs (tranche 6). Rewrite 12,000 words of accepted proposals, or apply the rules only to `rfc/README.md` and to new RFCs? Resolved on 2026-09-03: `rfc/README.md` only. The two merged RFC bodies stay as records, and new RFCs follow the rules.
 2. TSDoc. The rules name TSDoc, and the API reference is built from it. A pass would touch most source files and regenerate every `api.md`. Recommendation: a separate plan, one package per PR, after the markdown tranches.
 3. Records. This plan leaves `plans/` and changelog history unchanged. Confirm.
 4. Enforcement. A lint step could fail when prose in a markdown file contains an em dash, a semicolon, or "e.g.". The check script is a starting point. Should it become `scripts/checkProse.ts` and run in `npm run lint`? A `.ts` file under `plans/` is not an option, because `eslint .` and the root `tsc --noEmit` include it.
@@ -88,6 +88,7 @@ The readability metrics in `inventory.md` come from a second script that is not 
 - 2026-09-03: tranche 3 rewritten on branch `docs/writing-style-cmcd-guides`, stacked on the tranche 2 branch. PR pending.
 - 2026-09-03: tranche 4 rewritten on branch `docs/writing-style-c2pa-guides`, stacked on the tranche 3 branch. PR pending.
 - 2026-09-03: tranche 5 rewritten on branch `docs/writing-style-agent-instructions`, stacked on the tranche 4 branch. PR pending.
+- 2026-09-03: tranche 6 rewritten on branch `docs/writing-style-rfc`, stacked on the tranche 5 branch, `rfc/README.md` only. PR pending. All six tranches are done.
 
 ## Noticed, not changed (tranche 1)
 
@@ -125,3 +126,7 @@ Tables and code blocks are frozen in this pass, so these items stay as they are.
 
 - `.claude/skills/create-pr/SKILL.md` names one model in the required `Co-Authored-By` trailer. `AGENTS.md` asks for the agent name and model of the agent that wrote the commit. The skill text is a fact about the skill, so this pass left it.
 - `.claude/agents/code-reviewer.md` uses "DX" inside the frozen report template. Code blocks are frozen in this pass.
+
+## Noticed, not changed (tranche 6)
+
+- `rfc/README.md`: the directory tree in the Directory Structure section contains a semicolon in a comment. Code blocks are frozen in this pass.

--- a/plans/writing-style-compliance/steps.md
+++ b/plans/writing-style-compliance/steps.md
@@ -124,7 +124,7 @@ git add plans/writing-style-compliance/inventory.md
 git commit -s -m "docs(plans): record the tranche 1 metrics"
 ```
 
-- [ ] **Step 13: Push and hand over**
+- [x] **Step 13: Push and hand over**
 
 ```bash
 git push -u origin docs/writing-style-compliance
@@ -396,14 +396,16 @@ Casey creates the PR with `/create-pr`.
 
 **Known violations at the base:** `rfc/README.md` has 3 sentences over 25 words and the verbs "settle" and "shape". The two RFC bodies average 20.4 and 23.3 words per sentence, with 30 and 40 percent of sentences over 25 words. Both exceed 1,500 words and need a Terms list.
 
-- [ ] **Step 1: Create the branch**
+- [x] **Step 1: Create the branch**
 
 ```bash
 git fetch origin
 git checkout -b docs/writing-style-rfc origin/main
 ```
 
-- [ ] **Step 2: Rewrite `rfc/README.md`**
+Done differently on 2026-09-03: tranches 2 to 5 had no PR yet, so the branch was created from the tranche 5 head 0742f7a88 instead. The checks use `origin/main` as the base, because `rfc/README.md` is identical at both commits. Rebase onto `main` after tranche 5 merges.
+
+- [x] **Step 2: Rewrite `rfc/README.md`**
 
 - [x] **Step 3: Check**
 
@@ -420,7 +422,7 @@ git add rfc/README.md
 git commit -s -m "docs(rfc): apply the writing style rules to the RFC process document"
 ```
 
-- [x] **Step 5: If approved, rewrite one RFC body per commit with a Terms list, check each, and commit each**
+- [ ] **Step 5: If approved, rewrite one RFC body per commit with a Terms list, check each, and commit each**. Not approved: Casey decided on 2026-09-03 that the two merged RFC bodies stay as records.
 
 ```bash
 bash plans/writing-style-compliance/check.sh origin/main rfc/cmcd-reporter-middleware.md
@@ -436,3 +438,5 @@ git push -u origin docs/writing-style-rfc
 ```
 
 Casey creates the PR with `/create-pr`.
+
+**Outcome (2026-09-03):** `rfc/README.md` changed, and every check passed. RFC, PR, and DCO are defined at first use. The idioms about buy-in, living with an addition, and a design that won are replaced with literal wording. The two merged RFC bodies are unchanged by decision. This task completes the plan.

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -1,19 +1,19 @@
 # RFCs
 
-Proposals that need community buy-in before proceeding.
+Requests for comments (RFCs): proposals that need community agreement first.
 
 ## What Belongs Here
 
 - Changes to the public API surface of any package
 - New packages or significant changes to core architecture
 - Spec-interpretation decisions that affect wire behavior
-- Anything that needs alignment from adopters or maintainers before implementation
+- Anything that needs agreement from adopters or maintainers before implementation
 
 **Use a plan instead** (`plans/<feature-name>/`) for implementation details and design-session artifacts you own.
 
 **Skip both for:** bug fixes, internal changes with no public API surface, and documentation updates.
 
-The public-API rule above takes precedence over size. A small addition still needs an RFC if it lands in a package's public API surface, because adopters live with it and we cannot take it back without a breaking change. "Small" is not an exception; "not public" is.
+The public API rule above takes precedence over size. A small addition to a package's public API surface still needs an RFC. Adopters depend on it, and removing it is a breaking change. "Small" is not an exception. "Not public" is.
 
 ## File Format
 
@@ -37,17 +37,17 @@ implementation-plan: plans/<feature-name>/
 
 ## Suggested Outline
 
-RFCs here are usually API design proposals. Structure them for two readers, adopters first and maintainers second:
+RFCs here are usually API design proposals. Structure them for adopters first and maintainers second:
 
 - **Summary**: the proposal in one paragraph, with a code sample if it fits.
 - **Motivation**: the problem, who has it, and why existing extension points cannot solve it.
 - **Guide-level explanation**: the feature as an adopter experiences it, with complete, runnable examples.
 - **Reference-level explanation**: types, semantics, edge-case behavior, and interactions with existing features, in enough detail to implement from.
 - **Drawbacks**: honest costs.
-- **Rationale and alternatives**: what else was considered and why this shape won.
+- **Rationale and alternatives**: what else was considered and why this design was chosen.
 - **Prior art**: precedent in other players and libraries.
-- **Unresolved questions**: what community review should settle.
-- **Future possibilities**: follow-ups that are deliberately out of scope.
+- **Unresolved questions**: what community review should decide.
+- **Future possibilities**: follow-ups that are out of scope on purpose.
 - **Final Decision**: completed after review (decision, rationale, date).
 
 Sections scale to the proposal. Small RFCs can drop what they do not need.
@@ -74,8 +74,8 @@ rfc/
 ## Contributing an RFC
 
 1. Create a branch: `rfc/<feature-name>`
-2. Open a PR titled `[RFC] Feature Name`; community review happens as PR comments
+2. Open a pull request (PR) titled `[RFC] Feature Name`. Community review happens as PR comments
 3. Record the outcome in the RFC's Final Decision section and update `status`
 4. Squash-merge with a `docs(rfc): <feature name>` commit
 
-All commits require DCO sign-off (`git commit -s`), as everywhere in this repo.
+All commits require a Developer Certificate of Origin (DCO) sign-off (`git commit -s`).

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -74,7 +74,7 @@ rfc/
 ## Contributing an RFC
 
 1. Create a branch: `rfc/<feature-name>`
-2. Open a pull request (PR) titled `[RFC] Feature Name`. Community review happens as PR comments
+2. Open a pull request (PR) titled `[RFC] Feature Name`, where community review happens as PR comments
 3. Record the outcome in the RFC's Final Decision section and update `status`
 4. Squash-merge with a `docs(rfc): <feature name>` commit
 


### PR DESCRIPTION
## Description

Tranche 6 of the writing style compliance plan in `plans/writing-style-compliance/`. This PR applies the Writing Style rules from `AGENTS.md` to `rfc/README.md`, the RFC process document.

Semicolons are removed, the one sentence over 25 words is split, and the idioms about buy-in, living with an addition, and a design that won are replaced with literal wording. RFC, PR, and DCO are defined at first use. Headings, code blocks, and the status table are unchanged. The two merged RFC bodies stay as records by decision, which closes open question 1 of the plan.

| One file | Before | After |
|---|---|---|
| Prose words | 357 | 357 |
| Sentences over 25 words (check script) | 1 | 0 |

The metrics script in the plan inventory reports 3 and 2 sentences over 25 words for the same file. It joins list items that have no final period into one sentence, and the file has two such lists. The inventory states this next to the row.

This PR was stacked on #439, which merged on 2026-09-03. The branch is rebased onto `main`, so the diff shows only these two commits.
## Test Plan

- [x] `bash plans/writing-style-compliance/check.sh origin/main rfc/README.md`: 7 PASS, 0 FAIL.
- [x] Markdown only. Build, tests, typecheck, and lint are not affected.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (not applicable: documentation only)
- [x] Docs/guides updated
- [ ] Changelog updated (not applicable: no package change)

Refs: #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)



