### PR TITLE
docs: remove the abbreviation definitions that the writing style pass added

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -75,7 +75,7 @@ Video players consume this library. Every unnecessary byte costs end users.
 - **No semicolons**: The project uses no-semicolon style.
 - **Single quotes**: Use single quotes for strings, with `avoidEscape: true`.
 - **Tabs for indentation**: The project uses tabs.
-- **ECMAScript modules (ESM) only**: `"type": "module"`. No CommonJS patterns.
+- **ESM only**: `"type": "module"`. No CommonJS patterns.
 - **File extensions in imports**: Use `.ts` extensions in source imports, such as `import { foo } from './foo.ts'`.
 - **Peer dependencies**: Cross-package imports should be declared as `peerDependencies` with `"*"` version.
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: [base branch]
 
 # Create Pull Request
 
-Validate that tests and documentation pass, then create a well-formatted GitHub pull request (PR) for the current branch.
+Validate that tests and documentation pass, then create a well-formatted GitHub PR for the current branch.
 
 ## Context
 
@@ -46,7 +46,7 @@ Follow these steps in strict order. Do NOT skip ahead.
 - Verify the current branch is NOT `main`. If it is, stop and tell the user to create a feature branch first.
 - If a PR already exists for this branch, inform the user and ask whether to update the existing PR description or stop.
 - Ensure all changes are committed. If not, inform the user and stop.
