### PR TITLE
docs(agents): drop the abbreviation and Terms list rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,10 @@ CML collaborators and adopters live in many countries. Many of them do not read 
 
 - One idea per sentence. Keep sentences under 20 words and split any sentence over 25. No semicolons (;) and no em dashes (—).
 - Active voice and simple tenses (present, past, future). Write instructions in the imperative with the condition first: "If the build fails, read the log."
-- One name per thing for the whole document, never a synonym for variety. Give a document over about 1,500 words a short Terms list near the top.
+- One name per thing for the whole document, never a synonym for variety.
 - No idioms, metaphors, or figures of speech. If a phrase cannot be translated word for word, replace it.
 - Prefer one verb to a phrasal verb ("configure", not "set up") and literal verbs for facts ("the table shows", not "the table carries").
-- Define every abbreviation and term of art once, at first use: MPD, HAM, GC, p95, post-order. Do not use "e.g.", "i.e.", or "vs".
+- Do not use "e.g.", "i.e.", or "vs".
 - Give every pronoun a visible noun in the same or previous sentence: "this check", not "this".
 - At most three nouns in a row. Break longer strings with prepositions.
 - Keep the author's hedges. "May have failed" does not become "failed". Never add a fact the source did not state.


### PR DESCRIPTION
## Description

The Writing Style section of `AGENTS.md` asked writers to define every abbreviation at first use, and to give every document over about 1,500 words a Terms list. This PR removes both rules. Video developers know the abbreviations in this repository, such as HLS, DASH, CMCD, and CTA. A reader who does not can search for them. The definition rule also made Copilot flag specification identifiers such as CTA-5004-B and RFC 8941 in #437.

Two sentences stay as their own bullets: one name per thing for the whole document, and no "e.g.", "i.e.", or "vs".

After #437 to #441 merge, one final PR removes the definitions and the Terms table that the two rules added to the documents.

## Test Plan

- [x] `bash plans/writing-style-compliance/check.sh origin/main AGENTS.md`: chars, length, abbrev, blocks, links, and shorter pass. The numbers check reports the removed tokens 1,500 and p95, which is the intended change.
- [x] Markdown only. Build, tests, typecheck, and lint are not affected.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (not applicable: documentation only)
- [x] Docs/guides updated
- [ ] Changelog updated (not applicable: `AGENTS.md` is not part of a package)

Refs: #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
