### PR TITLE
fix: compare peer versions correctly in the publish script

### DIFF
--- a/scripts/compareVersions.ts
+++ b/scripts/compareVersions.ts
@@ -1,10 +1,11 @@
 // Precedence rules: https://semver.org/#spec-item-11
+// Pattern: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 type ParsedVersion = {
 	release: number[];
 	prerelease: string[];
 };
 
-const versionPattern = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 function parseVersion(version: string): ParsedVersion {
 	const match = versionPattern.exec(version)

--- a/scripts/compareVersions.ts
+++ b/scripts/compareVersions.ts
@@ -1,0 +1,77 @@
+// Precedence rules: https://semver.org/#spec-item-11
+type ParsedVersion = {
+	release: number[];
+	prerelease: string[];
+};
+
+const versionPattern = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+function parseVersion(version: string): ParsedVersion {
+	const match = versionPattern.exec(version)
+
+	if (!match) {
+		throw new Error(`Invalid version "${version}". Expected <major>.<minor>.<patch>[-<prerelease>][+<build>].`)
+	}
+
+	return {
+		release: [Number(match[1]), Number(match[2]), Number(match[3])],
+		prerelease: match[4] ? match[4].split('.') : [],
+	}
+}
+
+function compareIdentifiers(a: string, b: string): number {
+	const numericA = /^\d+$/.test(a)
+	const numericB = /^\d+$/.test(b)
+
+	if (numericA && numericB) {
+		return Math.sign(Number(a) - Number(b))
+	}
+
+	if (numericA) {
+		return -1
+	}
+
+	if (numericB) {
+		return 1
+	}
+
+	return a < b ? -1 : a > b ? 1 : 0
+}
+
+/**
+ * Returns `true` when `value` is one exact semantic version and not a range.
+ */
+export function isVersion(value: string): boolean {
+	return versionPattern.test(value)
+}
+
+/**
+ * Compares two semantic versions.
+ * Returns a negative number when `a` is lower than `b`, `0` when they are equal, and a positive number when `a` is higher.
+ */
+export function compareVersions(a: string, b: string): number {
+	const versionA = parseVersion(a)
+	const versionB = parseVersion(b)
+
+	for (let i = 0; i < 3; i++) {
+		if (versionA.release[i] !== versionB.release[i]) {
+			return versionA.release[i] - versionB.release[i]
+		}
+	}
+
+	if (versionA.prerelease.length === 0 || versionB.prerelease.length === 0) {
+		return versionB.prerelease.length - versionA.prerelease.length
+	}
+
+	const length = Math.min(versionA.prerelease.length, versionB.prerelease.length)
+
+	for (let i = 0; i < length; i++) {
+		const result = compareIdentifiers(versionA.prerelease[i], versionB.prerelease[i])
+
+		if (result !== 0) {
+			return result
+		}
+	}
+
+	return versionA.prerelease.length - versionB.prerelease.length
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -102,10 +102,10 @@ async function processPackage(name: PackageName, pkg: Package, packages: Package
 	if (!updated && deps) {
 		const parsed = JSON.parse(deps)
 		// npm 12 wraps the `--json` output of a single field in an array. npm 11 prints the object.
-		const peerDependencies: Record<string, string> = (Array.isArray(parsed) ? parsed[0] : parsed) ?? {}
+		const publishedPeers: Record<string, string> = (Array.isArray(parsed) ? parsed[0] : parsed) ?? {}
 
-		for (const dep in peerDependencies) {
-			const publishedPeer = peerDependencies[dep]
+		for (const dep in publishedPeers) {
+			const publishedPeer = publishedPeers[dep]
 
 			if (!packages[dep] || !isVersion(publishedPeer)) {
 				continue

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { cmd } from './cmd.ts'
+import { compareVersions, isVersion } from './compareVersions.ts'
 import { exec } from './exec.ts'
 import { projects } from './projects.ts'
 
@@ -79,18 +80,21 @@ async function processPackage(name: PackageName, pkg: Package, packages: Package
 	const deps = await exec(`npm view ${name} peerDependencies --json`)
 
 	if (!updated && deps) {
-		const peerDependencies = JSON.parse(deps)
+		const parsed = JSON.parse(deps)
+		// npm 12 wraps the `--json` output of a single field in an array. npm 11 prints the object.
+		const peerDependencies: Record<string, string> = (Array.isArray(parsed) ? parsed[0] : parsed) ?? {}
 
 		for (const dep in peerDependencies) {
-			// TODO: Remove the wildcard check after first successful publish.
-			if (!packages[dep] || peerDependencies[dep] === '*') {
+			const publishedPeer = peerDependencies[dep]
+
+			if (!packages[dep] || !isVersion(publishedPeer)) {
 				continue
 			}
 
-			const version = peerDependencies[dep]
+			const currentPeer = packages[dep][2].version
 
-			if (version < packages[dep][1]) {
-				throw new Error(`Package ${name} (${version}) needs to update its version because ${dep}'s version (${packages[dep][1]}) has changed.`)
+			if (compareVersions(publishedPeer, currentPeer) < 0) {
+				throw new Error(`Package ${name} (${version}) needs a version bump. Its published release depends on ${dep}@${publishedPeer}, and ${dep} is now ${currentPeer}. Run "npm run prepare-release".`)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

The publish script checks a package that is at its published version for peer dependencies that were bumped in the same release. If one was, the package needs its own bump, which `npm run prepare-release` normally cascades. That guard never fired, for two reasons:

- It compared the published peer version with `packages[dep][1]`, the path of the peer's package.json, instead of `packages[dep][2].version`. A version string always sorts after a path in a string comparison, so the condition was always false. The error message would also have printed a path where it says version.
- npm 12 wraps the `--json` output of `npm view <name> peerDependencies` in an array, so `for...in` visited the index `"0"` instead of the peer names. npm 11, which CI uses through `setup-node` with Node 24, prints the object.

Changes:

- New `scripts/compareVersions.ts` with `compareVersions` (Semantic Versioning 2.0.0 precedence, including prerelease identifiers) and `isVersion`. A plain string comparison orders `1.10.0` before `1.9.0`, and the root package declares no `semver` dependency, so a small helper avoids adding one.
- `processPackage` unwraps the array shape, reads the peer's current version from its package.json, and compares with `compareVersions`. Range peers are skipped, because a bumped peer still satisfies a range. c2pa declares `>=1.0.1` and `>=1.0.0` for its CML peers. That check replaces the wildcard check and its stale TODO, since `*` is not a version either.
- The error names the package, the published peer version, the current peer version, and the command that fixes it.

Verification:

- `eslint` and `tsc --noEmit -p scripts/tsconfig.json` pass.
- Comparison cases pass: numeric ordering, prerelease precedence from the spec examples, build metadata ignored, and ranges rejected by `isVersion`.
- End-to-end runs of the script against the npm registry, with `npm publish` and `gh release create` replaced by shims that print their arguments. Control runs publish cmcd and request with no false positive, including c2pa with range peers. With utils set to 1.6.1 locally, the guard stops the publish with `Package @svta/cml-drm (1.1.10) needs a version bump. Its published release depends on @svta/cml-utils@1.6.0, and @svta/cml-utils is now 1.6.1. Run "npm run prepare-release".`, under both npm 11 and npm 12. Without this change, the same run publishes.

This PR touches the same function as #449 in different hunks, so the two merge cleanly in either order.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (n/a: `scripts/` has no test harness, verified with the runs above)
- [ ] Docs/guides updated (n/a)
- [ ] Changelog updated (n/a: repo script, not a published package)

Refs: #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