-- **Developer Certificate of Origin (DCO) sign-off check**: Verify that every commit on this branch has a `Signed-off-by:` line:
+- **DCO sign-off check**: Verify that every commit on this branch has a `Signed-off-by:` line:
 
 ```bash
 git log main..HEAD --format="%h %s" --no-merges | while read hash rest; do

--- a/.claude/skills/pr-feedback/SKILL.md
+++ b/.claude/skills/pr-feedback/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: [PR number]
 
 # Resolve PR Review Feedback
 
-Fetch all unresolved review comments from the GitHub pull request (PR) of the current branch. Evaluate their validity, plan fixes, and implement them after user approval.
+Fetch all unresolved review comments from the GitHub PR for the current branch. Evaluate their validity, plan fixes, and implement them after user approval.
 
 ## Context
 
@@ -145,7 +145,7 @@ After approval:
 ### Step 6: Commit and push
 
 1. Stage the changed files. Be specific, and do not use `git add -A`.
-2. Create a commit with a Conventional Commits message and a Developer Certificate of Origin (DCO) sign-off (`git commit -s`).
+2. Create a commit with a Conventional Commits message and a DCO sign-off (`git commit -s`).
 3. Push to the current branch: `git push`
 
 **Ask the user for confirmation before pushing.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Common Media Library (CML) is a collection of TypeScript libraries for web video
 
 The strategic goal is **widespread adoption**. Evaluate every decision against these priorities, in order:
 
-1. **Performance**: Avoid unnecessary runtime overhead, memory leaks, and excessive garbage collection (GC). This code runs on every video playback.
+1. **Performance**: Avoid unnecessary runtime overhead, memory leaks, and excessive GC. This code runs on every video playback.
 2. **Tree-shakeability**: Adopters' final bundle size is what matters. Adopters must not receive code they do not import.
 3. **Developer experience**: Correct usage should be obvious. Incorrect usage should fail at compile time.
 4. **Documentation quality**: Adopters evaluate libraries by their docs before reading source code.
@@ -23,7 +23,7 @@ The strategic goal is **widespread adoption**. Evaluate every decision against t
 - `npm run build -w libs/<package>`: Build a package. The root `npm run build` builds every package in dependency order.
 - `npm run typecheck`: Run the typechecker
 - `npm test -w libs/<package>`: Run the tests for a package. Build first: the tests import the bundled `dist/` output of the package and its workspace dependencies.
-- `npm test`: Full validation at the root. It runs lint, build all, typecheck, then every package's tests. The pull request (PR) checks run this command.
+- `npm test`: Full validation at the root. It runs lint, build all, typecheck, then every package's tests. The PR checks run this command.
 - `npm run format`: Run the linter with auto-fix
 - `npm run ver <package> <version>`: Bump one package version during release prep. `<package>` is the folder name without the `libs/` prefix. The command updates `package.json` and inserts the new version section and compare links in `CHANGELOG.md`.
 - `npm run prepare-release`: Prepare a release. The command detects packages whose `package.json` version differs from the published npm version. It then cascades patch bumps, with changelog entries, to the packages that depend on them.
@@ -46,7 +46,7 @@ APIs are the product. Design them so that the easy way is the correct way:
 - Bump versions only in dedicated release-prep PRs, with `npm run ver` and then `npm run prepare-release` (see Build Commands).
 - Avoid breaking changes. If one is unavoidable, provide migration guidance in the changelog and the docs.
 - Save plans and design-session artifacts in `plans/<feature-name>/`, where the folder name is the feature or issue. Save each part of the plan, such as steps or architecture, in its own file: `plans/<feature-name>/steps.md`. Do not use `docs/` for planning documents.
-- Proposals that need community agreement are requests for comments (RFCs), not plans: public API changes, new packages, and significant architecture changes. Save an RFC as `rfc/<feature-name>.md` and follow the process in `rfc/README.md`.
+- Proposals that need community agreement are RFCs, not plans: public API changes, new packages, and significant architecture changes. Save an RFC as `rfc/<feature-name>.md` and follow the process in `rfc/README.md`.
 
 ## Documentation
 
@@ -75,7 +75,7 @@ CML collaborators and adopters live in many countries. Many of them do not read 
 
 ## Git Commit Guidelines
 
-- **Always use `git commit -s`** to add the Developer Certificate of Origin (DCO) sign-off. Every commit must have this sign-off.
+- **Always use `git commit -s`** to add the DCO sign-off. Every commit must have this sign-off.
 - Follow the Conventional Commits format: `feat:`, `fix:`, `refactor:`, `chore:`, and the other types.
 - **Never commit directly to `main`**, even for docs or specs. All work goes on a feature branch and merges through a PR. For issue-driven work, name the branch `issue/<number>-<short-kebab-slug>`.
 - For AI-assisted commits, include a `Co-Authored-By: <agent-name> <model> <noreply@anthropic.com>` trailer in the commit body.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing to the Common Media Library.
 
 Read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approachable and respectful.
 
-This guide gives an overview of the contribution workflow: opening an issue, creating a pull request (PR), review, and merge.
+This guide gives an overview of the contribution workflow: opening an issue, creating a PR, review, and merge.
 
 ## Getting started
 
@@ -38,7 +38,7 @@ Look through our [existing issues](https://github.com/streaming-video-technology
 ### Commit your update
 
 > **Warning**
-> This library requires a Developer Certificate of Origin (DCO) sign-off on every commit. See https://github.com/apps/dco for more information.
+> This library requires a DCO sign-off on every commit. See https://github.com/apps/dco for more information.
 
 1. Run `npm run format` to format the code before committing.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you need help with the Common Media Library, or if you want to talk with othe
 
 ## Contributing
 
-The Common Media Library is free and open source. We welcome help of any kind: fixing bugs, improving documentation, or suggesting new features. Read the [contributing guide](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/CONTRIBUTING.md) for details. The [Streaming Video Technology Alliance (SVTA)](https://www.svta.org) Players and Playback working group oversees contributions and project decisions.
+The Common Media Library is free and open source. We welcome help of any kind: fixing bugs, improving documentation, or suggesting new features. Read the [contributing guide](https://github.com/streaming-video-technology-alliance/common-media-library/blob/main/CONTRIBUTING.md) for details. The [SVTA](https://www.svta.org) Players and Playback working group oversees contributions and project decisions.
 
 ## Code of Conduct
 

--- a/SCOPING.md
+++ b/SCOPING.md
@@ -25,7 +25,7 @@ Maintain a modern, modular JavaScript utility library for media playback. To ach
 ## Project Scope
 
 The initial scope of the Common Media Library will cover the following functionality:
-- Software development kits (SDKs) for standards-based media player features, such as:
+- SDKs for standards-based media player features, such as:
   - Common Media Client Data (CMCD) encoding / decoding
   - Common Media Server Data (CMSD) encoding / decoding
   - ID3 tag parsing 
@@ -50,7 +50,7 @@ The library will use the Apache 2.0 license. When applicable, a `NOTICE.md` file
 
 ### Source Code
 
-The source code will be maintained in a public GitHub repository under the `streaming-video-technology-alliance` organization. Changes are submitted as pull requests to the repository. Every pull request needs approval from at least two code reviewers approved by the Streaming Video Technology Alliance (SVTA). A reviewer is an SVTA member or a subject matter expert.
+The source code will be maintained in a public GitHub repository under the `streaming-video-technology-alliance` organization. Changes are submitted as pull requests to the repository. Every pull request needs approval from at least two code reviewers approved by the SVTA. A reviewer is an SVTA member or a subject matter expert.
 
 
 ### Documentation

--- a/libs/608/README.md
+++ b/libs/608/README.md
@@ -18,8 +18,7 @@ import { CaptionScreen, Row } from "@svta/cml-608";
 
 CTA-608 captions are embedded in the video elementary stream as an ATSC A/53 `cc_data()`
 payload. Only the envelope around the payload differs by codec. The envelope is either a
-supplemental enhancement information (SEI) message in a network abstraction layer (NAL)
-unit, or an open bitstream unit (OBU). Choose the extractor that matches the sample entry
+SEI message in a NAL unit, or an OBU. Choose the extractor that matches the sample entry
 type:
 
 | Sample entry            | Envelope                          | Extractor                          |

--- a/libs/608/test/fixtures/README.md
+++ b/libs/608/test/fixtures/README.md
@@ -2,13 +2,12 @@
 
 ## `608_av1.mp4`
 
-A real, decodable AV1 fragmented mp4 with CTA-608 captions in `metadata_itu_t_t35` open
-bitstream units (OBUs): 256x144, 30 fps, 40 frames, Main profile (`av01.0.00M.08`), one
-fragment.
+A real, decodable AV1 fragmented mp4 with CTA-608 captions in `metadata_itu_t_t35` OBUs:
+256x144, 30 fps, 40 frames, Main profile (`av01.0.00M.08`), one fragment.
 
 The caption is `HELLO WORLD` as a pop-on on row 15, with each control code doubled.
 Frames 0-13 contain 14 field 1 byte pairs. Frames 30-31 contain `EDM`. One pair per frame
-is what a Scenarist Closed Caption (SCC) source specifies.
+is what an SCC source specifies.
 
 Regenerate in two steps. First, encode the clean AV1 bitstream with `+bitexact` for a
 byte-reproducible encode:
@@ -42,6 +41,6 @@ go608-inject -i av01-clean.mp4 -sub hello.scc -o 608_av1.mp4 -fps 30
 
 ## `608_h264.m4s` and `608_h265.m4s`
 
-Pre-existing fixtures with captions in `itu_t_t35` supplemental enhancement information
-(SEI) messages, on both fields. One frame's `cc_data()` packs all byte pairs of a caption.
+Pre-existing fixtures with captions in `itu_t_t35` SEI messages, on both fields. One frame's
+`cc_data()` packs all byte pairs of a caption.
 Their provenance is not recorded.

--- a/libs/c2pa/CHANGELOG.md
+++ b/libs/c2pa/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to
 
 ### Changed
 
-- README: the prose is rewritten for readers who do not read English as a first language. BMFF, COSE, EMSG, VOD, and JUMBF are defined at first use. The code examples are unchanged.
-- Validation guides (Manifest Box, VOD Merkle, VSI/EMSG, and Results and Error Codes): the prose is rewritten for readers who do not read English as a first language. BMFF, COSE, EMSG, VOD, and Merkle tree are defined at first use. The code examples and tables are unchanged.
+- README: the prose is rewritten for readers who do not read English as a first language. The code examples are unchanged.
+- Validation guides (Manifest Box, VOD Merkle, VSI/EMSG, and Results and Error Codes): the prose is rewritten for readers who do not read English as a first language. Merkle tree is defined at first use. The code examples and tables are unchanged.
 - README: the usage examples are complete. The segment URLs are function parameters.
-- Validation guides: the tables define DER and JWK, empty cells no longer use an em dash, and a code comment no longer uses an em dash.
+- Validation guides: empty table cells no longer use an em dash, and a code comment no longer uses an em dash.
 
 
 ## [1.1.2] - 2026-08-11

--- a/libs/c2pa/README.md
+++ b/libs/c2pa/README.md
@@ -1,12 +1,12 @@
 # @svta/cml-c2pa
 
-C2PA (Coalition for Content Provenance and Authenticity) live video validation for ISO Base Media File Format (BMFF) and MP4 containers.
+C2PA (Coalition for Content Provenance and Authenticity) live video validation for BMFF and MP4 containers.
 
 Supported C2PA segment validation methods:
 
-- **§19.3 Per-segment C2PA Manifest Box**: each segment embeds a full C2PA manifest with a CBOR Object Signing and Encryption (COSE) signature
-- **§19.4 Verifiable Segment Info (VSI/EMSG)**: the init segment contains the manifest and the session keys. Each media segment contains a small signed event message (EMSG) box
-- **§15.12.2 / §18.6 VOD Merkle**: for video on demand (VOD) assets in fragmented MP4, the init manifest stores one Merkle tree row per track. Each media segment contains its own leaf hash and proof
+- **§19.3 Per-segment C2PA Manifest Box**: each segment embeds a full C2PA manifest with a COSE signature
+- **§19.4 Verifiable Segment Info (VSI/EMSG)**: the init segment contains the manifest and the session keys. Each media segment contains a small signed EMSG box
+- **§15.12.2 / §18.6 VOD Merkle**: for VOD assets in fragmented MP4, the init manifest stores one Merkle tree row per track. Each media segment contains its own leaf hash and proof
 
 
 ## Installation

--- a/libs/c2pa/docs/manifest-box-validation.md
+++ b/libs/c2pa/docs/manifest-box-validation.md
@@ -5,13 +5,13 @@ description: Validate live streams using per-segment C2PA Manifest Boxes (C2PA s
 
 # Manifest Box Validation
 
-The Manifest Box method embeds a full C2PA manifest in each media segment, as section 19.3 of the C2PA specification defines. Each segment is self-contained, with its own CBOR Object Signing and Encryption (COSE) signature, so it needs no init segment and no session keys.
+The Manifest Box method embeds a full C2PA manifest in each media segment, as section 19.3 of the C2PA specification defines. Each segment is self-contained, with its own COSE signature, so it needs no init segment and no session keys.
 
 Manifest ID chaining verifies the continuity between segments. See Manifest ID Chaining below.
 
 ## Overview
 
-Unlike the [VSI/EMSG method](vsi-validation.md), the Manifest Box method needs no separate init segment validation step. One function, `validateC2paManifestBoxSegment`, does everything: manifest parsing, signature verification, ISO Base Media File Format (BMFF) hash validation, and continuity checks.
+Unlike the [VSI/EMSG method](vsi-validation.md), the Manifest Box method needs no separate init segment validation step. One function, `validateC2paManifestBoxSegment`, does everything: manifest parsing, signature verification, BMFF hash validation, and continuity checks.
 
 Two pieces of state pass from one call to the next:
 

--- a/libs/c2pa/docs/merkle-validation.md
+++ b/libs/c2pa/docs/merkle-validation.md
@@ -5,7 +5,7 @@ description: Validate on-demand fragmented MP4 assets using Merkle tree proofs (
 
 # VOD Merkle Validation
 
-The video on demand (VOD) Merkle method (C2PA section 15.12.2.2 / 18.6) validates fragmented MP4 (fMP4) assets, such as HLS or DASH VOD streams. The manifest does not list every segment hash. Instead, the init manifest stores one row of a Merkle tree per track. A Merkle tree is a hash tree: each row is computed from the row below. Each media segment has a small auxiliary `uuid` box. The box gives the leaf index of the segment (`location`) and the sibling hashes that derive the stored row from the leaf hash.
+The VOD Merkle method (C2PA section 15.12.2.2 / 18.6) validates fragmented MP4 (fMP4) assets, such as HLS or DASH VOD streams. The manifest does not list every segment hash. Instead, the init manifest stores one row of a Merkle tree per track. A Merkle tree is a hash tree: each row is computed from the row below. Each media segment has a small auxiliary `uuid` box. The box gives the leaf index of the segment (`location`) and the sibling hashes that derive the stored row from the leaf hash.
 
 Unlike the [Manifest Box](manifest-box-validation.md) and [VSI/EMSG](vsi-validation.md) methods, VOD Merkle segments have no manifest or signature of their own. The manifest of the init segment is the only source of trust.
 

--- a/libs/c2pa/docs/results-and-error-codes.md
+++ b/libs/c2pa/docs/results-and-error-codes.md
@@ -88,7 +88,7 @@ import { C2paStatusCode } from '@svta/cml-c2pa'
 > [!NOTE]
 > `C2paStatusCode` values appear in `InitSegmentValidation.errorCodes` and `ManifestBoxValidationResult.errorCodes`, which check manifest integrity. They do not appear in `SegmentValidationResult.errorCodes`: the VSI/EMSG segment validation (Verifiable Segment Info, in event message boxes) uses only `LiveVideoStatusCode`.
 >
-> For video on demand (VOD) Merkle streams, `InitSegmentValidation` extracts `merkleMaps` from the `c2pa.hash.bmff.v3` assertion and validates the `initHash` binding of each entry. `LiveVideoStatusCode.SESSIONKEY_INVALID` is not reported when `merkleMaps` is not empty, because VOD Merkle segments do not use session keys.
+> For VOD Merkle streams, `InitSegmentValidation` extracts `merkleMaps` from the `c2pa.hash.bmff.v3` assertion and validates the `initHash` binding of each entry. `LiveVideoStatusCode.SESSIONKEY_INVALID` is not reported when `merkleMaps` is not empty, because VOD Merkle segments do not use session keys.
 
 ## Working with Manifest Data
 

--- a/libs/c2pa/docs/vsi-validation.md
+++ b/libs/c2pa/docs/vsi-validation.md
@@ -5,14 +5,14 @@ description: Validate live streams using the Verifiable Segment Info method (C2P
 
 # VSI/EMSG Validation
 
-The Verifiable Segment Info (VSI) method is a two-phase approach to C2PA live video validation, defined in section 19.4 of the C2PA specification. The init segment contains the full C2PA manifest and the session keys. Each media segment contains a small event message (EMSG) box with a COSE_Sign1 signature, verified against those session keys. COSE means CBOR Object Signing and Encryption.
+The Verifiable Segment Info (VSI) method is a two-phase approach to C2PA live video validation, defined in section 19.4 of the C2PA specification. The init segment contains the full C2PA manifest and the session keys. Each media segment contains a small EMSG box with a COSE_Sign1 signature, verified against those session keys.
 
 ## Overview
 
 The validation flow has two phases:
 
 1. **Init segment**: call `validateC2paInitSegment` once. It parses the C2PA manifest, verifies its integrity, and extracts the validated session keys.
-2. **Media segments**: call `validateC2paSegment` for each media segment. The function finds the C2PA EMSG box and verifies the COSE_Sign1 signature against a session key. It then checks the ISO Base Media File Format (BMFF) content hash and validates the sequence number.
+2. **Media segments**: call `validateC2paSegment` for each media segment. The function finds the C2PA EMSG box and verifies the COSE_Sign1 signature against a session key. It then checks the BMFF content hash and validates the sequence number.
 
 A `SequenceState` object passes from each media segment call to the next and tracks the sequence numbers.
 
@@ -34,7 +34,7 @@ The returned `InitSegmentValidation` object contains:
 | Field | Type | Description |
 |-------|------|-------------|
 | `manifest` | `C2paManifest \| null` | Parsed manifest (label, assertions, signature info) |
-| `certificate` | `Uint8Array \| null` | End-entity certificate in Distinguished Encoding Rules (DER) format |
+| `certificate` | `Uint8Array \| null` | DER-encoded end-entity certificate |
 | `manifestId` | `string \| null` | Manifest identifier |
 | `sessionKeys` | `readonly ValidatedSessionKey[]` | Session keys with valid signer binding |
 | `isValid` | `boolean` | All checks passed |
@@ -59,7 +59,7 @@ Each `ValidatedSessionKey` contains:
 | Field | Type | Description |
 |-------|------|-------------|
 | `kid` | `string` | Key ID (hex-encoded) |
-| `jwk` | `CoseKeyJwk` | Public key in JSON Web Key (JWK) format, compatible with WebCrypto |
+| `jwk` | `CoseKeyJwk` | Public key in JWK format (WebCrypto-compatible) |
 | `minSequenceNumber` | `number` | Minimum accepted sequence number |
 | `validityPeriod` | `number` | Key lifetime in seconds |
 | `createdAt` | `string` | ISO 8601 timestamp of key creation |

--- a/libs/cmaf-ham/samples/cmaf-ham-conversion/README.md
+++ b/libs/cmaf-ham/samples/cmaf-ham-conversion/README.md
@@ -12,7 +12,7 @@ When you run `npm run dev`, the CMAF-Ham library creates different versions of t
    * `ham.json`: A JSON export of the Ham object.
    * `validations.json`: The validation results for each presentation of the content.
    * `main.m3u8`: The multivariant playlist of the HLS version of the content.
-   * `main.mpd`: The Media Presentation Description (MPD) of the DASH version of the content.
+   * `main.mpd`: The MPD of the DASH version of the content.
 
 ## Play the output in a Web Player
 Serve the `dist/` folder with a static web server that allows cross-origin requests. Then load a manifest URL in a player.

--- a/libs/cmaf-ham/src/README.md
+++ b/libs/cmaf-ham/src/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-HTTP Live Streaming (HLS) and Dynamic Adaptive Streaming over HTTP (DASH) are the two main video streaming technologies today. Users often need to convert between HLS and DASH, edit manifests, and read manifest structures in code.
+HLS and DASH are the two main video streaming technologies today. Users often need to convert between HLS and DASH, edit manifests, and read manifest structures in code.
 
-The Common Media Application Format (CMAF) for segmented media (ISO/IEC 23000-19) defines one universal format for both. The format is based on the ISO Base Media File Format (ISO BMFF). CMAF also defines the Hypothetical Application Model (HAM), a framework that shows how streaming applications use CMAF segments and fragments. This project is based on the principles of the CMAF standard and the [Hypothetical Application Model](https://cdn.cta.tech/cta/media/media/resources/standards/cta-5005-a-final.pdf).
+The Common Media Application Format (CMAF) for segmented media (ISO/IEC 23000-19) defines one universal format for both. The format is based on ISO BMFF. CMAF also defines the Hypothetical Application Model, a framework that shows how streaming applications use CMAF segments and fragments. This project is based on the principles of the CMAF standard and the [Hypothetical Application Model](https://cdn.cta.tech/cta/media/media/resources/standards/cta-5005-a-final.pdf).
 
 ## Features
 

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
 ### Changed
 
 - README: the `CmcdReportRecorder` paragraph is rewritten for readers who do not read English as a first language. The code examples are unchanged.
-- User Guide, Report Recorder Guide, and Validation Guide: the prose is rewritten for readers who do not read English as a first language. The User Guide gains a Terms section. The code examples and tables are unchanged.
+- User Guide, Report Recorder Guide, and Validation Guide: the prose is rewritten for readers who do not read English as a first language. The code examples and tables are unchanged.
 - User Guide and Validation Guide: one heading, one table cell, and one code comment no longer use a contraction or an em dash.
 
 ### Fixed

--- a/libs/cmcd/docs/user-guide.md
+++ b/libs/cmcd/docs/user-guide.md
@@ -5,26 +5,7 @@ description: How to use the CMCD reporter
 
 # CMCD User Guide
 
-The `CmcdReporter` class manages Common Media Client Data (CMCD) reporting in a video player from one place. It handles request-mode reporting, which adds CMCD data to media requests, and event-mode reporting, which sends periodic reports to analytics endpoints.
-
-## Terms
-
-| Term | Meaning |
-| --- | --- |
-| CMCD | Common Media Client Data. CTA-5004-B is the version 2 specification. |
-| Request mode | The reporter adds CMCD data to a media request, as a query parameter or as headers. |
-| Event mode | The reporter sends CMCD reports to event targets in a POST body. |
-| Event target | An analytics endpoint configured in `eventTargets`, with its own events, keys, and interval. |
-| Destination | The request path or one event target. |
-| Data store | The values set with `update()`. The reporter keeps them and includes them in later reports. |
-| Session | One playback session, identified by the session ID key `sid`. |
-| State-change event | An event that `update()` fires when a tracked key changes value. |
-| Dedup | Deduplication. `update()` drops a state-change event when the value did not change. |
-| Transform | A function that changes or cancels one report before it is sent. |
-| Provenance record | The frozen record that `createRequestReport()` attaches to a request, so that a late response reports under the right session. |
-| Wire format | The encoded form of a report as it is transmitted. RFC 8941, the structured field values standard, defines the encoding. |
-| Shard | One of the CMCD headers in headers mode, such as `CMCD-Object`, `CMCD-Request`, and `CMCD-Session`. |
-| `msd` | The media start delay key. The reporter sends it once per session. |
+The `CmcdReporter` class manages CMCD reporting in a video player from one place. It handles request-mode reporting, which adds CMCD data to media requests, and event-mode reporting, which sends periodic reports to analytics endpoints.
 
 ## Installation
 
@@ -628,7 +609,7 @@ Attribution uses a frozen provenance record (`CmcdRequestProvenance`). `createRe
 
 The reporter rebuilds a `RESPONSE_RECEIVED` event from the record, with the record's `cid` and the caller's request-time inputs. So a response that completes after a session or content change keeps the meaning it had when its request was sent.
 
