### PR TITLE
chore: prepare release of 4 packages

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-09-03
+
 ### Added
 
 - `CmcdReporterConfig.sessionRetention` — the number of ended sessions the reporter retains state for, in addition to the current one (default `2`; `0` disables retention, `Infinity` never evicts; only `number` values are accepted and floored, anything else falls back to the default). The reporter now keeps per-session state (data snapshot, sequence numbers, `msd` gate, dedup baseline, unsent queues) for recently ended sessions, so a media request that completes after a `sid` change reports under the session that issued it: its own `sid`, its next per-target sequence number, its still-unsent `msd`, and its frozen data snapshot, which is detached at the transition so mutating an array previously passed to `update()` cannot rewrite an ended session's late reports. A `sid` change also drains an ended session's unsent event reports (each keeps its own `sid` and sequence number) before eviction can discard them. Implements the accepted RFC in `rfc/cmcd-session-retention.md` ([#416](https://github.com/streaming-video-technology-alliance/common-media-library/pull/416))
@@ -237,7 +239,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.5.0...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.6.0...HEAD
+[2.6.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.5.0...cmcd-v2.6.0
 [2.5.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.1...cmcd-v2.5.0
 [2.4.1]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.4.0...cmcd-v2.4.1
 [2.4.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/cmcd-v2.3.2...cmcd-v2.4.0

--- a/libs/cmcd/package.json
+++ b/libs/cmcd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-cmcd",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"description": "Common Media Client Data (CMCD) encoding and decoding",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/drm/CHANGELOG.md
+++ b/libs/drm/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.10] - 2026-09-03
+
+### Changed
+
+- Update `@svta/cml-xml` to 1.2.0
+
 ## [1.1.9] - 2026-08-11
 
 ### Changed
@@ -100,7 +106,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.9...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.10...HEAD
+[1.1.10]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.9...drm-v1.1.10
 [1.1.9]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.8...drm-v1.1.9
 [1.1.8]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.7...drm-v1.1.8
 [1.1.7]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/drm-v1.1.6...drm-v1.1.7

--- a/libs/drm/package.json
+++ b/libs/drm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-drm",
-	"version": "1.1.9",
+	"version": "1.1.10",
 	"description": "Digital Rights Management (DRM) functionality",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/request/CHANGELOG.md
+++ b/libs/request/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.16] - 2026-09-03
+
+### Changed
+
+- Update `@svta/cml-cmcd` to 2.6.0
+- Update `@svta/cml-xml` to 1.2.0
+
 ## [1.0.15] - 2026-07-28
 
 ### Changed
@@ -121,7 +128,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.15...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.16...HEAD
+[1.0.16]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.15...request-v1.0.16
 [1.0.15]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.14...request-v1.0.15
 [1.0.14]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.13...request-v1.0.14
 [1.0.13]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/request-v1.0.12...request-v1.0.13

--- a/libs/request/package.json
+++ b/libs/request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-request",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"description": "Common Media Request and Response types",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/libs/xml/CHANGELOG.md
+++ b/libs/xml/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-09-03
+
 ### Fixed
 
 - `parseXml` no longer hangs on an attribute with no quoted value, such as `<a b>`, `<a b=c/>`, or input truncated mid-attribute. It now throws an error that names the attribute and reports the line and column, matching the XML 1.0 `Attribute ::= Name Eq AttValue` production.
@@ -88,7 +90,8 @@ and this project adheres to
 - Convert to mono-repo ([#238](https://github.com/streaming-video-technology-alliance/common-media-library/issues/238))
 - Produce single bundled export for each package ([#260](https://github.com/streaming-video-technology-alliance/common-media-library/issues/260))
 
-[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.6...HEAD
+[Unreleased]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.2.0...HEAD
+[1.2.0]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.6...xml-v1.2.0
 [1.1.6]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.5...xml-v1.1.6
 [1.1.5]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.4...xml-v1.1.5
 [1.1.4]: https://github.com/streaming-video-technology-alliance/common-media-library/compare/xml-v1.1.3...xml-v1.1.4

--- a/libs/xml/package.json
+++ b/libs/xml/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svta/cml-xml",
-	"version": "1.1.6",
+	"version": "1.2.0",
 	"description": "XML parsing utilities",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
 		},
 		"libs/cmcd": {
 			"name": "@svta/cml-cmcd",
-			"version": "2.5.0",
+			"version": "2.6.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -139,7 +139,7 @@
 		},
 		"libs/drm": {
 			"name": "@svta/cml-drm",
-			"version": "1.1.9",
+			"version": "1.1.10",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -190,7 +190,7 @@
 		},
 		"libs/request": {
 			"name": "@svta/cml-request",
-			"version": "1.0.15",
+			"version": "1.0.16",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -244,7 +244,7 @@
 		},
 		"libs/xml": {
 			"name": "@svta/cml-xml",
-			"version": "1.1.6",
+			"version": "1.2.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"


### PR DESCRIPTION
## Description

Release prep for the two packages with unreleased changes, plus the patch bumps `npm run prepare-release` cascades to their dependents. Two direct bumps, two cascaded.

- cmcd 2.6.0 (minor): session retention (`CmcdReporterConfig.sessionRetention`, `CMCD_REQUEST_PROVENANCE`, `CmcdDecodeOptions.useSymbol`), `decodeCmcd` keeping RFC 8941 parameters on dictionary members and inner lists, and the `msd` lifecycle, HTTP 410 scoping, session-owned `sid`/`msd` stamping, and encode-at-enqueue fixes. Merged in #416 and #420 (issues #408, #409, #410).
- xml 1.2.0 (minor): `parseXml` no longer hangs on malformed or truncated input, rejects close tags that only start with the open tag's name and quoted attributes without `=`, reports line and column when a close tag is cut off, and is rewritten as a flat, non-recursive scanner that parses dense `SegmentTimeline` manifests 20 to 40 percent faster (#424). Merged in #425, #430, and #432. Minor rather than patch because markup that used to parse leniently now throws.
- request 1.0.16 and drm 1.1.10: cascaded patch bumps. request declares peer dependencies on cmcd and xml, drm on xml. Version and changelog only, since both peer ranges are `*`.

Every other package carries README-only changelog entries from the writing-style pass (#436 to #443) and no dependency on cmcd or xml. They are not bumped here. Whether those README fixes warrant patch releases of their own is a separate decision. The cmcd, xml, drm, and request README entries from that pass land under the versions this PR cuts, since the READMEs ship with them. PR #422 (the reporter refactor) is deliberately not in this release. It lands on its own afterwards and will need main merged in, since its cmcd changelog entries sit next to the ones this PR moves under 2.6.0.

Validated with root `npm test` (lint, build, typecheck, and every package's tests).

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (n/a: version bumps and changelogs only)
- [ ] Docs/guides updated (n/a)
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
