### PR TITLE
fix(cmcd): compare token values by text in encoder and validators

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `encodeCmcd` now writes a token field as a bare token when its value is an `SfItem` that wraps a string. The token fields are `ot`, `sf`, `st`, `e`, and `sta`. `decodeCmcd` returns that shape for a member with parameters, such as `ot=m;com.example-p=1`. The encoder wrote the field as a quoted string, which is not valid CMCD ([#419](https://github.com/streaming-video-technology-alliance/common-media-library/issues/419))
+- `encodeCmcd` compares the `e` value by token text. `decodeCmcd` with `useSymbol` returns `e` as a `Symbol` or an `SfToken`. Such an event report now keeps its response-received keys on `e=rr`, `bg=?0` on `e=b`, and `pr=1` on `e=pr`. The version 1 down-conversion also matches the `ot` parameter of an inner-list item by token text ([#419](https://github.com/streaming-video-technology-alliance/common-media-library/issues/419))
+- `validateCmcdValues` accepts a token field whose value is an `SfItem`, a `Symbol`, or an `SfToken`. Since 2.6.0, `validateCmcdEvents` and the other string validators rejected a valid member such as `ot=m;com.example-p=1`. The message was `invalid token value "[object Object]"`. `validateCmcdStructure` applies the event rules (`cen`, `url`, response keys, state-change fields, `ec`) when `e` is a `Symbol` or an `SfToken` ([#419](https://github.com/streaming-video-technology-alliance/common-media-library/issues/419))
+
 ## [2.6.0] - 2026-09-03
 
 ### Added

--- a/libs/cmcd/src/prepareCmcdData.ts
+++ b/libs/cmcd/src/prepareCmcdData.ts
@@ -3,12 +3,11 @@ import { CMCD_FORMATTER_MAP } from './CMCD_FORMATTER_MAP.ts'
 import { CMCD_V2 } from './CMCD_V2.ts'
 import type { Cmcd } from './Cmcd.ts'
 import type { CmcdEncodeOptions } from './CmcdEncodeOptions.ts'
-import { CMCD_EVENT_BACKGROUNDED_MODE, CMCD_EVENT_CUSTOM_EVENT, CMCD_EVENT_ERROR, CMCD_EVENT_PLAYBACK_RATE, CMCD_EVENT_RESPONSE_RECEIVED } from './CmcdEventType.ts'
+import { CMCD_EVENT_BACKGROUNDED_MODE, CMCD_EVENT_CUSTOM_EVENT, CMCD_EVENT_ERROR, CMCD_EVENT_PLAYBACK_RATE, CMCD_EVENT_RESPONSE_RECEIVED, type CmcdEventType } from './CmcdEventType.ts'
 import { CMCD_STATE_EVENT_FIELDS } from './CMCD_STATE_EVENT_FIELDS.ts'
 import type { CmcdFormatterOptions } from './CmcdFormatterOptions.ts'
 import type { CmcdKey } from './CmcdKey.ts'
 import type { CmcdVersion } from './CmcdVersion.ts'
-import type { CmcdObjectType } from './CmcdObjectType.ts'
 import { CMCD_EVENT_MODE, CMCD_REQUEST_MODE } from './CmcdReportingMode.ts'
 import type { CmcdValue } from './CmcdValue.ts'
 import { isCmcdEventKey } from './isCmcdEventKey.ts'
@@ -18,6 +17,7 @@ import { CMCD_INNER_LIST_KEYS } from './CMCD_INNER_LIST_KEYS.ts'
 import { isCmcdV1Key } from './isCmcdV1Key.ts'
 import { isTokenField } from './isTokenField.ts'
 import { isValid } from './isValid.ts'
+import { toTokenString } from './toTokenString.ts'
 
 const filterMap: Record<string, (key: string) => boolean> = {
 	[CMCD_EVENT_MODE]: isCmcdEventKey,
@@ -27,12 +27,13 @@ const filterMap: Record<string, (key: string) => boolean> = {
 /**
  * Unwrap an inner list or SfItem value to a plain scalar.
  */
-function unwrapValue(value: any, ot?: CmcdObjectType): any {
+function unwrapValue(value: any, ot?: unknown): any {
 	if (Array.isArray(value)) {
 		let item: any
 
-		if (ot) {
-			item = value.find(item => item.params?.ot === ot)
+		const otText = toTokenString(ot)
+		if (otText) {
+			item = value.find(item => toTokenString(item.params?.ot) === otText)
 		}
 
 		if (!item) {
@@ -112,6 +113,7 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 
 	// Down-convert V2 data to V1 format if needed
 	const data = version === 1 ? downConvertToV1(obj) : obj
+	const eventType = toTokenString(data['e'])
 
 	const keyFilter = version === 1 ? isCmcdV1Key : filterMap[reportingMode]
 
@@ -120,7 +122,7 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 	// custom keys because isCmcdCustomKey enforces the serializable charset.
 	let keys = Object.keys(data).filter(keyFilter) as CmcdKey[]
 
-	if (data['e'] && data['e'] !== CMCD_EVENT_RESPONSE_RECEIVED) {
+	if (data['e'] && eventType !== CMCD_EVENT_RESPONSE_RECEIVED) {
 		keys = keys.filter(key => !isCmcdResponseReceivedKey(key))
 	}
 
@@ -133,9 +135,7 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 	const isEventMode = reportingMode === CMCD_EVENT_MODE
 
 	if (isEventMode) {
-		const eventType = data['e']
-
-		if (!keys.includes('e') && eventType != null) {
+		if (!keys.includes('e') && data['e'] != null) {
 			keys.push('e')
 		}
 
@@ -155,7 +155,7 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 			keys.push('url')
 		}
 
-		const requiredField = eventType ? CMCD_STATE_EVENT_FIELDS.get(eventType) : undefined
+		const requiredField = eventType ? CMCD_STATE_EVENT_FIELDS.get(eventType as CmcdEventType) : undefined
 		if (requiredField && data[requiredField] != null && !keys.includes(requiredField)) {
 			keys.push(requiredField)
 		}
@@ -198,7 +198,7 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 		// Playback rate should only be sent if not equal to 1, except as
 		// the value of a PLAYBACK_RATE state-change event (where pr=1 is
 		// the data being reported, not a default to skip).
-		if (key === 'pr' && value === 1 && !(isEventMode && data['e'] === CMCD_EVENT_PLAYBACK_RATE)) {
+		if (key === 'pr' && value === 1 && !(isEventMode && eventType === CMCD_EVENT_PLAYBACK_RATE)) {
 			continue
 		}
 
@@ -215,13 +215,18 @@ export function prepareCmcdData(obj: Record<string, any>, options: CmcdEncodeOpt
 		const isBgFalseTransition = isEventMode
 			&& value === false
 			&& key === 'bg'
-			&& data['e'] === CMCD_EVENT_BACKGROUNDED_MODE
+			&& eventType === CMCD_EVENT_BACKGROUNDED_MODE
 		if (!isValid(value) && !isBgFalseTransition) {
 			continue
 		}
 
-		if (isTokenField(key) && typeof value === 'string') {
-			value = new SfToken(value)
+		if (isTokenField(key)) {
+			if (typeof value === 'string') {
+				value = new SfToken(value)
+			}
+			else if (value instanceof SfItem && typeof value.value === 'string') {
+				value = new SfItem(new SfToken(value.value), value.params)
+			}
 		}
 
 		(results as any)[key] = value

--- a/libs/cmcd/src/toTokenString.ts
+++ b/libs/cmcd/src/toTokenString.ts
@@ -1,0 +1,29 @@
+import { SfItem, SfToken, symbolToStr } from '@svta/cml-structured-field-values'
+
+/**
+ * Resolve the text of a token value.
+ *
+ * A token may be a plain string, a registry `Symbol`, an `SfToken`, or an
+ * `SfItem` that wraps one of those.
+ *
+ * @param value - The value to resolve.
+ *
+ * @returns The token text, or `undefined` when the value is not a token.
+ *
+ * @internal
+ */
+export function toTokenString(value: unknown): string | undefined {
+	if (value instanceof SfItem) {
+		return toTokenString(value.value)
+	}
+
+	if (typeof value === 'string') {
+		return value
+	}
+
+	if (typeof value === 'symbol' || value instanceof SfToken) {
+		return symbolToStr(value)
+	}
+
+	return undefined
+}

--- a/libs/cmcd/src/validateCmcdStructure.ts
+++ b/libs/cmcd/src/validateCmcdStructure.ts
@@ -9,6 +9,7 @@ import type { CmcdValidationOptions } from './CmcdValidationOptions.ts'
 import type { CmcdValidationResult } from './CmcdValidationResult.ts'
 import { CMCD_VALIDATION_SEVERITY_ERROR, CMCD_VALIDATION_SEVERITY_WARNING } from './CmcdValidationSeverity.ts'
 import { resolveVersion } from './resolveVersion.ts'
+import { toTokenString } from './toTokenString.ts'
 
 /**
  * Validates the structural rules of a CMCD payload.
@@ -70,7 +71,9 @@ export function validateCmcdStructure(data: Record<string, unknown>, options?: C
 
 	// Custom event checks
 	if ('e' in data) {
-		if (data['e'] === CMCD_EVENT_CUSTOM_EVENT) {
+		const eventType = toTokenString(data['e'])
+
+		if (eventType === CMCD_EVENT_CUSTOM_EVENT) {
 			if (!('cen' in data)) {
 				issues.push({
 					key: 'cen',
@@ -90,7 +93,7 @@ export function validateCmcdStructure(data: Record<string, unknown>, options?: C
 		}
 
 		// Response-received key restriction and required url
-		if (data['e'] === CMCD_EVENT_RESPONSE_RECEIVED) {
+		if (eventType === CMCD_EVENT_RESPONSE_RECEIVED) {
 			if (!('url' in data)) {
 				issues.push({
 					key: 'url',
@@ -112,18 +115,18 @@ export function validateCmcdStructure(data: Record<string, unknown>, options?: C
 		}
 
 		// State-change events require their associated field
-		for (const [eventType, requiredField] of CMCD_STATE_EVENT_FIELDS) {
-			if (data['e'] === eventType && !(requiredField in data)) {
+		for (const [stateEventType, requiredField] of CMCD_STATE_EVENT_FIELDS) {
+			if (eventType === stateEventType && !(requiredField in data)) {
 				issues.push({
 					key: requiredField,
-					message: `State-change event (e="${eventType}") requires the "${requiredField}" key to be present.`,
+					message: `State-change event (e="${stateEventType}") requires the "${requiredField}" key to be present.`,
 					severity: CMCD_VALIDATION_SEVERITY_ERROR
 				})
 			}
 		}
 
 		// Error event requires ec
-		if (data['e'] === CMCD_EVENT_ERROR && !('ec' in data)) {
+		if (eventType === CMCD_EVENT_ERROR && !('ec' in data)) {
 			issues.push({
 				key: 'ec',
 				message: 'Error event (e="e") requires the "ec" key to be present.',

--- a/libs/cmcd/src/validateCmcdValues.ts
+++ b/libs/cmcd/src/validateCmcdValues.ts
@@ -10,6 +10,7 @@ import type { CmcdValidationResult } from './CmcdValidationResult.ts'
 import { CMCD_VALIDATION_SEVERITY_ERROR, CMCD_VALIDATION_SEVERITY_WARNING } from './CmcdValidationSeverity.ts'
 import { isCmcdCustomKey } from './isCmcdCustomKey.ts'
 import { resolveVersion } from './resolveVersion.ts'
+import { toTokenString } from './toTokenString.ts'
 
 const HUNDRED_ROUNDING_KEYS = /* @__PURE__ */ new Set(['bl', 'dl', 'mtp', 'rtp', 'tbl'])
 const INTEGER_ROUNDING_KEYS = /* @__PURE__ */ new Set(['br', 'd', 'tb'])
@@ -209,10 +210,11 @@ export function validateCmcdValues(data: Record<string, unknown>, options?: Cmcd
 
 			case CMCD_KEY_TYPE_TOKEN: {
 				const validValues = CMCD_TOKEN_VALUES[key]
-				if (validValues && !validValues.includes(value as string)) {
+				const token = toTokenString(value)
+				if (validValues && (token === undefined || !validValues.includes(token))) {
 					issues.push({
 						key,
-						message: `Key "${key}" has invalid token value "${String(value)}". Expected one of: ${validValues.join(', ')}.`,
+						message: `Key "${key}" has invalid token value "${token ?? String(value)}". Expected one of: ${validValues.join(', ')}.`,
 						severity: CMCD_VALIDATION_SEVERITY_ERROR
 					})
 				}

--- a/libs/cmcd/test/decodeCmcd.test.ts
+++ b/libs/cmcd/test/decodeCmcd.test.ts
@@ -114,4 +114,24 @@ describe('decodeCmcd', () => {
 			su: true,
 		})
 	})
+
+	it('round-trips a token field that carries params with tokens reduced to strings', () => {
+		const s = 'ot=m;com.example-p=1,v=2'
+
+		equal(encodeCmcd(decodeCmcd(s) as Cmcd), s)
+	})
+
+	it('round-trips event reports whose e is preserved as a token', () => {
+		const options = { reportingMode: 'event' as const }
+		const strings = [
+			'bg=?0,e=b,ts=1000,v=2',
+			'e=pr,pr=1,ts=1000,v=2',
+			'e=rr,rc=200,ts=1000,url="https://example.com/seg.m4s",v=2',
+		]
+
+		for (const s of strings) {
+			equal(encodeCmcd(decodeCmcd(s, { useSymbol: false }) as Cmcd, options), s)
+			equal(encodeCmcd(decodeCmcd(s, { useSymbol: true }) as Cmcd, options), s)
+		}
+	})
 })

--- a/libs/cmcd/test/encodeCmcd.test.ts
+++ b/libs/cmcd/test/encodeCmcd.test.ts
@@ -1,6 +1,6 @@
-import type { CmcdEncodeOptions } from '@svta/cml-cmcd'
+import type { Cmcd, CmcdEncodeOptions } from '@svta/cml-cmcd'
 import { CmcdEventType, CmcdPlayerState, CmcdReportingMode, encodeCmcd } from '@svta/cml-cmcd'
-import { SfToken } from '@svta/cml-structured-field-values'
+import { SfItem, SfToken } from '@svta/cml-structured-field-values'
 import { equal, ok } from 'node:assert'
 import { describe, it } from 'node:test'
 import { toCmcdValue } from '@svta/cml-cmcd'
@@ -317,6 +317,36 @@ describe('encodeCmcd', () => {
 				br: [5000, 128],
 			}
 			equal(encodeCmcd(input), 'br=(5000 128),v=2')
+		})
+	})
+
+	describe('token values', () => {
+		it('re-tokenizes a token field wrapped in an SfItem', () => {
+			const input = { ot: new SfItem('m', { 'com.example-p': 1 }) } as unknown as Cmcd
+			equal(encodeCmcd(input), 'ot=m;com.example-p=1,v=2')
+		})
+
+		it('keeps response-received keys when e is an SfToken', () => {
+			const input = { e: new SfToken('rr'), rc: 200, ts: 1000, url: 'https://example.com/seg.m4s' } as unknown as Cmcd
+			equal(encodeCmcd(input, { reportingMode: CmcdReportingMode.EVENT }), 'e=rr,rc=200,ts=1000,url="https://example.com/seg.m4s",v=2')
+		})
+
+		it('keeps bg=false on a backgrounded-mode event when e is a Symbol', () => {
+			const input = { bg: false, e: Symbol.for('b'), ts: 1000 } as unknown as Cmcd
+			equal(encodeCmcd(input, { reportingMode: CmcdReportingMode.EVENT }), 'bg=?0,e=b,ts=1000,v=2')
+		})
+
+		it('keeps pr=1 on a playback-rate event when e is an SfToken', () => {
+			const input = { e: new SfToken('pr'), pr: 1, ts: 1000 } as unknown as Cmcd
+			equal(encodeCmcd(input, { reportingMode: CmcdReportingMode.EVENT }), 'e=pr,pr=1,ts=1000,v=2')
+		})
+
+		it('matches the ot param of an inner-list item by token text in V1 down-conversion', () => {
+			const input = {
+				br: [toCmcdValue(3000, { ot: Symbol.for('a') }), toCmcdValue(6000, { ot: Symbol.for('v') })],
+				ot: new SfToken('v'),
+			} as unknown as Cmcd
+			equal(encodeCmcd(input, { version: 1 }), 'br=6000,ot=v')
 		})
 	})
 })

--- a/libs/cmcd/test/validateCmcdEvents.test.ts
+++ b/libs/cmcd/test/validateCmcdEvents.test.ts
@@ -99,4 +99,10 @@ e=t,sid="session-1",ts=1700000001000,bl=(5000),v=2`
 		const result = validateCmcdEvents('')
 		deepStrictEqual(result.data, [])
 	})
+
+	it('accepts a token field that carries params', () => {
+		const result = validateCmcdEvents('e=ps,ot=m;com.example-p=1,sid="session-1",sta=p,ts=1700000000000,v=2')
+		equal(result.valid, true)
+		deepStrictEqual(result.issues, [])
+	})
 })

--- a/libs/cmcd/test/validateCmcdStructure.test.ts
+++ b/libs/cmcd/test/validateCmcdStructure.test.ts
@@ -1,4 +1,5 @@
 import { validateCmcdStructure } from '@svta/cml-cmcd'
+import { SfToken } from '@svta/cml-structured-field-values'
 import { equal } from 'node:assert'
 import { describe, it } from 'node:test'
 
@@ -185,5 +186,27 @@ describe('validateCmcdStructure', () => {
 		const result = validateCmcdStructure({ v: 3, br: 3000 })
 		equal(result.valid, false)
 		equal(result.issues.some(i => i.key === 'v' && i.severity === 'error'), true)
+	})
+
+	it('reports a missing state-change field when e is a Symbol', () => {
+		const result = validateCmcdStructure({ e: Symbol.for('ps'), ts: 123 }, { reportingMode: 'event' })
+		equal(result.valid, false)
+		equal(result.issues.some(i => i.key === 'sta' && i.severity === 'error'), true)
+	})
+
+	it('reports a missing ec when e is an SfToken', () => {
+		const result = validateCmcdStructure({ e: new SfToken('e'), ts: 123 }, { reportingMode: 'event' })
+		equal(result.valid, false)
+		equal(result.issues.some(i => i.key === 'ec' && i.severity === 'error'), true)
+	})
+
+	it('accepts cen on a custom event when e is an SfToken', () => {
+		const result = validateCmcdStructure({ e: new SfToken('ce'), cen: 'my-event', ts: 123 }, { reportingMode: 'event' })
+		equal(result.valid, true)
+	})
+
+	it('accepts response keys on a response-received event when e is a Symbol', () => {
+		const result = validateCmcdStructure({ e: Symbol.for('rr'), rc: 200, ts: 123, url: 'https://example.com/seg.m4s' }, { reportingMode: 'event' })
+		equal(result.valid, true)
 	})
 })

--- a/libs/cmcd/test/validateCmcdValues.test.ts
+++ b/libs/cmcd/test/validateCmcdValues.test.ts
@@ -1,5 +1,6 @@
 import { validateCmcdValues } from '@svta/cml-cmcd'
-import { equal } from 'node:assert'
+import { SfItem, SfToken } from '@svta/cml-structured-field-values'
+import { equal, match } from 'node:assert'
 import { describe, it } from 'node:test'
 
 describe('validateCmcdValues', () => {
@@ -137,5 +138,27 @@ describe('validateCmcdValues', () => {
 	it('accepts string key with correct type (smrt)', () => {
 		const result = validateCmcdValues({ smrt: 'base64data', v: 2 })
 		equal(result.valid, true)
+	})
+
+	it('accepts a token field wrapped in an SfItem', () => {
+		const result = validateCmcdValues({ ot: new SfItem('m', { 'com.example-p': 1 }) })
+		equal(result.valid, true)
+	})
+
+	it('accepts a token field decoded as a registry Symbol', () => {
+		const result = validateCmcdValues({ ot: Symbol.for('m') })
+		equal(result.valid, true)
+	})
+
+	it('accepts a token field decoded as an SfToken', () => {
+		const result = validateCmcdValues({ sf: new SfToken('d') })
+		equal(result.valid, true)
+	})
+
+	it('reports the token text of an invalid wrapped token value', () => {
+		const result = validateCmcdValues({ ot: new SfItem('zzz', { 'com.example-p': 1 }) })
+		equal(result.valid, false)
+		equal(result.issues[0].key, 'ot')
+		match(result.issues[0].message, /"zzz"/)
 	})
 })


### PR DESCRIPTION
## Summary

- Since 2.6.0 (#416), `decodeCmcd` returns a token field as an `SfItem` when the member carries parameters, and as a `Symbol` or an `SfToken` with `useSymbol`. The encoder and the validators still compared those values as plain strings.
- `encodeCmcd` wrote `ot=m;com.example-p=1` back as `ot="m";com.example-p=1`, which is not valid CMCD. With a `Symbol` or `SfToken` `e`, an `e=rr` report lost its response keys, `bg=?0` was dropped on `e=b`, and `pr=1` was dropped on `e=pr`. The version 1 down-conversion matched the `ot` parameter of inner-list items the same way.
- `validateCmcdValues` rejected valid tokens with `invalid token value "[object Object]"`. This is a 2.6.0 regression for the string validators such as `validateCmcdEvents`, because 2.5.0 dropped the parameters before validation. `validateCmcdStructure` skipped the event rules when `e` was not a plain string.
- One internal helper, `toTokenString`, resolves a string, a `Symbol`, an `SfToken`, or an `SfItem` to its token text. The encoder and both validators use it. The public API report is unchanged.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-cmcd | 2.6.0 | fix |

## Test Plan

- [x] 16 new tests, written first and failing against the 2.6.0 code: the encoder re-tokenizes an `SfItem`-wrapped token field, event reports with a `Symbol` or `SfToken` `e` keep their keys, the v1 down-conversion matches `ot` by token text, the validators accept `SfItem`, `Symbol`, and `SfToken` tokens, and `validateCmcdEvents` accepts `ot=m;com.example-p=1`
- [x] `npm test -w libs/cmcd`: 545 pass, 0 fail
- [x] `npm run typecheck`, `npx eslint libs/cmcd`, and `npm run build -w docs` pass
- [x] `cml-cmcd.api.md` is unchanged

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated (no guide describes these code paths, so the changelog is the only doc change)
- [x] Changelog updated

Fixes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