-The `sid` itself is the session identity. CTA-5004-B expects it to be unique per playback session, so generate a new universally unique identifier (UUID) for every session.
+The `sid` itself is the session identity. CTA-5004-B expects it to be unique per playback session, so generate a new UUID for every session.
 
 > [!WARNING]
 > Never reuse a session ID. Everything session-scoped depends on the `sid`, so reusing one corrupts the collected data. The reporter replaces the retained session that has the same `sid`. The late responses of the replaced session are then relabeled onto the replacement, and they consume the replacement's sequence numbers and gates.

--- a/libs/cmcd/docs/validation-guide.md
+++ b/libs/cmcd/docs/validation-guide.md
@@ -5,7 +5,7 @@ description: How to validate CMCD payloads
 
 # CMCD Validation Guide
 
-The `@svta/cml-cmcd` library provides composable validation functions. They verify that CMCD payloads conform to the CTA-5004 (v1) and CTA-5004-B (v2) specifications. Use them on the receiving side. Examples are an analytics server that collects CMCD event reports, and a content delivery network (CDN) log processor that inspects CMCD request data.
+The `@svta/cml-cmcd` library provides composable validation functions. They verify that CMCD payloads conform to the CTA-5004 (v1) and CTA-5004-B (v2) specifications. Use them on the receiving side. Examples are an analytics server that collects CMCD event reports, and a CDN log processor that inspects CMCD request data.
 
 ## Overview
 

