### PR TITLE
fix(cmcd): flag requests with CMCD in both headers and query

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Fixed
 
-- `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request, and CTA-5004 (version 1) says a request MUST NOT carry both. The headers are still validated and their data is returned. The query parameter is now read from the query string without parsing the full URL, so a relative URL no longer throws
+- `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request, and CTA-5004 (version 1) says a request MUST NOT carry both. The headers are still validated and their data is returned. The query parameter is now read from the query string without parsing the full URL, so a relative URL no longer throws. A `CMCD` parameter inside the URL fragment is not read as a query parameter. When the fragment is the only place that holds one, the error message says so, because a server never receives a fragment
 
 ## [2.6.1] - 2026-09-07
 

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to
 
 ### Fixed
 
-- `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request, and CTA-5004 (version 1) says a request MUST NOT carry both. The headers are still validated and their data is returned. The query parameter is now read from the query string without parsing the full URL, so a relative URL no longer throws. A `CMCD` parameter inside the URL fragment is not read as a query parameter. When the fragment is the only place that holds one, the error message says so, because a server never receives a fragment
 
 ## [2.6.1] - 2026-09-07
 

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request, and CTA-5004 (version 1) says a request MUST NOT carry both. The headers are still validated and their data is returned. The query parameter is now read from the query string without parsing the full URL, so a relative URL no longer throws
+
 ## [2.6.1] - 2026-09-07
 
 ### Fixed

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Fixed
 
+- `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request. The validator still checks the headers and returns their data
+- `validateCmcdRequest` reads the `CMCD` parameter from the query string and ignores the URL fragment. A relative URL no longer throws. When the fragment is the only place with a `CMCD` parameter, the error message says so
 
 ## [2.6.1] - 2026-09-07
 

--- a/libs/cmcd/docs/validation-guide.md
+++ b/libs/cmcd/docs/validation-guide.md
@@ -95,7 +95,7 @@ In request mode, CMCD data is attached to segment requests as query parameters o
 
 ### Using `validateCmcdRequest`
 
-The `validateCmcdRequest` function accepts a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object or an `HttpRequest` object from `@svta/cml-utils`. It checks for CMCD headers first. If it finds any CMCD header shards, it delegates to `validateCmcdHeaders`, which verifies the shard placement. Otherwise, it extracts the `CMCD` query parameter from the URL.
+The `validateCmcdRequest` function accepts a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object or an `HttpRequest` object from `@svta/cml-utils`. It checks for CMCD headers first. If it finds any CMCD header shards, it delegates to `validateCmcdHeaders`, which verifies the shard placement. Otherwise, it extracts the `CMCD` query parameter from the URL. A request that carries CMCD data in both the headers and the query parameter is an error. CTA-5004-B allows one transmission mode per request. The validator still checks the headers and returns their data.
 
 ```typescript
 import { validateCmcdRequest } from "@svta/cml-cmcd";

--- a/libs/cmcd/docs/validation-guide.md
+++ b/libs/cmcd/docs/validation-guide.md
@@ -95,7 +95,7 @@ In request mode, CMCD data is attached to segment requests as query parameters o
 
 ### Using `validateCmcdRequest`
 
-The `validateCmcdRequest` function accepts a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object or an `HttpRequest` object from `@svta/cml-utils`. It checks for CMCD headers first. If it finds any CMCD header shards, it delegates to `validateCmcdHeaders`, which verifies the shard placement. Otherwise, it extracts the `CMCD` query parameter from the URL. A request that carries CMCD data in both the headers and the query parameter is an error. CTA-5004-B allows one transmission mode per request. The validator still checks the headers and returns their data.
+The `validateCmcdRequest` function accepts a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object or an `HttpRequest` object from `@svta/cml-utils`. It checks for CMCD headers first. If it finds any CMCD header shards, it delegates to `validateCmcdHeaders`, which verifies the shard placement. Otherwise, it extracts the `CMCD` query parameter from the URL. A request that carries CMCD data in both the headers and the query parameter is an error. CTA-5004-B allows one transmission mode per request. The validator still checks the headers and returns their data. A `CMCD` parameter inside the URL fragment is ignored, because a server never receives the fragment. When it is the only CMCD data on the request, the error message names the fragment.
 
 ```typescript
 import { validateCmcdRequest } from "@svta/cml-cmcd";

