### PR TITLE
docs: describe the manual first publish of a new package

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Test
         run: npm test
 
+      # This workflow cannot publish a package that is not on npm yet.
+      # See "Publishing a New Package" in AGENTS.md.
       - name: Publish Package
         run: npm publish --provenance --access public -w libs/${{ inputs.package }}
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Test
         run: npm test
 
+      # This workflow cannot publish a package that is not on npm yet.
+      # See "Publishing a New Package" in AGENTS.md.
       - name: Publish
         run: npm run pub
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,19 @@ The strategic goal is **widespread adoption**. Evaluate every decision against t
 - `npm run ver <package> <version>`: Bump one package version during release prep. `<package>` is the folder name without the `libs/` prefix. The command updates `package.json` and inserts the new version section and compare links in `CHANGELOG.md`.
 - `npm run prepare-release`: Prepare a release. The command detects packages whose `package.json` version differs from the published npm version. It then cascades patch bumps, with changelog entries, to the packages that depend on them.
 
+## Publishing a New Package
+
+The Publish workflow uses npm trusted publishing. A trusted publisher is configured per package on npmjs.com. The workflow cannot publish a package that is not on npm yet. The first release of a new package needs these manual steps:
+
+1. Merge the release-prep PR. That PR sets the first version, adds the package to `scripts/projects.ts`, and sets the RFC status to `implemented`.
+2. From a clean checkout of `main`, run `npm ci` and `npm run build`.
+3. Publish the package once manually: `npm publish --no-provenance --access public -w libs/<package>`. The package sets `publishConfig.provenance`, and npm can only generate provenance in CI.
+4. On npmjs.com, open the package settings and add a trusted publisher. Select GitHub Actions with organization `streaming-video-technology-alliance`, repository `common-media-library`, and workflow `publish.yml`.
+5. Run the Publish workflow. It publishes the other packages of the release and skips the new package, because npm already has that version.
+6. Create the GitHub release for the new package manually: `gh release create <package>-v<version> --target main --title "@svta/cml-<package> v<version>"`. Use the changelog section of the version as the notes.
+
+If the Publish workflow runs before steps 3 and 4, the run fails. This happened for c2pa 1.0.0 on 2026-04-15 and for error-codes 0.1.0 on 2026-09-08.
+
 ## Developer Experience
 
 APIs are the product. Design them so that the easy way is the correct way:


### PR DESCRIPTION
## Description

The Publish workflow uses npm trusted publishing, and a trusted publisher is configured per package on npmjs.com. The workflow cannot publish a package that does not exist on npm yet. The first release of c2pa on 2026-04-15 and of error-codes on 2026-09-08 ([run 34183487093](https://github.com/streaming-video-technology-alliance/common-media-library/actions/runs/34183487093/job/101927117477)) both failed this way. The manual steps that resolved the c2pa release were not written down, so the error-codes release repeated the investigation.

Changes:

- `AGENTS.md` gains a "Publishing a New Package" section after the Build Commands, next to the `ver` and `prepare-release` documentation. It states the constraint and lists the six steps: merge the release-prep PR, build from a clean `main`, publish once with `--no-provenance`, add the trusted publisher on npmjs.com, re-run the Publish workflow, and create the GitHub release manually.
- `publish.yml` and `publish-package.yml` get a two-line comment above their publish step that points to that section.

Two details a reviewer may want to check:

- `--no-provenance` on the command line overrides `publishConfig.provenance` in package.json. npm's publish command filters out publishConfig keys that were set as CLI flags, so the documented command works without editing package.json.
- The text says the run fails when the manual steps are skipped, without saying where. That stays true after #449 merges, when the failure moves from `npm view` to the `npm publish` of the new package.

The new section measures 10 words per sentence on average with no flagged idioms, so it follows the writing rules in the same file.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (n/a: documentation only)
- [x] Docs/guides updated
- [ ] Changelog updated (n/a: repo documentation, not a published package)

Refs: #448, #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