--- a/libs/cta/README.md
+++ b/libs/cta/README.md
@@ -1,6 +1,6 @@
 # @svta/cml-cta
 
-Common functionality for Consumer Technology Association (CTA) standards, including CMCD, CMSD, and CTA-608/CEA-608. Do not use this utility package directly. Use `@svta/cml-cmcd`, `@svta/cml-cmsd`, or `@svta/cml-608`.
+Common functionality for CTA standards, including CMCD, CMSD, and CTA-608/CEA-608. Do not use this utility package directly. Use `@svta/cml-cmcd`, `@svta/cml-cmsd`, or `@svta/cml-608`.
 
 ## Installation
 

--- a/libs/dash/CHANGELOG.md
+++ b/libs/dash/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to
 
 ### Changed
 
-- README: the description defines DASH at first use.
 - README: the usage example prints its results instead of calling an undefined `assert`.
 
 

--- a/libs/dash/README.md
+++ b/libs/dash/README.md
@@ -1,6 +1,6 @@
 # @svta/cml-dash
 
-Dynamic Adaptive Streaming over HTTP (DASH) manifest parsing functionality.
+DASH manifest parsing functionality.
 
 ## Installation
 

--- a/libs/iso-bmff/docs/writing-boxes.md
+++ b/libs/iso-bmff/docs/writing-boxes.md
@@ -144,7 +144,7 @@ const box = {
 };
 ```
 
-You can also get a box type from `IsoBoxMap` with the box's four-character code (FourCC):
+You can also get a box type from `IsoBoxMap` with the box's FourCC:
 
 ```typescript
 import type { IsoBoxMap } from "@svta/cml-iso-bmff";