--- a/libs/cmcd/src/validateCmcdRequest.ts
+++ b/libs/cmcd/src/validateCmcdRequest.ts
@@ -5,9 +5,11 @@ import type { CmcdDataValidationResult } from './CmcdDataValidationResult.ts'
 import { type CmcdHeaderField, CMCD_HEADER_FIELDS } from './CmcdHeaderField.ts'
 import { CMCD_REQUEST_MODE } from './CmcdReportingMode.ts'
 import type { CmcdValidationOptions } from './CmcdValidationOptions.ts'
+import type { CmcdValidationResult } from './CmcdValidationResult.ts'
 import { CMCD_VALIDATION_SEVERITY_ERROR } from './CmcdValidationSeverity.ts'
 import { decodeCmcd } from './decodeCmcd.ts'
 import { ensureHeaders } from './ensureHeaders.ts'
+import { mergeValidationResults } from './mergeValidationResults.ts'
 import { validateCmcd } from './validateCmcd.ts'
 import { validateCmcdHeaders } from './validateCmcdHeaders.ts'
 
@@ -21,7 +23,9 @@ import { validateCmcdHeaders } from './validateCmcdHeaders.ts'
  * The function checks for CMCD data in the HTTP headers first. If CMCD
  * headers are found, validation includes shard-placement checks via
  * {@link validateCmcdHeaders}. Otherwise, the CMCD query parameter is
- * extracted from the URL and validated.
+ * extracted from the URL and validated. A request that carries CMCD data
+ * in both the headers and the `CMCD` query parameter is an error. The
+ * headers are still validated and their data is returned.
  *
  * @param request - A `Request` or `HttpRequest` to validate.
  * @param options - Validation options (excluding `reportingMode`).
