### PR TITLE
fix: handle a package that is not on npm yet in the publish script

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -33,6 +33,20 @@ async function loadPackages(): Promise<Packages> {
 
 const tagRegex = /^\d+\.\d+\.\d+(.*$)/
 
+// npm view exits with E404 for a package that has never been published
+async function viewPublished(name: PackageName, prop: string): Promise<string | undefined> {
+	try {
+		return await exec(`npm view ${name} ${prop}`)
+	}
+	catch (error) {
+		if (error instanceof Error && error.message.includes('E404')) {
+			return undefined
+		}
+
+		throw error
+	}
+}
+
 async function getChanges(folder: string, version: string): Promise<string> {
 	const changelog = await readFile(path.resolve(folder, 'CHANGELOG.md'), 'utf8')
 	const sections = changelog.split(/^## /m)
@@ -74,7 +88,13 @@ async function processPackage(name: PackageName, pkg: Package, packages: Package
 
 	const tag = version.replace(tagRegex, '$1')
 	const prop = tag ? 'dist-tags.prerelease' : 'version'
-	const latest = await exec(`npm view ${name} ${prop}`)
+	const latest = await viewPublished(name, prop)
+
+	if (latest === undefined) {
+		console.log(`${name} is not on npm yet. Publishing ${version}...`)
+		return folder
+	}
+
 	const updated = latest.trim() !== version
 	const deps = await exec(`npm view ${name} peerDependencies --json`)
 


### PR DESCRIPTION
## Description

The publish script ran `npm view <name> version` for every package in the publish list before it published anything. For a package that has never been published, npm exits with `E404`, and the script died. [Publish run 34183487093](https://github.com/streaming-video-technology-alliance/common-media-library/actions/runs/34183487093/job/101927117477) failed this way on `@svta/cml-error-codes` 0.1.0 after #448 merged. The cascade bumps for cmcd 2.6.1 and request 1.0.17 were not published either. The first c2pa release on 2026-04-15 failed the same way.

`processPackage` now treats an `E404` from `npm view` as a package that needs its first publish. It logs that state, skips the peer-dependency check, and returns the folder for publishing. Other `npm view` failures still throw. `prepareRelease.ts` already handles the unpublished case the same way.

This change does not remove the manual bootstrap for a new package. CI publishes through npm trusted publishing, and a trusted publisher is configured per package on npmjs.com. The first publish of a new package still happens by hand, followed by the trusted-publisher setup. With this fix, the packages before it in the list publish, and the failure moves to the `npm publish` step of the new package.

Verification:

- `eslint scripts/publish.ts` and `tsc --noEmit -p scripts/tsconfig.json` pass.
- An end-to-end run of the patched script against the real registry, with `npm publish` and `gh release create` replaced by shell shims that print their arguments. The run logs `@svta/cml-error-codes is not on npm yet. Publishing 0.1.0...`, then publishes cmcd, request, and error-codes in that order, each followed by its release.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (n/a: `scripts/` has no test harness, verified with the end-to-end run above)
- [ ] Docs/guides updated (n/a)
- [ ] Changelog updated (n/a: repo script, not a published package)

Refs: #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