--- a/plans/writing-style-compliance/inventory.md
+++ b/plans/writing-style-compliance/inventory.md
@@ -4,7 +4,7 @@ Baseline metrics for every file in scope, measured on 2026-09-03 at commit 26fd6
 
 ## How the numbers were measured
 
-A script outside the repository produced the numbers: `prose-metrics.ts` from the #431 plain-language pass, in Casey's Claude project folder. The script removes code fences, tables, headings, frontmatter, and link targets. Each inline code span counts as one word. A sentence ends at a period, an exclamation mark, a question mark, or a colon followed by a capital letter. "FK grade" is the Flesch-Kincaid grade level. "Flagged" lists hits from a fixed list of idioms and figurative verbs collected during the #431 pass. Some hits are false positives, so the column is a signal, not a gate.
+A script outside the repository produced the numbers: `prose-metrics.ts` from the #431 plain-language pass, in Casey's Claude project folder. The script removes code fences, tables, headings, frontmatter, and link targets. Each inline code span counts as one word. A sentence ends at a period, an exclamation mark, a question mark, or a colon followed by a capital letter. "FK grade" is the Flesch-Kincaid grade level. "Flagged" lists hits from a fixed list of idioms and figurative verbs collected during the #431 pass. Some hits are false positives, so the column is a signal, not a gate. Until 2026-09-03 the script matched each flag as a prefix, so "vs" counted VSI, "sat" counted satisfy, and "bar" counted bare. The Flagged column of every table was regenerated on that date with the fixed script, from the file versions that each table measured. The sentence splitter joins list items that have no final period into one sentence. The "Over 25 words" column overstates for files with such lists.
 
 Targets from the #431 pass: average under 15 words per sentence, and under 10 percent of sentences over 25 words. Technical vocabulary raises the grade, so the grade is a signal, not a gate.
 
@@ -12,7 +12,7 @@ Targets from the #431 pass: average under 15 words per sentence, and under 10 pe
 
 | Tranche | File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
 |---|---|---|---|---|---|---|---|
-| 1 | `AGENTS.md` | 1001 | 78 | 12.8 | 6 (8%) | 7.2 | carries(1), pay for(1), bar(1), e.g.(3), i.e.(1), vs(1) |
+| 1 | `AGENTS.md` | 1001 | 78 | 12.8 | 6 (8%) | 7.2 | carries(1), pay for(1), e.g.(3), i.e.(1), vs(1) |
 | 1 | `CLAUDE.md` | 106 | 4 | 26.5 | 1 (25%) | 15.9 | none |
 | 1 | `README.md` | 322 | 18 | 17.9 | 5 (28%) | 9.9 | none |
 | 1 | `CONTRIBUTING.md` | 257 | 23 | 11.2 | 0 (0%) | 6.2 | none |
@@ -22,7 +22,7 @@ Targets from the #431 pass: average under 15 words per sentence, and under 10 pe
 | 1 | `.github/ISSUE_TEMPLATE/bug_report.md` | 85 | 6 | 14.2 | 0 (0%) | 7.8 | e.g.(4) |
 | 1 | `.github/ISSUE_TEMPLATE/feature_request.md` | 71 | 6 | 11.8 | 0 (0%) | 8.1 | none |
 | 2 | `libs/608/README.md` | 154 | 8 | 19.3 | 2 (25%) | 9.2 | carries(1), come from(1) |
-| 2 | `libs/c2pa/README.md` | 205 | 12 | 17.1 | 1 (8%) | 10.2 | carries(3), vs(2) |
+| 2 | `libs/c2pa/README.md` | 205 | 12 | 17.1 | 1 (8%) | 10.2 | carries(3) |
 | 2 | `libs/cmaf-ham/README.md` | 16 | 1 | 16.0 | 0 (0%) | 15.0 | none |
 | 2 | `libs/cmcd/README.md` | 42 | 3 | 14.0 | 0 (0%) | 8.1 | none |
 | 2 | `libs/cmsd/README.md` | 8 | 1 | 8.0 | 0 (0%) | 11.1 | none |
@@ -42,25 +42,25 @@ Targets from the #431 pass: average under 15 words per sentence, and under 10 pe
 | 2 | `libs/xml/README.md` | 3 | 1 | 3.0 | 0 (0%) | 13.1 | none |
 | 2 | `libs/cmaf-ham/src/README.md` | 237 | 15 | 15.8 | 0 (0%) | 13.5 | none |
 | 2 | `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md` | 293 | 24 | 12.2 | 2 (8%) | 5.6 | none |
-| 2 | `libs/608/test/fixtures/README.md` | 149 | 9 | 16.6 | 1 (11%) | 6.4 | carry(2) |
+| 2 | `libs/608/test/fixtures/README.md` | 149 | 9 | 16.6 | 1 (11%) | 6.4 | none |
 | 2 | `libs/iso-bmff/docs/reading-boxes.md` | 96 | 6 | 16.0 | 1 (17%) | 8.0 | none |
 | 2 | `libs/iso-bmff/docs/utilities.md` | 120 | 9 | 13.3 | 0 (0%) | 6.1 | none |
 | 2 | `libs/iso-bmff/docs/writing-boxes.md` | 208 | 16 | 13.0 | 1 (6%) | 7.2 | e.g.(1) |
-| 3 | `libs/cmcd/docs/report-recorder-guide.md` | 894 | 56 | 16.0 | 8 (14%) | 8.2 | straight into(2), carries(1), carry(1), shape(4) |
-| 3 | `libs/cmcd/docs/user-guide.md` | 2860 | 144 | 19.9 | 45 (31%) | 10.0 | frozen(2), sat(1), holds(1), carries(5), carry(3), deliberate(1), bar(2), shape(4), stay(4), stays(2), e.g.(3) |
+| 3 | `libs/cmcd/docs/report-recorder-guide.md` | 894 | 56 | 16.0 | 8 (14%) | 8.2 | straight into(2), carries(1), carry(1), shape(3) |
+| 3 | `libs/cmcd/docs/user-guide.md` | 2860 | 144 | 19.9 | 45 (31%) | 10.0 | frozen(2), holds(1), carries(5), carry(3), shape(4), stay(2), stays(2), e.g.(3) |
 | 3 | `libs/cmcd/docs/validation-guide.md` | 533 | 32 | 16.7 | 6 (19%) | 9.1 | e.g.(2) |