@@ -36,12 +40,25 @@ import { validateCmcdHeaders } from './validateCmcdHeaders.ts'
  */
 export function validateCmcdRequest(request: Request | HttpRequest, options?: Omit<CmcdValidationOptions, 'reportingMode'>): CmcdDataValidationResult {
 	const headers = extractHeaderRecord(request.headers)
+	const param = getCmcdQueryParam(request.url)
 
 	if (headers) {
-		return validateCmcdHeaders(headers, options)
-	}
+		const result = validateCmcdHeaders(headers, options)
 
-	const param = new URL(request.url).searchParams.get(CMCD_PARAM)
+		if (!param) {
+			return result
+		}
+
+		const conflict: CmcdValidationResult = {
+			valid: false,
+			issues: [{
+				message: 'CMCD data found in both request headers and the "CMCD" query parameter. A request must use only one transmission mode.',
+				severity: CMCD_VALIDATION_SEVERITY_ERROR,
+			}],
+		}
+
+		return { ...mergeValidationResults(conflict, result), data: result.data }
+	}
 
 	if (!param) {
 		return {
@@ -70,6 +87,18 @@ export function validateCmcdRequest(request: Request | HttpRequest, options?: Om
 
 	const result = validateCmcd(data, { ...options, reportingMode: CMCD_REQUEST_MODE })
 	return { ...result, data }
+}
+
+function getCmcdQueryParam(url: string): string | null {
+	const start = url.indexOf('?')
+
+	if (start < 0) {
+		return null
+	}
+
+	const end = url.indexOf('#', start)
+
+	return new URLSearchParams(url.slice(start + 1, end < 0 ? url.length : end)).get(CMCD_PARAM)
 }
 
 function extractHeaderRecord(headers: Headers | Record<string, string> | undefined): Partial<Record<CmcdHeaderField, string>> | undefined {

--- a/libs/cmcd/src/validateCmcdRequest.ts
+++ b/libs/cmcd/src/validateCmcdRequest.ts
@@ -64,7 +64,9 @@ export function validateCmcdRequest(request: Request | HttpRequest, options?: Om
 		return {
 			valid: false,
 			issues: [{
-				message: 'No CMCD data found in request headers or query parameters.',
+				message: hasCmcdInFragment(request.url)
+					? 'No CMCD data found in request headers or query parameters. The URL fragment contains a "CMCD" parameter. A server never receives the fragment.'
+					: 'No CMCD data found in request headers or query parameters.',
 				severity: CMCD_VALIDATION_SEVERITY_ERROR,
 			}],
 			data: {} as CmcdData,
@@ -89,16 +91,24 @@ export function validateCmcdRequest(request: Request | HttpRequest, options?: Om
 	return { ...result, data }
 }
 
+const CMCD_IN_FRAGMENT = /(?:^|[?&])CMCD=/
+
 function getCmcdQueryParam(url: string): string | null {
-	const start = url.indexOf('?')
+	const hash = url.indexOf('#')
+	const path = hash < 0 ? url : url.slice(0, hash)
+	const start = path.indexOf('?')
 
 	if (start < 0) {
 		return null
 	}
 
-	const end = url.indexOf('#', start)
+	return new URLSearchParams(path.slice(start + 1)).get(CMCD_PARAM)
+}
 
-	return new URLSearchParams(url.slice(start + 1, end < 0 ? url.length : end)).get(CMCD_PARAM)
+function hasCmcdInFragment(url: string): boolean {
+	const hash = url.indexOf('#')
+
+	return hash >= 0 && CMCD_IN_FRAGMENT.test(url.slice(hash + 1))
 }
 
 function extractHeaderRecord(headers: Headers | Record<string, string> | undefined): Partial<Record<CmcdHeaderField, string>> | undefined {

--- a/libs/cmcd/test/validateCmcdRequest.test.ts
+++ b/libs/cmcd/test/validateCmcdRequest.test.ts
@@ -137,6 +137,74 @@ describe('validateCmcdRequest', () => {
 		})
 	})
 
+	describe('both transmission modes', () => {
+		const message = 'CMCD data found in both request headers and the "CMCD" query parameter. A request must use only one transmission mode.'
+
+		it('reports error for a Request with CMCD headers and a CMCD query parameter', () => {
+			const request = new Request('https://cdn.example.com/seg.mp4?CMCD=br%3D5000', {
+				headers: {
+					'CMCD-Object': 'br=3000,d=4004',
+				},
+			})
+			const result = validateCmcdRequest(request)
+			equal(result.valid, false)
+			equal(result.issues.some(i => i.severity === 'error' && i.message === message), true)
+		})
+
+		it('reports error for an HttpRequest with CMCD headers and a CMCD query parameter', () => {
+			const result = validateCmcdRequest({
+				url: 'https://cdn.example.com/seg.mp4?CMCD=br%3D5000',
+				headers: {
+					'CMCD-Object': 'br=3000,d=4004',
+				},
+			})
+			equal(result.valid, false)
+			equal(result.issues.some(i => i.severity === 'error' && i.message === message), true)
+		})
+
+		it('still validates the headers and returns their data', () => {
+			const result = validateCmcdRequest({
+				url: 'https://cdn.example.com/seg.mp4?CMCD=br%3D5000',
+				headers: {
+					'CMCD-Object': 'bl=21600',
+				},
+			})
+			equal(result.issues.some(i => i.key === 'bl'), true)
+			equal(result.data['bl'], 21600)
+			equal('br' in result.data, false)
+		})
+
+		it('does not report the error when the query parameter is empty', () => {
+			const result = validateCmcdRequest({
+				url: 'https://cdn.example.com/seg.mp4?CMCD=',
+				headers: {
+					'CMCD-Object': 'br=3000,d=4004',
+				},
+			})
+			equal(result.valid, true)
+		})
+	})
+
+	describe('relative URLs', () => {
+		it('validates headers on a relative URL', () => {
+			const result = validateCmcdRequest({
+				url: 'seg.mp4',
+				headers: {
+					'CMCD-Object': 'br=3000,d=4004',
+				},
+			})
+			equal(result.valid, true)
+		})
+
+		it('validates the query parameter on a relative URL', () => {
+			const result = validateCmcdRequest({
+				url: 'seg.mp4?CMCD=br%3D3000%2Cbl%3D21600#t=10',
+			})
+			equal(result.valid, true)
+			equal(result.data['bl'], 21600)
+		})
+	})
+
 	it('returns decoded data from headers path', () => {
 		const result = validateCmcdRequest({
 			url: 'https://cdn.example.com/seg.mp4',

--- a/libs/cmcd/test/validateCmcdRequest.test.ts
+++ b/libs/cmcd/test/validateCmcdRequest.test.ts
@@ -205,6 +205,45 @@ describe('validateCmcdRequest', () => {
 		})
 	})
 
+	describe('URL fragments', () => {
+		const url = 'https://cdn.example.com/seg.mp4#t=10?CMCD=br%3D5000'
+
+		it('ignores a CMCD parameter inside the fragment when headers are present', () => {
+			const result = validateCmcdRequest({
+				url,
+				headers: {
+					'CMCD-Object': 'br=3000,d=4004',
+				},
+			})
+			equal(result.valid, true)
+			deepStrictEqual(result.issues, [])
+			equal(result.data['br'], 3000)
+		})
+
+		it('ignores a CMCD parameter inside the fragment of a Request', () => {
+			const request = new Request(url, {
+				headers: {
+					'CMCD-Object': 'br=3000,d=4004',
+				},
+			})
+			equal(validateCmcdRequest(request).valid, true)
+		})
+
+		it('reports no CMCD data and names the fragment when the parameter is only in the fragment', () => {
+			const result = validateCmcdRequest({ url })
+			equal(result.valid, false)
+			equal(result.issues.length, 1)
+			equal(result.issues[0].message, 'No CMCD data found in request headers or query parameters. The URL fragment contains a "CMCD" parameter. A server never receives the fragment.')
+			deepStrictEqual(result.data, {})
+		})
+
+		it('keeps the plain message when the fragment has no CMCD parameter', () => {
+			const result = validateCmcdRequest({ url: 'https://cdn.example.com/seg.mp4#t=10' })
+			equal(result.valid, false)
+			equal(result.issues[0].message, 'No CMCD data found in request headers or query parameters.')
+		})
+	})
+
 	it('returns decoded data from headers path', () => {
 		const result = validateCmcdRequest({
 			url: 'https://cdn.example.com/seg.mp4',


### PR DESCRIPTION
## Summary

- `validateCmcdRequest` validated the CMCD headers when any were present and ignored a `CMCD` query parameter on the same request. CTA-5004 (v1) says a request MUST NOT carry both, and CTA-5004-B says each report MUST use only one transmission mode.
- The validator now reports an error when both are present. It still validates the headers and returns their data, so a receiver keeps the other findings.
- The query parameter is read from the query string instead of the full URL. A header-only request with a relative URL keeps working, and a query-only request with a relative URL no longer throws. A `CMCD` parameter inside the URL fragment is not a query parameter. When it is the only CMCD on the request, the error message says so, because a server never receives a fragment.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-cmcd | 2.6.1 | fix |

## Test Plan

- [x] `npm run build -w libs/cmcd` and `npm test -w libs/cmcd`: 555 tests pass, 10 of them new (`Request` and `HttpRequest` conflict cases, headers still validated, empty `CMCD=` not flagged, relative URLs, URL fragments)
- [x] `npm run typecheck` and `eslint .` pass
- [x] `npm run build -w docs` passes
- [x] The API report `libs/cmcd/config/cml-cmcd.api.md` has no diff

Notes for review:

- `CmcdReporter` never emits both modes by itself: `createRequestReport` is a `switch` on `transmissionMode`. It does copy the incoming headers, so a caller that already set `CMCD-*` headers and runs the reporter in query mode produces both. That is the caller's request, not the reporter's output.
- This branch and #453 both add a `### Fixed` block under `## [Unreleased]` in the cmcd changelog. Whichever merges second has a small changelog conflict.

Refs: #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