-| 4 | `libs/c2pa/docs/manifest-box-validation.md` | 545 | 29 | 18.8 | 6 (21%) | 10.5 | holds(1), carries(2), e.g.(2), vs(2) |
-| 4 | `libs/c2pa/docs/merkle-validation.md` | 409 | 18 | 22.7 | 6 (33%) | 10.3 | carries(2), carry(1), vs(2) |
-| 4 | `libs/c2pa/docs/results-and-error-codes.md` | 262 | 20 | 13.1 | 2 (10%) | 8.5 | vs(4) |
-| 4 | `libs/c2pa/docs/vsi-validation.md` | 415 | 25 | 16.6 | 4 (16%) | 9.1 | carries(3), stay(1), stays(1), vs(2) |
-| 5 | `.claude/agents/code-reviewer.md` | 822 | 98 | 8.4 | 4 (4%) | 6.2 | hot path(1), bar(3), e.g.(4), vs(1) |
-| 5 | `.claude/rules/code-quality.md` | 220 | 24 | 9.2 | 0 (0%) | 6.4 | bar(1), e.g.(1) |
-| 5 | `.claude/skills/code-review/SKILL.md` | 100 | 12 | 8.3 | 0 (0%) | 6.1 | bar(1) |
+| 4 | `libs/c2pa/docs/manifest-box-validation.md` | 545 | 29 | 18.8 | 6 (21%) | 10.5 | holds(1), carries(2), e.g.(2) |
+| 4 | `libs/c2pa/docs/merkle-validation.md` | 409 | 18 | 22.7 | 6 (33%) | 10.3 | carries(2), carry(1) |
+| 4 | `libs/c2pa/docs/results-and-error-codes.md` | 262 | 20 | 13.1 | 2 (10%) | 8.5 | none |
+| 4 | `libs/c2pa/docs/vsi-validation.md` | 415 | 25 | 16.6 | 4 (16%) | 9.1 | carries(3), stays(1) |
+| 5 | `.claude/agents/code-reviewer.md` | 822 | 98 | 8.4 | 4 (4%) | 6.2 | e.g.(4), vs(1) |
+| 5 | `.claude/rules/code-quality.md` | 220 | 24 | 9.2 | 0 (0%) | 6.4 | e.g.(1) |
+| 5 | `.claude/skills/code-review/SKILL.md` | 100 | 12 | 8.3 | 0 (0%) | 6.1 | none |
 | 5 | `.claude/skills/create-pr/SKILL.md` | 686 | 62 | 11.1 | 4 (6%) | 5.7 | e.g.(2), vs(2) |
 | 5 | `.claude/skills/pr-feedback/SKILL.md` | 790 | 75 | 10.5 | 2 (3%) | 6.4 | vs(1) |
-| 6 | `rfc/README.md` | 317 | 24 | 13.2 | 3 (13%) | 9.9 | deliberate(1), settle(1), shape(1) |
-| 6 | `rfc/cmcd-reporter-middleware.md` | 6195 | 303 | 20.4 | 90 (30%) | 11.2 | sits in(1), hot path(1), plausible(1), therefore(2), whereas(2), fan-out(5), sat(2), holds(1), carries(3), carry(1), walk(1), pays(1), deliberate(5), bar(2), shape(8), sits(1), stay(5), stays(2), keeps to(1), e.g.(3) |
-| 6 | `rfc/cmcd-session-retention.md` | 6040 | 259 | 23.3 | 103 (40%) | 12.0 | the price(1), hot path(1), turn out(1), shows up(1), frozen(13), holds(4), carries(4), carry(8), pays(1), deliberate(5), settle(4), bar(4), shape(14), shaped(3), sits(1), stay(2), stays(2) |
+| 6 | `rfc/README.md` | 317 | 24 | 13.2 | 3 (13%) | 9.9 | settle(1), shape(1) |
+| 6 | `rfc/cmcd-reporter-middleware.md` | 6195 | 303 | 20.4 | 90 (30%) | 11.2 | sits in(1), hot path(1), plausible(1), therefore(2), whereas(2), fan-out(5), holds(1), carries(3), carry(1), pays(1), deliberate(1), shape(7), sits(1), stay(3), stays(2), e.g.(3) |
+| 6 | `rfc/cmcd-session-retention.md` | 6040 | 259 | 23.3 | 103 (40%) | 12.0 | the price(1), hot path(1), turn out(1), shows up(1), frozen(13), holds(4), carries(4), carry(5), pays(1), deliberate(2), shape(10), shaped(3), sits(1), stays(2) |
 
 ## After tranche 1
 
@@ -68,7 +68,7 @@ Recorded after the rewrite. Same script, same settings.
 
 | File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
 |---|---|---|---|---|---|---|
-| `AGENTS.md` | 997 | 107 | 9.3 | 1 (1%) | 5.9 | carries(1), bar(1), e.g.(1), i.e.(1), vs(1) |
+| `AGENTS.md` | 997 | 107 | 9.3 | 1 (1%) | 5.9 | carries(1), e.g.(1), i.e.(1), vs(1) |
 | `CLAUDE.md` | 105 | 5 | 21.0 | 1 (20%) | 14.0 | none |
 | `README.md` | 281 | 23 | 12.2 | 0 (0%) | 8.1 | none |
 | `CONTRIBUTING.md` | 219 | 23 | 9.5 | 0 (0%) | 6.4 | none |
@@ -86,7 +86,7 @@ Twelve files changed. The other 13 files, all package READMEs of one or two sent
 |---|---|---|---|---|---|---|
 | `libs/608/README.md` | 149 | 13 | 11.5 | 0 (0%) | 7.6 | none |
 | `libs/608/test/fixtures/README.md` | 149 | 13 | 11.5 | 1 (8%) | 5.1 | none |
-| `libs/c2pa/README.md` | 197 | 10 | 19.7 | 3 (30%) | 10.2 | vs(2) |
+| `libs/c2pa/README.md` | 197 | 10 | 19.7 | 3 (30%) | 10.2 | none |
 | `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md` | 250 | 27 | 9.3 | 0 (0%) | 4.5 | none |
 | `libs/cmaf-ham/src/README.md` | 205 | 17 | 12.1 | 0 (0%) | 9.0 | none |
 | `libs/cmcd/README.md` | 41 | 3 | 13.7 | 0 (0%) | 5.3 | none |
@@ -103,8 +103,8 @@ All three guides changed. The Terms table in the User Guide does not count as pr
 
 | File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
 |---|---|---|---|---|---|---|
-| `libs/cmcd/docs/user-guide.md` | 2827 | 207 | 13.7 | 8 (4%) | 7.1 | frozen(2), sat(1), bar(2), stay(5), stays(3) |
-| `libs/cmcd/docs/report-recorder-guide.md` | 885 | 65 | 13.6 | 2 (3%) | 6.6 | stay(1), stays(1) |
+| `libs/cmcd/docs/user-guide.md` | 2827 | 207 | 13.7 | 8 (4%) | 7.1 | frozen(2) |
+| `libs/cmcd/docs/report-recorder-guide.md` | 885 | 65 | 13.6 | 2 (3%) | 6.6 | none |
 | `libs/cmcd/docs/validation-guide.md` | 509 | 38 | 13.4 | 2 (5%) | 7.7 | none |
 
 ## After tranche 4
@@ -113,10 +113,10 @@ All four guides changed.
 
 | File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
 |---|---|---|---|---|---|---|
-| `libs/c2pa/docs/manifest-box-validation.md` | 540 | 34 | 15.9 | 3 (9%) | 8.7 | vs(2) |
-| `libs/c2pa/docs/merkle-validation.md` | 406 | 29 | 14.0 | 1 (3%) | 5.8 | vs(1) |
-| `libs/c2pa/docs/results-and-error-codes.md` | 258 | 20 | 12.9 | 1 (5%) | 7.9 | vs(4) |
-| `libs/c2pa/docs/vsi-validation.md` | 410 | 31 | 13.2 | 3 (10%) | 7.2 | vs(2) |
+| `libs/c2pa/docs/manifest-box-validation.md` | 540 | 34 | 15.9 | 3 (9%) | 8.7 | none |
+| `libs/c2pa/docs/merkle-validation.md` | 406 | 29 | 14.0 | 1 (3%) | 5.8 | none |
+| `libs/c2pa/docs/results-and-error-codes.md` | 258 | 20 | 12.9 | 1 (5%) | 7.9 | none |
+| `libs/c2pa/docs/vsi-validation.md` | 410 | 31 | 13.2 | 3 (10%) | 7.2 | none |
 
 ## After tranche 5
 
@@ -124,9 +124,9 @@ All five files changed. Frontmatter and the shell injection lines are byte-ident
 
 | File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
 |---|---|---|---|---|---|---|
-| `.claude/agents/code-reviewer.md` | 821 | 105 | 7.8 | 1 (1%) | 5.9 | bar(3) |
-| `.claude/rules/code-quality.md` | 220 | 25 | 8.8 | 0 (0%) | 6.3 | bar(1) |
-| `.claude/skills/code-review/SKILL.md` | 100 | 12 | 8.3 | 0 (0%) | 6.2 | bar(1) |
+| `.claude/agents/code-reviewer.md` | 821 | 105 | 7.8 | 1 (1%) | 5.9 | none |
+| `.claude/rules/code-quality.md` | 220 | 25 | 8.8 | 0 (0%) | 6.3 | none |
+| `.claude/skills/code-review/SKILL.md` | 100 | 12 | 8.3 | 0 (0%) | 6.2 | none |
 | `.claude/skills/create-pr/SKILL.md` | 683 | 65 | 10.5 | 3 (5%) | 5.3 | none |
 | `.claude/skills/pr-feedback/SKILL.md` | 788 | 82 | 9.6 | 2 (2%) | 5.8 | none |
 
@@ -139,3 +139,32 @@ Only `rfc/README.md` changed. Casey decided on 2026-09-03 that the two merged RF
 | `rfc/README.md` | 316 | 27 | 11.7 | 2 (7%) | 9.4 | none |
 
 The two sentences over 25 words in this row are not sentences. The metrics script joins list items that have no final period, and `rfc/README.md` has two such lists. The baseline row counts the same two joins plus one real sentence, which the rewrite split. The check script finds no sentence over 25 words in the rewritten file.
+
+## After tranche 8
+
+The sweep removed the abbreviation definitions that tranches 1 to 7 added, and the Terms table of the CMCD user guide. The table lists every in-scope file that the sweep changed.
+
+| File | Prose words | Sentences | Avg words per sentence | Over 25 words | FK grade | Flagged |
+|---|---|---|---|---|---|---|
+| `.claude/agents/code-reviewer.md` | 819 | 105 | 7.8 | 1 (1%) | 5.9 | none |
+| `.claude/skills/create-pr/SKILL.md` | 682 | 65 | 10.5 | 3 (5%) | 5.2 | none |
+| `.claude/skills/pr-feedback/SKILL.md` | 782 | 82 | 9.5 | 2 (2%) | 5.7 | none |
+| `AGENTS.md` | 956 | 104 | 9.2 | 1 (1%) | 5.8 | carries(1), e.g.(1), i.e.(1), vs(1) |
+| `CONTRIBUTING.md` | 210 | 23 | 9.1 | 0 (0%) | 6.0 | none |
+| `README.md` | 291 | 24 | 12.1 | 0 (0%) | 7.8 | none |
+| `SCOPING.md` | 386 | 26 | 14.8 | 2 (8%) | 10.4 | none |
+| `libs/608/README.md` | 140 | 13 | 10.8 | 0 (0%) | 6.4 | none |
+| `libs/608/test/fixtures/README.md` | 140 | 13 | 10.8 | 0 (0%) | 3.9 | none |
+| `libs/c2pa/README.md` | 182 | 10 | 18.2 | 3 (30%) | 9.5 | none |
+| `libs/c2pa/docs/manifest-box-validation.md` | 530 | 34 | 15.6 | 3 (9%) | 8.6 | none |
+| `libs/c2pa/docs/merkle-validation.md` | 403 | 29 | 13.9 | 1 (3%) | 5.8 | none |
+| `libs/c2pa/docs/results-and-error-codes.md` | 255 | 20 | 12.8 | 1 (5%) | 7.8 | none |
+| `libs/c2pa/docs/vsi-validation.md` | 396 | 30 | 13.2 | 3 (10%) | 7.2 | none |
+| `libs/cmaf-ham/samples/cmaf-ham-conversion/README.md` | 238 | 25 | 9.5 | 1 (4%) | 4.6 | none |
+| `libs/cmaf-ham/src/README.md` | 190 | 17 | 11.2 | 0 (0%) | 8.6 | none |
+| `libs/cmcd/docs/user-guide.md` | 2820 | 207 | 13.6 | 7 (3%) | 7.1 | frozen(2) |
+| `libs/cmcd/docs/validation-guide.md` | 506 | 38 | 13.3 | 2 (5%) | 7.6 | none |
+| `libs/cta/README.md` | 33 | 5 | 6.6 | 0 (0%) | 4.5 | none |
+| `libs/dash/README.md` | 4 | 1 | 4.0 | 0 (0%) | 18.4 | none |
+| `libs/iso-bmff/docs/writing-boxes.md` | 190 | 17 | 11.2 | 1 (6%) | 6.0 | none |
+| `rfc/README.md` | 307 | 26 | 11.8 | 2 (8%) | 9.2 | none |

--- a/plans/writing-style-compliance/overview.md
+++ b/plans/writing-style-compliance/overview.md
@@ -46,7 +46,7 @@ For each file:
 1. Take the base version from git. For tranche 1 the base is commit 8ddcad72c, the merge of #433 into `main`. For later tranches the base is `origin/main`.
 2. Rewrite prose only. Keep code blocks, tables, frontmatter, link targets, and heading text. Two guides link to each other's `#custom-keys` heading: `libs/cmcd/docs/user-guide.md` and `libs/cmcd/docs/validation-guide.md`.
 3. Keep every fact, number, hedge, and tense. If the original says "will", the rewrite says "will". If a fact looks wrong or stale, do not change it. Record it under "Noticed, not changed" in the PR description.
-4. Apply the rules in this order. First split sentences and remove semicolons and em dashes. Then replace idioms and phrasal verbs, and define abbreviations at first use. Last, give each pronoun a noun and use one name per thing.
+4. Apply the rules in this order. First split sentences and remove semicolons and em dashes. Then replace idioms and phrasal verbs, and define abbreviations at first use. Last, give each pronoun a noun and use one name per thing. The definition rule was removed on 2026-09-03, and tranche 8 reverted the definitions.
 5. Do a second pass that removes duplication. The file must not grow. If a definition of an abbreviation makes a very short file longer, record the reason in the PR description.
 6. Run the check script. Fix every FAIL.
 7. Record the after metrics in `inventory.md`.
@@ -90,6 +90,8 @@ The readability metrics in `inventory.md` come from a second script that is not 
 - 2026-09-03: tranche 5 rewritten on branch `docs/writing-style-agent-instructions`, stacked on the tranche 4 branch. PR #439.
 - 2026-09-03: tranche 6 rewritten on branch `docs/writing-style-rfc`, stacked on the tranche 5 branch, `rfc/README.md` only. PR #440. All six tranches are done.
 - 2026-09-03: tranche 7 on branch `docs/writing-style-fixes`, stacked on the tranche 6 branch. It fixes every item in the "Noticed, not changed" sections below and the cmaf-ham sample script. PR #441.
+- 2026-09-03: Casey removed the abbreviation rule and the Terms list rule from `AGENTS.md`. PR #442. Video developers know the abbreviations, and a reader who does not can search for them.
+- 2026-09-03: tranche 8 on branch `docs/writing-style-sweep`, from `main` after #441 merged. It reverts the 45 definitions that tranches 1 to 7 added in 22 files. It also removes the Terms table from the CMCD user guide. PR pending.
 
 ## Noticed, not changed (tranche 1)
 

--- a/plans/writing-style-compliance/steps.md
+++ b/plans/writing-style-compliance/steps.md
@@ -458,3 +458,25 @@ Casey creates the PR with `/create-pr`.
 - [x] **Step 7: Commit and push.** Casey creates the PR with `/create-pr`.
 
 **Outcome (2026-09-03):** all items fixed. Two code defects found on the way stay open. The cmaf-ham sample script fails after its first DASH sample with a malformed output path. `npm run dev -w libs/cmaf-ham` fails because the script reads paths relative to the sample folder. Both are code, not documentation.
+
+---
+
+### Task 8: Tranche 8, revert the abbreviation definitions
+
+**Files:** the 22 in-scope files in which tranches 1 to 7 added a definition of the form "long name (ABBR)". Also the changelogs of c2pa, cmcd, and dash.
+
+**Base:** `main` after #441 merged, commit 75bcaabe0. Casey removed the abbreviation rule and the Terms list rule from `AGENTS.md` in #442.
+
+- [x] **Step 1: Create the branch** `docs/writing-style-sweep` from `main`.
+- [x] **Step 2: Find the definitions.** For every in-scope file, list each "(ABBR)" at the head of the stack that the base of tranche 1 does not contain. That base is commit 8ddcad72c. The scan found 45 definitions in 22 files.
+- [x] **Step 3: Revert each definition to the abbreviation alone.** Keep the rest of the rewrite. Restore the two table cells in `libs/c2pa/docs/vsi-validation.md` to their base text. Remove the Terms section from `libs/cmcd/docs/user-guide.md`, because it exists only because of the removed rule. Change "of the current branch" to "for the current branch" in `.claude/skills/pr-feedback/SKILL.md`.
+- [x] **Step 4: Verify.** Run the check script against `origin/main` for every changed file. Rescan for the 45 definitions.
+- [x] **Step 5: Update the changelogs.** Remove the sentences that describe the definitions from the Unreleased notes of c2pa, cmcd, and dash. The other packages keep their notes, because their prose is still rewritten.
+- [x] **Step 6: Regenerate the Flagged column of `inventory.md`** with the fixed metrics script, from the file versions that each table measured. Add the After tranche 8 table.
+- [x] **Step 7: Commit and push.**
+
+**Outcome (2026-09-03):** 22 files changed. The sweep removed 45 definitions and the Terms table. Every check passed for every file, except the blocks check for the two files whose tables changed by design: `libs/c2pa/docs/vsi-validation.md` and `libs/cmcd/docs/user-guide.md`. The metrics script fix changed 26 Flagged cells in the inventory.
+
+| Twenty-two files | Before | After |
+|---|---|---|
+| Prose words | 10,613 | 10,460 |

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -1,6 +1,6 @@
 # RFCs
 
-Requests for comments (RFCs): proposals that need community agreement first.
+Proposals that need community agreement first.
 
 ## What Belongs Here
 
@@ -74,8 +74,8 @@ rfc/
 ## Contributing an RFC
 
 1. Create a branch: `rfc/<feature-name>`
-2. Open a pull request (PR) titled `[RFC] Feature Name`, where community review happens as PR comments
+2. Open a PR titled `[RFC] Feature Name`, where community review happens as PR comments
 3. Record the outcome in the RFC's Final Decision section and update `status`
 4. Squash-merge with a `docs(rfc): <feature name>` commit
 
-All commits require a Developer Certificate of Origin (DCO) sign-off (`git commit -s`).
+All commits require a DCO sign-off (`git commit -s`).


### PR DESCRIPTION
## Description

Tranche 8 of the writing style compliance plan in `plans/writing-style-compliance/`, and the last one. #442 removed the abbreviation rule and the Terms list rule from `AGENTS.md`. This PR reverts what those two rules added during tranches 1 to 7.

- 45 definitions of the form "long name (ABBR)" in 22 files return to the abbreviation alone. The rest of each rewrite stays.
- The two table cells in `libs/c2pa/docs/vsi-validation.md` return to their original text.
- The Terms table of the CMCD user guide is removed. It existed only because of the removed rule.
- The pr-feedback skill says "the GitHub PR for the current branch", which closes a Copilot comment on #439.
- The Unreleased notes of c2pa, cmcd, and dash no longer describe the definitions.

The second commit updates the plan. The metrics script matched each flag as a prefix, so "vs" counted VSI and "bar" counted bare. The Flagged column of every inventory table is regenerated with the fixed script, which changed 26 cells. This closes a Copilot comment on #438.

| Twenty-two files | Before | After |
|---|---|---|
| Prose words | 10,613 | 10,460 |

## Test Plan

- [x] `bash plans/writing-style-compliance/check.sh origin/main <22 files>`: every check passes, except the blocks check for the two files whose tables change by design.
- [x] A rescan for the 45 definitions finds none.
- [x] Markdown only. Build, tests, typecheck, and lint are not affected.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (not applicable: documentation only)
- [x] Docs/guides updated
- [x] Changelog updated

Refs: #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
