### PR TITLE
[RFC] Session API for CMCD version 2

### DIFF
--- a/plans/cmcd-session-api/architecture.md
+++ b/plans/cmcd-session-api/architecture.md
@@ -8,10 +8,10 @@ Baseline: `main` at `2653a012`, `@svta/cml-cmcd` 2.6.1 plus the unreleased fixes
 
 | Unit | Owns | Public |
 |---|---|---|
-| Session | the `sid`, the normalized configuration, the players, the targets, the timers, the visibility listener, and the session totals | `CmcdSession` |
-| Player | the pushed store, the reported baselines of `sta`, `pr`, `cid`, and `br`, the host, the `su` derivation, and the open starvation span | `CmcdPlayer` |
-| Target | one destination: `sn`, the `msd` gate, the `bsd` cursor, the per-player `bs` flag and `ec` buffer, and for an event target the queue, the back-off, and the 410 flag | no |
-| Request origin | the link from a decorated request to its player, its request target, its raw per-request data, its start time, and its host | no |
+| Session | the `sid`, the normalized configuration, the reporters, the targets, the timers, the visibility listener, and the session totals | `CmcdSession` |
+| Reporter | the pushed store, the reported baselines of `sta`, `pr`, `cid`, and `br`, the host, the `su` derivation, and the open starvation span | `CmcdSessionReporter` |
+| Target | one destination: `sn`, the `msd` gate, the `bsd` cursor, the per-reporter `bs` flag and `ec` buffer, and for an event target the queue, the back-off, and the 410 flag | no |
+| Request origin | the link from a decorated request to its reporter, its request target, its raw per-request data, its start time, and its host | no |
 | Preparation | the key table, value normalization, filtering, and encoding | no, `encodeCmcd` moves onto it later |
 
 The request target and the event targets share one state type and one report path. They differ in the encoder output, a query parameter or headers against a body line, and in delivery. The request target has no queue, because the player sends the request.
@@ -24,20 +24,20 @@ One export per file, per the package rule. Names are a starting point for the im
 |---|---|---|
 | `createCmcdSession.ts` | `createCmcdSession` | public |
 | `CmcdSession.ts`, `CmcdSessionConfig.ts`, `CmcdEventTargetConfig.ts`, `CmcdTransport.ts` | types | public |
-| `CmcdPlayer.ts`, `CmcdPlayerConfig.ts`, `CmcdPlayerData.ts`, `CmcdMetric.ts`, `CmcdNextObject.ts` | types | public |
+| `CmcdSessionReporter.ts`, `CmcdSessionReporterConfig.ts`, `CmcdPlaybackData.ts`, `CmcdMetric.ts`, `CmcdNextObject.ts` | types | public |
 | `CmcdRequestLike.ts`, `CmcdDecoratedRequest.ts`, `CmcdRequestRecord.ts`, `CmcdResponseInfo.ts`, `CmcdResourceTiming.ts` | types | public |
 | `CmcdRequestTransform.ts`, `CmcdEventTransform.ts`, `CmcdDiscreteEventType.ts` | types | public |
 | `CmcdEventType.ts` | adds `CMCD_EVENT_HOSTNAME` and `HOSTNAME` | public, existing file |
 | `CmcdKeySpec.ts`, `CMCD_KEY_SPECS.ts` | the key table | internal |
 | `normalizeValue.ts`, `formatNor.ts` | value normalization | internal |
 | `prepareReport.ts` | the table-driven preparation loop | internal |
-| `createCmcdSessionState.ts`, `createCmcdPlayerState.ts`, `createCmcdTargetState.ts` | state factories | internal |
+| `createCmcdSessionState.ts`, `createCmcdReporterState.ts`, `createCmcdTargetState.ts` | state factories | internal |
 | `deriveStateEvents.ts` | the state-change diff and the transition tracking | internal |
 | `assembleReport.ts` | the merge order and the derived defaults | internal |
 | `emitReport.ts` | transform, prepare, encode, commit, for one target | internal |
 | `deliverBatch.ts` | POST, response handling, back-off | internal |
 | `toResponseKeys.ts`, `readCmsdHeaders.ts` | the `rr` derivations | internal |
-| `observeVisibility.ts` | the `bg` listener | internal |
+| `observeVisibility.ts` | the `bg` listener, when `derive.bg` is on | internal |
 | `CMCD_REQUEST_ORIGINS.ts` | the `WeakMap` from record to origin | internal |
 
 No module runs code at import time. The key table is an object literal, so it needs no purity annotation. The `WeakMap` is created inside a function that runs on first use, or has the annotation.
@@ -50,7 +50,7 @@ No module runs code at import time. The key table is an object literal, so it ne
 |---|---|---|
 | `sid` | `string` | immutable |
 | `config` | normalized `CmcdSessionConfig` | defaults applied, lists copied |
-| `players` | `Set<PlayerState>` | insertion order is creation order |
+| `reporters` | `Set<ReporterState>` | insertion order is creation order |
 | `requestTarget` | `TargetState` | always present |
 | `eventTargets` | `TargetState[]` | one per configured target |
 | `timers` | `ReturnType<typeof setInterval>[]` | one per event target with `t` and an interval over 0 |
@@ -62,7 +62,7 @@ No module runs code at import time. The key table is an object literal, so it ne
 | `countersSupplied` | `{ bsa?: true; bsda?: true; bsd?: true }` | per-key sticky override |
 | `disposed` | `boolean` | |
 
-### Player
+### Reporter
 
 | Field | Type | Notes |
 |---|---|---|
@@ -84,7 +84,7 @@ No module runs code at import time. The key table is an object literal, so it ne
 | `sn` | `number` | next sequence number |
 | `msdSent` | `boolean` | |
 | `bsdCursor` | `number` | completed spans delivered to this target |
-| `perPlayer` | `Map<PlayerState, { bs: boolean; ec: string[] }>` | entry removed on player dispose |
+| `perReporter` | `Map<ReporterState, { bs: boolean; ec: string[] }>` | entry removed on reporter dispose |
 | `queue` | `string[]` | event targets only, encoded lines |
 | `attempt`, `retryTimer` | `number`, timer handle or `undefined` | back-off state |
 | `gone` | `boolean` | set by a 410 |
@@ -93,17 +93,17 @@ No module runs code at import time. The key table is an object literal, so it ne
 
 | Field | Type |
 |---|---|
-| `player` | `PlayerState` |
-| `data` | the raw per-request `CmcdPlayerData` |
+| `reporter` | `ReporterState` |
+| `data` | the raw per-request `CmcdPlaybackData` |
 | `startedAt` | epoch milliseconds at `decorate()` |
 
-The origin is stored in a `WeakMap` keyed by the `CmcdRequestRecord` object. A spread copy of the request keeps the same record object, so the lookup still resolves. JSON produces a new object, so the lookup fails and the response reports under the calling player.
+The origin is stored in a `WeakMap` keyed by the `CmcdRequestRecord` object. A spread copy of the request keeps the same record object, so the lookup still resolves. JSON produces a new object, so the lookup fails and the response reports under the calling reporter.
 
 ## Algorithms
 
 ### update(data)
 
-1. If the player or its session is disposed, return.
+1. If the reporter or its session is disposed, return.
 2. Take `ts` from `data`, default `Date.now()`. Do not store it.
 3. For `bg`, `msd`, `bsa`, `bsda`, and `bsd` in `data`: write the value on the session and set the supplied flag. Remove the key from the merge. A pushed `bg` also calls `stopVisibility`.
 4. Merge the rest into `store`. Set `suSupplied` or `dlSupplied` when `su` or `dl` is present.
@@ -118,7 +118,7 @@ Runs when `sta` changes from the previous stored value.
 |---|---|
 | into s, with no `msdStart` | `msdStart = ts` |
 | into p, with `msdStart` set and `msd` unset | `msd = ts - msdStart`, when `msdSupplied` is false |
-| into r | `spanOpenedAt = ts`, `bsa += 1`, set `bs` on every target's entry for this player |
+| into r | `spanOpenedAt = ts`, `bsa += 1`, set `bs` on every target's entry for this reporter |
 | out of r, with `spanOpenedAt` set | push `ts - spanOpenedAt` to `spans`, add it to `bsda`, clear `spanOpenedAt` |
 | into s, k, or r | `su = true` |
 | into p | `su = false` |
@@ -134,9 +134,9 @@ For each field in the order `sta`, `pr`, `cid`, `bg`, `br`:
 3. Skip `pr` when the store's `sta` is not p.
 4. Set the reported value, then emit the event to every event target that lists it.
 
-`bg` emits one line per live player, like `t`. The others emit one line for the player. A `pr` change while paused is picked up on the next diff that runs while `sta` is p, because step 2 still sees a difference.
+`bg` emits one line per live reporter, like `t`. The others emit one line for the reporter. A `pr` change while paused is picked up on the next diff that runs while `sta` is p, because step 2 still sees a difference.
 
-### Emit(event, player, data, request?)
+### Emit(event, reporter, data, request?)
 
 For each event target that lists the event and is not gone:
 
@@ -145,16 +145,16 @@ For each event target that lists the event and is not gone:
 3. After every target, process the target queues.
 4. Rethrow the collected error. On a timer tick, pass it to `onError` instead, or throw when `onError` is absent.
 
-### Assemble(player, target, event?, data?)
+### Assemble(reporter, target, event?, data?)
 
 Merge in this order, later wins:
 
-1. the player's `store`
+1. the reporter's `store`
 2. the session data: `sid`, `v`, `bg`, `msd` when the target's gate is open, `bsa`, `bsda`, and the spans after the target's `bsdCursor` as `bsd`
 3. `data`
-4. the target's entry for the player: `bs` when flagged, `ec` when the buffer is not empty
-5. `su` from the player when `suSupplied` is false and the report has no `su`
-6. `dl` from `bl / pr` when `dlSupplied` is false, the report has `bl` and no `dl`, and `pr` is over 0 or absent
+4. the target's entry for the reporter: `bs` when flagged, `ec` when the buffer is not empty
+5. `su` from the reporter when `derive.su` is on, `suSupplied` is false, and the report has no `su`
+6. `dl` from `bl / pr` when `derive.dl` is on, `dlSupplied` is false, the report has `bl` and no `dl`, and `pr` is over 0 or absent
 7. `e` and `ts` for an event
 
 ### emitReport(target, report, event?, request?)
@@ -162,20 +162,20 @@ Merge in this order, later wins:
 1. When the target has a transform: copy nested values, run the transform, return on `null`, restore a removed required key, re-stamp `sid`, `e`, and `ts`.
 2. `report.sn = target.sn`.
 3. Prepare (below) and encode. An encoder error propagates, and step 4 does not run.
-4. Commit: `target.sn += 1`. When the output has `msd`, `msdSent = true`. Clear the player's `bs` and `ec` entry. Move `bsdCursor` to the end of the spans when the output has `bsd`.
+4. Commit: `target.sn += 1`. When the output has `msd`, `msdSent = true`. Clear the reporter's `bs` and `ec` entry. Move `bsdCursor` to the end of the spans when the output has `bsd`.
 5. Event target: push the line to the queue. Request target: return the prepared data for the URL or the headers.
 
 ### decorate(request, data)
 
 1. If disposed, return a copy of the request with a record `{ sid, data: {} }` and no origin.
-2. Read the host of `request.url`. When `hSupplied` is false and the host differs from `player.host`, set it and emit `h` after step 5.
+2. Read the host of `request.url`. When `hSupplied` is false and the host differs from `reporter.host`, set it and emit `h` after step 5.
 3. Assemble with the request target and `data`. Run `emitReport`. A cancelled report leaves the request as is.
 4. Query mode: set the `CMCD` query parameter, replacing an existing one. Header mode: copy `headers` and set the non-empty shards. `nor` values use `request.url` as the base for the relative path.
-5. Create the record `{ sid, data: prepared }`, store the origin `{ player, data, startedAt: Date.now() }`, and return `{ ...request, url, headers, cmcd: record }`.
+5. Create the record `{ sid, data: prepared }`, store the origin `{ reporter, data, startedAt: Date.now() }`, and return `{ ...request, url, headers, cmcd: record }`.
 
 ### recordResponse(request, info, data)
 
-1. Resolve the origin from `request.cmcd`. Without one, the origin is the calling player with empty data and no start time.
+1. Resolve the origin from `request.cmcd`. Without one, the origin is the calling reporter with empty data and no start time.
 2. Derive the response keys:
    - `url`: `request.url` without the `CMCD` parameter
    - `rc`: `info.status`, or 0
@@ -183,17 +183,17 @@ Merge in this order, later wins:
    - `ttfb`: `responseStart - startTime`
    - `ttlb`: `duration`, or `responseEnd - startTime`, else `Date.now() - origin.startedAt`
    - `cmsds` and `cmsdd`: the `CMSD-Static` and `CMSD-Dynamic` headers, base64 encoded
-3. Assemble for each `rr` target of the origin session: the origin player's store, the session data, `origin.data`, the derived keys, then `data`.
+3. Assemble for each `rr` target of the origin session: the origin reporter's store, the session data, `origin.data`, the derived keys, then `data`.
 4. Emit `rr` with the decorated request as the transform argument.
 5. When the origin session is disposed, dispatch its queues at once.
 
 ### Tick(target)
 
-For each live player in creation order, assemble with `t` and emit to this one target. With no players, emit one line from the session data alone. Then process the queue.
+For each live reporter in creation order, assemble with `t` and emit to this one target. With no reporters, emit one line from the session data alone. Then process the queue.
 
 ### dispose()
 
-Session: set `disposed`, clear the timers, call `stopVisibility`, mark every player disposed, and dispatch every queue in full. Player: set `disposed`, remove the player from `players`, and delete its entries in every target. A late response for a disposed player still resolves through its origin, because the origin references the player object.
+Session: set `disposed`, clear the timers, call `stopVisibility`, mark every reporter disposed, and dispatch every queue in full. Reporter: set `disposed`, remove the reporter from `reporters`, and delete its entries in every target. A late response for a disposed reporter still resolves through its origin, because the origin references the reporter object.
 
 ## Delivery
 
@@ -301,7 +301,7 @@ for key of report keys, sorted:
 | `update()` with one state change | one report object per event target, plus one copy per target with a transform |
 | `decorate()` | the report, the prepared object, the request copy, the record, the origin |
 | `recordResponse()` | the report per `rr` target |
-| tick | one report per player per target |
+| tick | one report per reporter per target |
 | idle | none |
 
 There is no per-call session lookup, no eviction pass, and no scan of past sessions. A late response follows one `WeakMap` read. `br` comparison in the diff is a loop over a short array.
@@ -315,12 +315,12 @@ Tests import from `@svta/cml-cmcd` and run against the built package.
 | Spec conformance | one fixture per scenario in CTA-5004-B section 8: 8.1.1 to 8.1.8, 8.2.1 to 8.2.9, and 8.3. Drive the API with an injected clock and compare the wire string to the spec text, after removing the whitespace the document formatting adds |
 | Derivations | one test per row of the derived keys table in the RFC, including the supplied-value override |
 | State-change diff | order, dedup, `pr` while paused, `cid` at creation, `bg` on the session, `br` by value |
-| Multi-player | two players, one `sid`, `sn` continuity per target, one `t` line per player, `nr`, player dispose |
+| Multi-player | two reporters, one `sid`, `sn` continuity per target, one `t` line per reporter, `nr`, reporter dispose |
 | Late responses | after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone |
 | Delivery | mock transport with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive |
 | Errors | configuration checks and their messages, encoder failure commits nothing, throwing transform isolation, `onError` on a tick |
 | Validation | every emitted line passes `validateCmcdEvents` or `validateCmcdRequest` |
-| Types | `@ts-expect-error` for a state-change type in `recordEvent`, `ce` without `cen`, `version` on an event target, `ec` in `CmcdPlayerData` |
+| Types | `@ts-expect-error` for a state-change type in `recordEvent`, `ce` without `cen`, `version` on an event target, `ec` in `CmcdPlaybackData` |
 | Bundle | the bare-import side-effect probe, and a size probe against the baseline in `comparison.md` |
 
 ## Sequencing
@@ -328,7 +328,7 @@ Tests import from `@svta/cml-cmcd` and run against the built package.
 A suggested order for `steps.md`.
 
 1. The key table, `normalizeValue`, `formatNor`, and `prepareReport`, with the spec fixtures for the wire strings.
-2. Session and player state, `update()`, the diff, and the transition tracking.
+2. Session and reporter state, `update()`, the diff, and the transition tracking.
 3. Targets, `emitReport`, and `decorate()`.
 4. `recordResponse()` and the origins.
 5. Delivery, timers, and `dispose()`.
@@ -348,7 +348,7 @@ These are independent of the RFC and can ship as fixes.
 
 ## Open implementation questions
 
-1. Whether `CmcdSession` and `CmcdPlayer` are plain objects from a factory or classes. Plain objects match the `create*` pattern of the package and mangle better. Classes give `instanceof`.
-2. Whether the request origin should hold the player strongly. A strong reference keeps a disposed player alive until its requests complete, which is the intended retention.
-3. Whether the `t` tick for a session without players should emit a line at all.
+1. Whether `CmcdSession` and `CmcdSessionReporter` are plain objects from a factory or classes. Plain objects match the `create*` pattern of the package and mangle better. Classes give `instanceof`.
+2. Whether the request origin should hold the reporter strongly. A strong reference keeps a disposed reporter alive until its requests complete, which is the intended retention.
+3. Whether the `t` tick for a session without reporters should emit a line at all.
 4. The exact configuration error type: `TypeError` for a wrong type and `RangeError` for a wrong value, or one `Error` with a code.

--- a/plans/cmcd-session-api/architecture.md
+++ b/plans/cmcd-session-api/architecture.md
@@ -8,10 +8,11 @@ Baseline: `main` at `2653a012`, `@svta/cml-cmcd` 2.6.1 plus the unreleased fixes
 
 | Unit | Owns | Public |
 |---|---|---|
-| Session | the `sid`, the normalized configuration, the reporters, the targets, the timers, the visibility listener, and the session totals | `CmcdSession` |
+| Session | the normalized configuration, the reporters, the current `sid` state, the timers, the visibility listener, and `bg` | `CmcdSession` |
+| `sid` state | everything that resets with a `sid`: the targets with their counters, gates, entries, queues, and 410 flags, and the session totals | no |
 | Reporter | the pushed store, the reported baselines of `sta`, `pr`, `cid`, and `br`, the host, the `su` derivation, and the open starvation span | `CmcdSessionReporter` |
 | Target | one destination: `sn`, the `msd` gate, the `bsd` cursor, the per-reporter `bs` flag and `ec` buffer, and for an event target the queue, the back-off, and the 410 flag | no |
-| Request origin | the link from a decorated request to its reporter, its request target, its raw per-request data, its start time, and its host | no |
+| Request origin | the link from a decorated request to its reporter, its `sid` state, the `cid` at issue time, its raw per-request data, and its start time | no |
 | Preparation | the key table, value normalization, filtering, and encoding | no, `encodeCmcd` moves onto it later |
 
 The request target and the event targets share one state type and one report path. They differ in the encoder output, a query parameter or headers against a body line, and in delivery. The request target has no queue, because the player sends the request.
@@ -31,7 +32,7 @@ One export per file, per the package rule. Names are a starting point for the im
 | `CmcdKeySpec.ts`, `CMCD_KEY_SPECS.ts` | the key table | internal |
 | `normalizeValue.ts`, `formatNor.ts` | value normalization | internal |
 | `prepareReport.ts` | the table-driven preparation loop | internal |
-| `createCmcdSessionState.ts`, `createCmcdReporterState.ts`, `createCmcdTargetState.ts` | state factories | internal |
+| `createCmcdSessionState.ts`, `createCmcdSidState.ts`, `createCmcdReporterState.ts`, `createCmcdTargetState.ts` | state factories | internal |
 | `deriveStateEvents.ts` | the state-change diff and the transition tracking | internal |
 | `assembleReport.ts` | the merge order and the derived defaults | internal |
 | `emitReport.ts` | transform, prepare, encode, commit, for one target | internal |
@@ -48,19 +49,28 @@ No module runs code at import time. The key table is an object literal, so it ne
 
 | Field | Type | Notes |
 |---|---|---|
-| `sid` | `string` | immutable |
 | `config` | normalized `CmcdSessionConfig` | defaults applied, lists copied |
 | `reporters` | `Set<ReporterState>` | insertion order is creation order |
+| `current` | `SidState` | replaced by `rotate()` |
+| `timers` | `ReturnType<typeof setInterval>[]` | one per event target with `t` and an interval over 0 |
+| `bg`, `bgSupplied` | `boolean \| undefined`, `boolean` | the session value, and whether a push stopped the visibility listener |
+| `stopVisibility` | `(() => void) \| undefined` | removes the listener |
+| `disposed` | `boolean` | |
+
+### `sid` state
+
+Everything that resets with a `sid`. `rotate()` creates a new one and marks the old one ended.
+
+| Field | Type | Notes |
+|---|---|---|
+| `sid` | `string` | immutable for this state |
+| `ended` | `boolean` | set by `rotate()` and `dispose()`, late reports send at once |
 | `requestTarget` | `TargetState` | always present |
 | `eventTargets` | `TargetState[]` | one per configured target |
-| `timers` | `ReturnType<typeof setInterval>[]` | one per event target with `t` and an interval over 0 |
-| `bg`, `bgReported` | `boolean \| undefined` | the value and the last reported value |
-| `bgSupplied` | `boolean` | a pushed `bg` stops the visibility listener |
-| `stopVisibility` | `(() => void) \| undefined` | removes the listener |
+| `bgReported` | `boolean \| undefined` | the last reported `bg` |
 | `msd`, `msdSupplied`, `msdStart` | `number \| undefined`, `boolean`, `number \| undefined` | `msdStart` is the `ts` of the first `sta` s |
 | `bsa`, `bsda`, `spans` | `number`, `number`, `number[]` | totals and completed span durations |
 | `countersSupplied` | `{ bsa?: true; bsda?: true; bsd?: true }` | per-key sticky override |
-| `disposed` | `boolean` | |
 
 ### Reporter
 
@@ -89,11 +99,15 @@ No module runs code at import time. The key table is an object literal, so it ne
 | `attempt`, `retryTimer` | `number`, timer handle or `undefined` | back-off state |
 | `gone` | `boolean` | set by a 410 |
 
+A target state belongs to one `sid` state. `rotate()` creates new ones from the same configuration.
+
 ### Request origin
 
 | Field | Type |
 |---|---|
 | `reporter` | `ReporterState` |
+| `sidState` | the `sid` state current at `decorate()` |
+| `cid` | the reporter's `cid` at `decorate()` |
 | `data` | the raw per-request `CmcdPlaybackData` |
 | `startedAt` | epoch milliseconds at `decorate()` |
 
@@ -105,14 +119,14 @@ The origin is stored in a `WeakMap` keyed by the `CmcdRequestRecord` object. A s
 
 1. If the reporter or its session is disposed, return.
 2. Take `ts` from `data`, default `Date.now()`. Do not store it.
-3. For `bg`, `msd`, `bsa`, `bsda`, and `bsd` in `data`: write the value on the session and set the supplied flag. Remove the key from the merge. A pushed `bg` also calls `stopVisibility`.
+3. For `bg`, `msd`, `bsa`, `bsda`, and `bsd` in `data`: write the value on the current `sid` state and set the supplied flag. `bg` is written on the session instead. Remove the key from the merge. A pushed `bg` also calls `stopVisibility`.
 4. Merge the rest into `store`. Set `suSupplied` or `dlSupplied` when `su` or `dl` is present.
 5. Run the transition tracking for `sta` when `data` has `sta` (below).
 6. Run the state-change diff (below).
 
 ### Transition tracking
 
-Runs when `sta` changes from the previous stored value.
+Runs when `sta` changes from the previous stored value. `msdStart`, `msd`, `bsa`, `bsda`, and `spans` live on the current `sid` state.
 
 | Transition | Effect |
 |---|---|
@@ -138,7 +152,7 @@ For each field in the order `sta`, `pr`, `cid`, `bg`, `br`:
 
 ### Emit(event, reporter, data, request?)
 
-For each event target that lists the event and is not gone:
+For each event target of the current `sid` state that lists the event and is not gone:
 
 1. Assemble the report (below).
 2. Run `emitReport` for the target (below). Collect the first thrown error.
@@ -171,11 +185,11 @@ Merge in this order, later wins:
 2. Read the host of `request.url`. When `hSupplied` is false and the host differs from `reporter.host`, set it and emit `h` after step 5.
 3. Assemble with the request target and `data`. Run `emitReport`. A cancelled report leaves the request as is.
 4. Query mode: set the `CMCD` query parameter, replacing an existing one. Header mode: copy `headers` and set the non-empty shards. `nor` values use `request.url` as the base for the relative path.
-5. Create the record `{ sid, data: prepared }`, store the origin `{ reporter, data, startedAt: Date.now() }`, and return `{ ...request, url, headers, cmcd: record }`.
+5. Create the record `{ sid, data: prepared }`, store the origin `{ reporter, sidState: current, cid: store.cid, data, startedAt: Date.now() }`, and return `{ ...request, url, headers, cmcd: record }`.
 
 ### recordResponse(request, info, data)
 
-1. Resolve the origin from `request.cmcd`. Without one, the origin is the calling reporter with empty data and no start time.
+1. Resolve the origin from `request.cmcd`. Without one, the origin is the calling reporter and the current `sid` state, with empty data and no start time.
 2. Derive the response keys:
    - `url`: `request.url` without the `CMCD` parameter
    - `rc`: `info.status`, or 0
@@ -183,17 +197,26 @@ Merge in this order, later wins:
    - `ttfb`: `responseStart - startTime`
    - `ttlb`: `duration`, or `responseEnd - startTime`, else `Date.now() - origin.startedAt`
    - `cmsds` and `cmsdd`: the `CMSD-Static` and `CMSD-Dynamic` headers, base64 encoded
-3. Assemble for each `rr` target of the origin session: the origin reporter's store, the session data, `origin.data`, the derived keys, then `data`.
+3. Assemble for each `rr` target of `origin.sidState`: the origin reporter's store, that state's session data, `origin.cid`, `origin.data`, the derived keys, then `data`.
 4. Emit `rr` with the decorated request as the transform argument.
-5. When the origin session is disposed, dispatch its queues at once.
+5. When `origin.sidState` is ended, dispatch its queues at once.
 
 ### Tick(target)
 
 For each live reporter in creation order, assemble with `t` and emit to this one target. With no reporters, emit one line from the session data alone. Then process the queue.
 
+### rotate(sid?)
+
+1. If the session is disposed, return.
+2. Resolve the `sid`: the argument, or a new UUID. Throw when it is over 64 characters. Return when it equals the current `sid`.
+3. Dispatch every queue of the current `sid` state in full and set its `ended` flag.
+4. Create a new `sid` state with new target states from the configuration.
+5. For each reporter, clear `reported` and `spanOpenedAt`.
+6. Point `current` at the new state. Nothing is emitted.
+
 ### dispose()
 
-Session: set `disposed`, clear the timers, call `stopVisibility`, mark every reporter disposed, and dispatch every queue in full. Reporter: set `disposed`, remove the reporter from `reporters`, and delete its entries in every target. A late response for a disposed reporter still resolves through its origin, because the origin references the reporter object.
+Session: set `disposed`, clear the timers, call `stopVisibility`, mark every reporter disposed, set `ended` on the current `sid` state, and dispatch every queue in full. Reporter: set `disposed`, remove the reporter from `reporters`, and delete its entries in every target. A late response for a disposed reporter still resolves through its origin, because the origin references the reporter object.
 
 ## Delivery
 
@@ -211,7 +234,7 @@ Per event target, `processQueue(drain)`:
 | 429, 5xx, or rejection | unshift the batch, `attempt += 1`, arm `retryTimer` for `min(1000 * 2 ** (attempt - 1), 60000)` ms, then process the queue with `drain` |
 | other 4xx | drop the batch, `attempt = 0` |
 
-`flush()` clears an armed retry timer and processes with `drain`. After `dispose()`, a failure at the 60 second step stops the retries. When the queue is longer than `maxQueueSize` after an unshift or a push, splice the oldest lines off the front.
+`flush()` clears an armed retry timer and processes with `drain`. Once the owning `sid` state has ended, a failure at the 60 second step stops the retries. When the queue is longer than `maxQueueSize` after an unshift or a push, splice the oldest lines off the front.
 
 The default transport: `fetch(url, { method: 'POST', headers, body, keepalive: body.length < 65536 })`, returning `{ status }`. A network error rejects.
 
@@ -316,7 +339,8 @@ Tests import from `@svta/cml-cmcd` and run against the built package.
 | Derivations | one test per row of the derived keys table in the RFC, including the supplied-value override |
 | State-change diff | order, dedup, `pr` while paused, `cid` at creation, `bg` on the session, `br` by value |
 | Multi-player | two reporters, one `sid`, `sn` continuity per target, one `t` line per reporter, `nr`, reporter dispose |
-| Late responses | after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone |
+| Late responses | after `rotate()`, after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone |
+| Rotation | `sn` restarts per target, the `msd` gate re-arms, baselines reset so the next push emits, the old queue drains at once, a 410 target is active again, the same `sid` is a no-op, and nothing is emitted by the call |
 | Delivery | mock transport with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive |
 | Errors | configuration checks and their messages, encoder failure commits nothing, throwing transform isolation, `onError` on a tick |
 | Validation | every emitted line passes `validateCmcdEvents` or `validateCmcdRequest` |
@@ -328,7 +352,7 @@ Tests import from `@svta/cml-cmcd` and run against the built package.
 A suggested order for `steps.md`.
 
 1. The key table, `normalizeValue`, `formatNor`, and `prepareReport`, with the spec fixtures for the wire strings.
-2. Session and reporter state, `update()`, the diff, and the transition tracking.
+2. Session, `sid`, and reporter state, `update()`, the diff, the transition tracking, and `rotate()`.
 3. Targets, `emitReport`, and `decorate()`.
 4. `recordResponse()` and the origins.
 5. Delivery, timers, and `dispose()`.

--- a/plans/cmcd-session-api/architecture.md
+++ b/plans/cmcd-session-api/architecture.md
@@ -24,7 +24,7 @@ One export per file, per the package rule. Names are a starting point for the im
 | File | Export | Kind |
 |---|---|---|
 | `createCmcdSession.ts` | `createCmcdSession` | public |
-| `CmcdSession.ts`, `CmcdSessionConfig.ts`, `CmcdEventTargetConfig.ts`, `CmcdTransport.ts` | types | public |
+| `CmcdSession.ts`, `CmcdSessionConfig.ts`, `CmcdEventTargetConfig.ts`, `CmcdRequester.ts` | types | public |
 | `CmcdSessionReporter.ts`, `CmcdSessionReporterConfig.ts`, `CmcdPlaybackData.ts`, `CmcdMetric.ts`, `CmcdNextObject.ts` | types | public |
 | `CmcdRequestLike.ts`, `CmcdDecoratedRequest.ts`, `CmcdRequestRecord.ts`, `CmcdResponseInfo.ts`, `CmcdResourceTiming.ts` | types | public |
 | `CmcdRequestTransform.ts`, `CmcdEventTransform.ts`, `CmcdDiscreteEventType.ts` | types | public |
@@ -148,7 +148,7 @@ For each field in the order `sta`, `pr`, `cid`, `bg`, `br`:
 3. Skip `pr` when the store's `sta` is not p.
 4. Set the reported value, then emit the event to every event target that lists it.
 
-`bg` emits one line per live reporter, like `t`. The others emit one line for the reporter. A `pr` change while paused is picked up on the next diff that runs while `sta` is p, because step 2 still sees a difference.
+`bg` emits one line per live reporter, like `t`. When `bg` changes to false, the session clears the value before the emit, so the `b` line and later reports carry no `bg`. The others emit one line for the reporter. A `pr` change while paused is picked up on the next diff that runs while `sta` is p, because step 2 still sees a difference.
 
 ### Emit(event, reporter, data, request?)
 
@@ -225,7 +225,7 @@ Per event target, `processQueue(drain)`:
 1. Return when the target is gone, the queue is empty, a send is in flight, or a retry timer is armed.
 2. Return when the queue is shorter than `batchSize` and `drain` is false.
 3. Splice the batch: the whole queue when `drain`, else `batchSize` lines.
-4. POST through the transport. Body: lines joined by `\n`. Headers: `Content-Type: application/cmcd` plus the target's headers.
+4. POST through the requester. Body: lines joined by `\n`. Headers: `Content-Type: application/cmcd` plus the target's headers.
 
 | Result | Action |
 |---|---|
@@ -236,7 +236,7 @@ Per event target, `processQueue(drain)`:
 
 `flush()` clears an armed retry timer and processes with `drain`. Once the owning `sid` state has ended, a failure at the 60 second step stops the retries. When the queue is longer than `maxQueueSize` after an unshift or a push, splice the oldest lines off the front.
 
-The default transport: `fetch(url, { method: 'POST', headers, body, keepalive: body.length < 65536 })`, returning `{ status }`. A network error rejects.
+The default requester: `fetch(url, { method: 'POST', headers, body, keepalive: body.length < 65536 })`, returning `{ status }`. A network error rejects.
 
 ## Key table
 
@@ -341,7 +341,7 @@ Tests import from `@svta/cml-cmcd` and run against the built package.
 | Multi-player | two reporters, one `sid`, `sn` continuity per target, one `t` line per reporter, `nr`, reporter dispose |
 | Late responses | after `rotate()`, after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone |
 | Rotation | `sn` restarts per target, the `msd` gate re-arms, baselines reset so the next push emits, the old queue drains at once, a 410 target is active again, the same `sid` is a no-op, and nothing is emitted by the call |
-| Delivery | mock transport with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive |
+| Delivery | mock requester with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive |
 | Errors | configuration checks and their messages, encoder failure commits nothing, throwing transform isolation, `onError` on a tick |
 | Validation | every emitted line passes `validateCmcdEvents` or `validateCmcdRequest` |
 | Types | `@ts-expect-error` for a state-change type in `recordEvent`, `ce` without `cen`, `version` on an event target, `ec` in `CmcdPlaybackData` |

--- a/plans/cmcd-session-api/architecture.md
+++ b/plans/cmcd-session-api/architecture.md
@@ -8,11 +8,11 @@ Baseline: `main` at `2653a012`, `@svta/cml-cmcd` 2.6.1 plus the unreleased fixes
 
 | Unit | Owns | Public |
 |---|---|---|
-| Session | the normalized configuration, the reporters, the current `sid` state, the timers, the visibility listener, and `bg` | `CmcdSession` |
-| `sid` state | everything that resets with a `sid`: the targets with their counters, gates, entries, queues, and 410 flags, and the session totals | no |
+| Session | the normalized configuration, replaced in part by `configure()`, the reporters, the current `sid` state, the timers, the visibility listener, and `bg` | `CmcdSession` |
+| `sid` state | everything that resets with a `sid`: the targets with their counters, gates, entries, queues, and 410 flags, the session totals, the pending `bsd` samples, and after `rotate()` a copy of each reporter's store | no |
 | Reporter | the pushed store, the reported baselines of `sta`, `pr`, `cid`, and `br`, the host, the `su` derivation, and the open starvation span | `CmcdSessionReporter` |
 | Target | one destination: `sn`, the `msd` gate, the `bsd` cursor, the per-reporter `bs` flag and `ec` buffer, and for an event target the queue, the back-off, and the 410 flag | no |
-| Request origin | the link from a decorated request to its reporter, its `sid` state, the `cid` at issue time, its raw per-request data, and its start time | no |
+| Request origin | the link from a decorated request to its reporter, its `sid` state, the `cid` at issue time, a copy of its per-request data, and its start time | no |
 | Preparation | the key table, value normalization, filtering, and encoding | no, `encodeCmcd` moves onto it later |
 
 The request target and the event targets share one state type and one report path. They differ in the encoder output, a query parameter or headers against a body line, and in delivery. The request target has no queue, because the player sends the request.
@@ -26,7 +26,7 @@ One export per file, per the package rule. Names are a starting point for the im
 | `createCmcdSession.ts` | `createCmcdSession` | public |
 | `CmcdSession.ts`, `CmcdSessionConfig.ts`, `CmcdEventTargetConfig.ts`, `CmcdRequester.ts` | types | public |
 | `CmcdSessionReporter.ts`, `CmcdSessionReporterConfig.ts`, `CmcdPlaybackData.ts`, `CmcdMetric.ts`, `CmcdNextObject.ts` | types | public |
-| `CmcdRequestLike.ts`, `CmcdDecoratedRequest.ts`, `CmcdRequestRecord.ts`, `CmcdResponseInfo.ts`, `CmcdResourceTiming.ts` | types | public |
+| `CmcdRequestLike.ts`, `CmcdDecoratedRequest.ts`, `CmcdRequestRecord.ts`, `CmcdResponseInfo.ts`, `CmcdResourceTiming.ts`, `CmcdResponseData.ts` | types | public |
 | `CmcdRequestTransform.ts`, `CmcdEventTransform.ts`, `CmcdDiscreteEventType.ts` | types | public |
 | `CmcdEventType.ts` | adds `CMCD_EVENT_HOSTNAME` and `HOSTNAME` | public, existing file |
 | `CmcdKeySpec.ts`, `CMCD_KEY_SPECS.ts` | the key table | internal |
@@ -68,8 +68,10 @@ Everything that resets with a `sid`. `rotate()` creates a new one and marks the 
 | `requestTarget` | `TargetState` | always present |
 | `eventTargets` | `TargetState[]` | one per configured target |
 | `bgReported` | `boolean \| undefined` | the last reported `bg` |
-| `msd`, `msdSupplied`, `msdStart` | `number \| undefined`, `boolean`, `number \| undefined` | `msdStart` is the `ts` of the first `sta` s |
-| `bsa`, `bsda`, `spans` | `number`, `number`, `number[]` | totals and completed span durations |
+| `msd`, `msdSupplied`, `msdStart` | `number \| undefined`, `boolean`, `number \| undefined` | `msdStart` is the `ts` of the first `sta` s, carried by `rotate()` while `msd` is unset |
+| `bsa`, `bsda` | `number`, `number` | totals since the `sid` started |
+| `pending` | `Map<string, number[]>` | the pending `bsd` samples per cause, automatic spans under the empty key, at most 100 per list |
+| `stores` | `Map<ReporterState, Record<string, unknown>>` | filled by `rotate()`, read by late responses |
 | `countersSupplied` | `{ bsa?: true; bsda?: true; bsd?: true }` | per-key sticky override |
 
 ### Reporter
@@ -93,7 +95,8 @@ Everything that resets with a `sid`. `rotate()` creates a new one and marks the 
 | `config` | normalized target configuration | |
 | `sn` | `number` | next sequence number |
 | `msdSent` | `boolean` | |
-| `bsdCursor` | `number` | completed spans delivered to this target |
+| `bsdCursors` | `Map<string, number>` | pending samples per cause delivered to this target |
+| `drainRequested` | `boolean` | event targets only, set by `flush()`, `rotate()`, `dispose()`, and a late `rr` |
 | `perReporter` | `Map<ReporterState, { bs: boolean; ec: string[] }>` | entry removed on reporter dispose |
 | `queue` | `string[]` | event targets only, encoded lines |
 | `attempt`, `retryTimer` | `number`, timer handle or `undefined` | back-off state |
@@ -108,7 +111,7 @@ A target state belongs to one `sid` state. `rotate()` creates new ones from the 
 | `reporter` | `ReporterState` |
 | `sidState` | the `sid` state current at `decorate()` |
 | `cid` | the reporter's `cid` at `decorate()` |
-| `data` | the raw per-request `CmcdPlaybackData` |
+| `data` | a copy of the raw per-request `CmcdPlaybackData`, nested values included |
 | `startedAt` | epoch milliseconds at `decorate()` |
 
 The origin is stored in a `WeakMap` keyed by the `CmcdRequestRecord` object. A spread copy of the request keeps the same record object, so the lookup still resolves. JSON produces a new object, so the lookup fails and the response reports under the calling reporter.
@@ -119,7 +122,7 @@ The origin is stored in a `WeakMap` keyed by the `CmcdRequestRecord` object. A s
 
 1. If the reporter or its session is disposed, return.
 2. Take `ts` from `data`, default `Date.now()`. Do not store it.
-3. For `bg`, `msd`, `bsa`, `bsda`, and `bsd` in `data`: write the value on the current `sid` state and set the supplied flag. `bg` is written on the session instead. Remove the key from the merge. A pushed `bg` also calls `stopVisibility`.
+3. For `bg`, `msd`, `bsa`, and `bsda` in `data`: write the value on the current `sid` state and set the supplied flag. `bg` is written on the session instead. For `bsd`: append one sample per cause to `pending` and set `countersSupplied.bsd`. Remove these keys from the merge. A pushed `bg` also calls `stopVisibility`.
 4. Merge the rest into `store`. Set `suSupplied` or `dlSupplied` when `su` or `dl` is present.
 5. Run the transition tracking for `sta` when `data` has `sta` (below).
 6. Run the state-change diff (below).
@@ -133,11 +136,11 @@ Runs when `sta` changes from the previous stored value. `msdStart`, `msd`, `bsa`
 | into s, with no `msdStart` | `msdStart = ts` |
 | into p, with `msdStart` set and `msd` unset | `msd = ts - msdStart`, when `msdSupplied` is false |
 | into r | `spanOpenedAt = ts`, `bsa += 1`, set `bs` on every target's entry for this reporter |
-| out of r, with `spanOpenedAt` set | push `ts - spanOpenedAt` to `spans`, add it to `bsda`, clear `spanOpenedAt` |
+| out of r, with `spanOpenedAt` set | add `ts - spanOpenedAt` to `bsda`, append it to the untagged `pending` list when a destination is eligible for `bsd` and `countersSupplied.bsd` is unset, clear `spanOpenedAt` |
 | into s, k, or r | `su = true` |
 | into p | `su = false` |
 
-`bsa` and `bsda` updates are skipped for a key in `countersSupplied`. The span list is still kept, because `bsd` may be automatic while `bsda` is supplied.
+`bsa` and `bsda` updates are skipped for a key in `countersSupplied`. The pending list is still fed, because `bsd` may be automatic while `bsda` is supplied.
 
 ### State-change diff
 
@@ -152,7 +155,7 @@ For each field in the order `sta`, `pr`, `cid`, `bg`, `br`:
 
 ### Emit(event, reporter, data, request?)
 
-For each event target of the current `sid` state that lists the event and is not gone:
+For each event target of the `sid` state that was current when the call began, when it lists the event and is not gone:
 
 1. Assemble the report (below).
 2. Run `emitReport` for the target (below). Collect the first thrown error.
@@ -164,28 +167,30 @@ For each event target of the current `sid` state that lists the event and is not
 Merge in this order, later wins:
 
 1. the reporter's `store`
-2. the session data: `sid`, `v`, `bg`, `msd` when the target's gate is open, `bsa`, `bsda`, and the spans after the target's `bsdCursor` as `bsd`
-3. `data`
-4. the target's entry for the reporter: `bs` when flagged, `ec` when the buffer is not empty
-5. `su` from the reporter when `derive.su` is on, `suSupplied` is false, and the report has no `su`
-6. `dl` from `bl / pr` when `derive.dl` is on, `dlSupplied` is false, the report has `bl` and no `dl`, and `pr` is over 0 or absent
-7. `e` and `ts` for an event
+2. the session data: `sid`, `v`, `bg`, `msd` when the target's gate is open, `bsa`, and `bsda`
+3. `bsd`: for each cause, the oldest `pending` sample past the target's cursor, one entry per cause
+4. `data`
+5. the target's entry for the reporter: `bs` when flagged, `ec` when the buffer is not empty
+6. `su` from the reporter when `derive.su` is on, `suSupplied` is false, and the report has no `su`
+7. `dl` from `bl / pr` when `derive.dl` is on, `dlSupplied` is false, the report has `bl` and no `dl`, and `pr` is over 0 or absent
+8. `e` and `ts` for an event
 
 ### emitReport(target, report, event?, request?)
 
 1. When the target has a transform: copy nested values, run the transform, return on `null`, restore a removed required key, re-stamp `sid`, `e`, and `ts`.
 2. `report.sn = target.sn`.
 3. Prepare (below) and encode. An encoder error propagates, and step 4 does not run.
-4. Commit: `target.sn += 1`. When the output has `msd`, `msdSent = true`. Clear the reporter's `bs` and `ec` entry. Move `bsdCursor` to the end of the spans when the output has `bsd`.
+4. Commit: `target.sn += 1`. When the output has `msd`, `msdSent = true`. Clear the reporter's `ec` entry, and its `bs` entry unless the store's `sta` is r. When the output has `bsd`, advance the target's cursor for each cause it carried. Then drop from each `pending` list the prefix that every eligible destination has passed. A destination is eligible when it is not gone, its `keys` include `bsd`, and, for the request target, the version is 2.
 5. Event target: push the line to the queue. Request target: return the prepared data for the URL or the headers.
 
 ### decorate(request, data)
 
 1. If disposed, return a copy of the request with a record `{ sid, data: {} }` and no origin.
-2. Read the host of `request.url`. When `hSupplied` is false and the host differs from `reporter.host`, set it and emit `h` after step 5.
-3. Assemble with the request target and `data`. Run `emitReport`. A cancelled report leaves the request as is.
-4. Query mode: set the `CMCD` query parameter, replacing an existing one. Header mode: copy `headers` and set the non-empty shards. `nor` values use `request.url` as the base for the relative path.
-5. Create the record `{ sid, data: prepared }`, store the origin `{ reporter, sidState: current, cid: store.cid, data, startedAt: Date.now() }`, and return `{ ...request, url, headers, cmcd: record }`.
+2. Capture the origin `{ reporter, sidState: current, cid: store.cid, data: a copy of data, startedAt: Date.now() }`. Every later step uses this origin, whatever a transform does.
+3. Read the host of `request.url`. When `hSupplied` is false and the host differs from `reporter.host`, set it and emit `h` after step 6.
+4. Assemble with the request target of the origin `sid` state and the data copy. Run `emitReport`. A cancelled report leaves the request as is.
+5. Copy the request. Remove the `CMCD` query parameter and every header whose name matches `CMCD-` case-insensitively. Query mode: set the `CMCD` parameter. Header mode: set the non-empty shards. `nor` values use `request.url` as the base for the relative path.
+6. Create the record `{ sid, data: prepared }`, store the origin, and return `{ ...request, url, headers, cmcd: record }`.
 
 ### recordResponse(request, info, data)
 
@@ -194,10 +199,10 @@ Merge in this order, later wins:
    - `url`: `request.url` without the `CMCD` parameter
    - `rc`: `info.status`, or 0
    - `ts`: `timing.startTime` mapped to epoch milliseconds, else `origin.startedAt`
-   - `ttfb`: `responseStart - startTime`
-   - `ttlb`: `duration`, or `responseEnd - startTime`, else `Date.now() - origin.startedAt`
+   - `ttfb`: `responseStart - startTime`, omitted when `responseStart` is absent, zero, or under `startTime`
+   - `ttlb`: `duration` when over zero, else `responseEnd - startTime` when `responseEnd` is over `startTime`, else `Date.now() - origin.startedAt` when a start time exists, else omitted
    - `cmsds` and `cmsdd`: the `CMSD-Static` and `CMSD-Dynamic` headers, base64 encoded
-3. Assemble for each `rr` target of `origin.sidState`: the origin reporter's store, that state's session data, `origin.cid`, `origin.data`, the derived keys, then `data`.
+3. Assemble for each `rr` target of `origin.sidState`, in this order: the origin reporter's store, or its entry in `origin.sidState.stores` when that state has ended. Then that state's session data, `origin.cid`, `origin.data`, the derived keys, and `data`.
 4. Emit `rr` with the decorated request as the transform argument.
 5. When `origin.sidState` is ended, dispatch its queues at once.
 
@@ -209,10 +214,17 @@ For each live reporter in creation order, assemble with `t` and emit to this one
 
 1. If the session is disposed, return.
 2. Resolve the `sid`: the argument, or a new UUID. Throw when it is over 64 characters. Return when it equals the current `sid`.
-3. Dispatch every queue of the current `sid` state in full and set its `ended` flag.
-4. Create a new `sid` state with new target states from the configuration.
-5. For each reporter, clear `reported` and `spanOpenedAt`.
-6. Point `current` at the new state. Nothing is emitted.
+3. Set `drainRequested` on every event target of the current `sid` state, dispatch its queues, and set its `ended` flag.
+4. Copy each reporter's store into the old state's `stores`.
+5. Create a new `sid` state with new target states from the configuration. Carry `msdStart` when the old state's `msd` is unset and `msdSupplied` is false.
+6. For each reporter, clear `reported`. When the store has `sta` r, set `spanOpenedAt` to the rotation time and set `bs` on the reporter's entries in the new targets. Otherwise clear `spanOpenedAt`.
+7. Point `current` at the new state. Nothing is emitted.
+
+### configure(settings)
+
+1. If the session is disposed, return.
+2. Run the configuration checks on `settings`. Throw on a violation.
+3. Replace `version`, `transmissionMode`, `keys`, and `headerMap` in the normalized configuration. The request target reads them at the next `decorate()`. Nothing is emitted, and no counter, gate, or entry changes.
 
 ### dispose()
 
@@ -222,17 +234,17 @@ Session: set `disposed`, clear the timers, call `stopVisibility`, mark every rep
 
 Per event target, `processQueue(drain)`:
 
-1. Return when the target is gone, the queue is empty, a send is in flight, or a retry timer is armed.
-2. Return when the queue is shorter than `batchSize` and `drain` is false.
+1. Set `drainRequested` when `drain` is true. Return when the target is gone, the queue is empty, a send is in flight, or a retry timer is armed.
+2. Return when the queue is shorter than `batchSize` and `drainRequested` is false.
 3. Splice the batch: the whole queue when `drain`, else `batchSize` lines.
 4. POST through the requester. Body: lines joined by `\n`. Headers: `Content-Type: application/cmcd` plus the target's headers.
 
 | Result | Action |
 |---|---|
-| 2xx or 3xx | `attempt = 0`, process the queue again |
+| 2xx or 3xx | `attempt = 0`, process the queue again, and clear `drainRequested` once the queue is empty |
 | 410 | `gone = true`, `queue.length = 0` |
 | 429, 5xx, or rejection | unshift the batch, `attempt += 1`, arm `retryTimer` for `min(1000 * 2 ** (attempt - 1), 60000)` ms, then process the queue with `drain` |
-| other 4xx | drop the batch, `attempt = 0` |
+| other 4xx | drop the batch, `attempt = 0`, process the queue again |
 
 `flush()` clears an armed retry timer and processes with `drain`. Once the owning `sid` state has ended, a failure at the 60 second step stops the retries. When the queue is longer than `maxQueueSize` after an unshift or a push, splice the oldest lines off the front.
 
@@ -322,7 +334,8 @@ for key of report keys, sorted:
 |---|---|
 | `update()` with no state change | the merge into the store |
 | `update()` with one state change | one report object per event target, plus one copy per target with a transform |
-| `decorate()` | the report, the prepared object, the request copy, the record, the origin |
+| `decorate()` | the report, the prepared object, the request copy, the record, the origin, the copy of `data` |
+| `rotate()` | the new `sid` state and its targets, and one store copy per reporter |
 | `recordResponse()` | the report per `rr` target |
 | tick | one report per reporter per target |
 | idle | none |
@@ -339,9 +352,14 @@ Tests import from `@svta/cml-cmcd` and run against the built package.
 | Derivations | one test per row of the derived keys table in the RFC, including the supplied-value override |
 | State-change diff | order, dedup, `pr` while paused, `cid` at creation, `bg` on the session, `br` by value |
 | Multi-player | two reporters, one `sid`, `sn` continuity per target, one `t` line per reporter, `nr`, reporter dispose |
-| Late responses | after `rotate()`, after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone |
-| Rotation | `sn` restarts per target, the `msd` gate re-arms, baselines reset so the next push emits, the old queue drains at once, a 410 target is active again, the same `sid` is a no-op, and nothing is emitted by the call |
-| Delivery | mock requester with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive |
+| Late responses | after `rotate()`, after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone. A late `rr` reads the store copied at rotation and the copied per-request data, and a mutated data object does not change it. An ended `sid` state is collectable once its requests are released, checked with a `WeakRef` under `node --expose-gc` |
+| Rotation | `sn` restarts per target, the `msd` gate re-arms, baselines reset so the next push emits, the old queue drains at once, a 410 target is active again, the same `sid` is a no-op, and nothing is emitted by the call. `msdStart` is carried while a startup is in progress, an open stall is measured from the rotation, and the new targets start with `bs` |
+| Configure | `configure()` replaces the request settings, keeps `sn` and the gates, and throws on a bad setting |
+| Stalls | `bs` on every report during a stall and once after recovery, `bsd` one stall per entry per cause in order, a second stall of the same cause waits, the cap at 100, no samples without an eligible destination, prefix reclamation |
+| Transform rotation | a transform that calls `rotate()` inside `decorate()` and inside an emission leaves the request and the remaining targets on the old `sid` |
+| Requests | re-decoration strips the old `CMCD` parameter and headers, the decorated type compiles for `{ url }`, `CmcdResponseData` accepts `ttfbb` and `smrt` and rejects `sn` |
+| Timing | `ttfb` omitted for a zero `responseStart`, `ttlb` from `responseEnd` for a cross-origin entry, the clock fallback measures the call |
+| Delivery | mock requester with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive, a drain kept across an in-flight send, and a `batchSize` over `maxQueueSize` throws |
 | Errors | configuration checks and their messages, encoder failure commits nothing, throwing transform isolation, `onError` on a tick |
 | Validation | every emitted line passes `validateCmcdEvents` or `validateCmcdRequest` |
 | Types | `@ts-expect-error` for a state-change type in `recordEvent`, `ce` without `cen`, `version` on an event target, `ec` in `CmcdPlaybackData` |

--- a/plans/cmcd-session-api/architecture.md
+++ b/plans/cmcd-session-api/architecture.md
@@ -1,0 +1,354 @@
+# CMCD session API: architecture
+
+Design record for [`rfc/cmcd-session-api.md`](../../rfc/cmcd-session-api.md). The RFC states the public API and its contract. This document states the internal units, their state, the algorithms, the key table, and the test plan. [`comparison.md`](./comparison.md) compares the design with `CmcdReporter` and with PR #422.
+
+Baseline: `main` at `2653a012`, `@svta/cml-cmcd` 2.6.1 plus the unreleased fixes of PR #453 and PR #454.
+
+## Units
+
+| Unit | Owns | Public |
+|---|---|---|
+| Session | the `sid`, the normalized configuration, the players, the targets, the timers, the visibility listener, and the session totals | `CmcdSession` |
+| Player | the pushed store, the reported baselines of `sta`, `pr`, `cid`, and `br`, the host, the `su` derivation, and the open starvation span | `CmcdPlayer` |
+| Target | one destination: `sn`, the `msd` gate, the `bsd` cursor, the per-player `bs` flag and `ec` buffer, and for an event target the queue, the back-off, and the 410 flag | no |
+| Request origin | the link from a decorated request to its player, its request target, its raw per-request data, its start time, and its host | no |
+| Preparation | the key table, value normalization, filtering, and encoding | no, `encodeCmcd` moves onto it later |
+
+The request target and the event targets share one state type and one report path. They differ in the encoder output, a query parameter or headers against a body line, and in delivery. The request target has no queue, because the player sends the request.
+
+## Files
+
+One export per file, per the package rule. Names are a starting point for the implementation plan.
+
+| File | Export | Kind |
+|---|---|---|
+| `createCmcdSession.ts` | `createCmcdSession` | public |
+| `CmcdSession.ts`, `CmcdSessionConfig.ts`, `CmcdEventTargetConfig.ts`, `CmcdTransport.ts` | types | public |
+| `CmcdPlayer.ts`, `CmcdPlayerConfig.ts`, `CmcdPlayerData.ts`, `CmcdMetric.ts`, `CmcdNextObject.ts` | types | public |
+| `CmcdRequestLike.ts`, `CmcdDecoratedRequest.ts`, `CmcdRequestRecord.ts`, `CmcdResponseInfo.ts`, `CmcdResourceTiming.ts` | types | public |
+| `CmcdRequestTransform.ts`, `CmcdEventTransform.ts`, `CmcdDiscreteEventType.ts` | types | public |
+| `CmcdEventType.ts` | adds `CMCD_EVENT_HOSTNAME` and `HOSTNAME` | public, existing file |
+| `CmcdKeySpec.ts`, `CMCD_KEY_SPECS.ts` | the key table | internal |
+| `normalizeValue.ts`, `formatNor.ts` | value normalization | internal |
+| `prepareReport.ts` | the table-driven preparation loop | internal |
+| `createCmcdSessionState.ts`, `createCmcdPlayerState.ts`, `createCmcdTargetState.ts` | state factories | internal |
+| `deriveStateEvents.ts` | the state-change diff and the transition tracking | internal |
+| `assembleReport.ts` | the merge order and the derived defaults | internal |
+| `emitReport.ts` | transform, prepare, encode, commit, for one target | internal |
+| `deliverBatch.ts` | POST, response handling, back-off | internal |
+| `toResponseKeys.ts`, `readCmsdHeaders.ts` | the `rr` derivations | internal |
+| `observeVisibility.ts` | the `bg` listener | internal |
+| `CMCD_REQUEST_ORIGINS.ts` | the `WeakMap` from record to origin | internal |
+
+No module runs code at import time. The key table is an object literal, so it needs no purity annotation. The `WeakMap` is created inside a function that runs on first use, or has the annotation.
+
+## State
+
+### Session
+
+| Field | Type | Notes |
+|---|---|---|
+| `sid` | `string` | immutable |
+| `config` | normalized `CmcdSessionConfig` | defaults applied, lists copied |
+| `players` | `Set<PlayerState>` | insertion order is creation order |
+| `requestTarget` | `TargetState` | always present |
+| `eventTargets` | `TargetState[]` | one per configured target |
+| `timers` | `ReturnType<typeof setInterval>[]` | one per event target with `t` and an interval over 0 |
+| `bg`, `bgReported` | `boolean \| undefined` | the value and the last reported value |
+| `bgSupplied` | `boolean` | a pushed `bg` stops the visibility listener |
+| `stopVisibility` | `(() => void) \| undefined` | removes the listener |
+| `msd`, `msdSupplied`, `msdStart` | `number \| undefined`, `boolean`, `number \| undefined` | `msdStart` is the `ts` of the first `sta` s |
+| `bsa`, `bsda`, `spans` | `number`, `number`, `number[]` | totals and completed span durations |
+| `countersSupplied` | `{ bsa?: true; bsda?: true; bsd?: true }` | per-key sticky override |
+| `disposed` | `boolean` | |
+
+### Player
+
+| Field | Type | Notes |
+|---|---|---|
+| `session` | `SessionState` | |
+| `store` | `Record<string, unknown>` | values as pushed, `undefined` deletes |
+| `reported` | `{ sta?, pr?, cid?, br? }` | last reported values, `br` compared by value |
+| `host`, `hSupplied` | `string \| undefined`, `boolean` | |
+| `su` | `boolean \| undefined` | derived, `undefined` until the first `sta` |
+| `suSupplied`, `dlSupplied` | `boolean` | a persistent push stops the derivation |
+| `spanOpenedAt` | `number \| undefined` | the `ts` of the last transition into r |
+| `disposed` | `boolean` | |
+
+### Target
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `'request' \| 'event'` | |
+| `config` | normalized target configuration | |
+| `sn` | `number` | next sequence number |
+| `msdSent` | `boolean` | |
+| `bsdCursor` | `number` | completed spans delivered to this target |
+| `perPlayer` | `Map<PlayerState, { bs: boolean; ec: string[] }>` | entry removed on player dispose |
+| `queue` | `string[]` | event targets only, encoded lines |
+| `attempt`, `retryTimer` | `number`, timer handle or `undefined` | back-off state |
+| `gone` | `boolean` | set by a 410 |
+
+### Request origin
+
+| Field | Type |
+|---|---|
+| `player` | `PlayerState` |
+| `data` | the raw per-request `CmcdPlayerData` |
+| `startedAt` | epoch milliseconds at `decorate()` |
+
+The origin is stored in a `WeakMap` keyed by the `CmcdRequestRecord` object. A spread copy of the request keeps the same record object, so the lookup still resolves. JSON produces a new object, so the lookup fails and the response reports under the calling player.
+
+## Algorithms
+
+### update(data)
+
+1. If the player or its session is disposed, return.
+2. Take `ts` from `data`, default `Date.now()`. Do not store it.
+3. For `bg`, `msd`, `bsa`, `bsda`, and `bsd` in `data`: write the value on the session and set the supplied flag. Remove the key from the merge. A pushed `bg` also calls `stopVisibility`.
+4. Merge the rest into `store`. Set `suSupplied` or `dlSupplied` when `su` or `dl` is present.
+5. Run the transition tracking for `sta` when `data` has `sta` (below).
+6. Run the state-change diff (below).
+
+### Transition tracking
+
+Runs when `sta` changes from the previous stored value.
+
+| Transition | Effect |
+|---|---|
+| into s, with no `msdStart` | `msdStart = ts` |
+| into p, with `msdStart` set and `msd` unset | `msd = ts - msdStart`, when `msdSupplied` is false |
+| into r | `spanOpenedAt = ts`, `bsa += 1`, set `bs` on every target's entry for this player |
+| out of r, with `spanOpenedAt` set | push `ts - spanOpenedAt` to `spans`, add it to `bsda`, clear `spanOpenedAt` |
+| into s, k, or r | `su = true` |
+| into p | `su = false` |
+
+`bsa` and `bsda` updates are skipped for a key in `countersSupplied`. The span list is still kept, because `bsd` may be automatic while `bsda` is supplied.
+
+### State-change diff
+
+For each field in the order `sta`, `pr`, `cid`, `bg`, `br`:
+
+1. Read the current value. `bg` reads the session, the rest read the store.
+2. Skip when the value equals the reported value. `br` compares element by element.
+3. Skip `pr` when the store's `sta` is not p.
+4. Set the reported value, then emit the event to every event target that lists it.
+
+`bg` emits one line per live player, like `t`. The others emit one line for the player. A `pr` change while paused is picked up on the next diff that runs while `sta` is p, because step 2 still sees a difference.
+
+### Emit(event, player, data, request?)
+
+For each event target that lists the event and is not gone:
+
+1. Assemble the report (below).
+2. Run `emitReport` for the target (below). Collect the first thrown error.
+3. After every target, process the target queues.
+4. Rethrow the collected error. On a timer tick, pass it to `onError` instead, or throw when `onError` is absent.
+
+### Assemble(player, target, event?, data?)
+
+Merge in this order, later wins:
+
+1. the player's `store`
+2. the session data: `sid`, `v`, `bg`, `msd` when the target's gate is open, `bsa`, `bsda`, and the spans after the target's `bsdCursor` as `bsd`
+3. `data`
+4. the target's entry for the player: `bs` when flagged, `ec` when the buffer is not empty
+5. `su` from the player when `suSupplied` is false and the report has no `su`
+6. `dl` from `bl / pr` when `dlSupplied` is false, the report has `bl` and no `dl`, and `pr` is over 0 or absent
+7. `e` and `ts` for an event
+
+### emitReport(target, report, event?, request?)
+
+1. When the target has a transform: copy nested values, run the transform, return on `null`, restore a removed required key, re-stamp `sid`, `e`, and `ts`.
+2. `report.sn = target.sn`.
+3. Prepare (below) and encode. An encoder error propagates, and step 4 does not run.
+4. Commit: `target.sn += 1`. When the output has `msd`, `msdSent = true`. Clear the player's `bs` and `ec` entry. Move `bsdCursor` to the end of the spans when the output has `bsd`.
+5. Event target: push the line to the queue. Request target: return the prepared data for the URL or the headers.
+
+### decorate(request, data)
+
+1. If disposed, return a copy of the request with a record `{ sid, data: {} }` and no origin.
+2. Read the host of `request.url`. When `hSupplied` is false and the host differs from `player.host`, set it and emit `h` after step 5.
+3. Assemble with the request target and `data`. Run `emitReport`. A cancelled report leaves the request as is.
+4. Query mode: set the `CMCD` query parameter, replacing an existing one. Header mode: copy `headers` and set the non-empty shards. `nor` values use `request.url` as the base for the relative path.
+5. Create the record `{ sid, data: prepared }`, store the origin `{ player, data, startedAt: Date.now() }`, and return `{ ...request, url, headers, cmcd: record }`.
+
+### recordResponse(request, info, data)
+
+1. Resolve the origin from `request.cmcd`. Without one, the origin is the calling player with empty data and no start time.
+2. Derive the response keys:
+   - `url`: `request.url` without the `CMCD` parameter
+   - `rc`: `info.status`, or 0
+   - `ts`: `timing.startTime` mapped to epoch milliseconds, else `origin.startedAt`
+   - `ttfb`: `responseStart - startTime`
+   - `ttlb`: `duration`, or `responseEnd - startTime`, else `Date.now() - origin.startedAt`
+   - `cmsds` and `cmsdd`: the `CMSD-Static` and `CMSD-Dynamic` headers, base64 encoded
+3. Assemble for each `rr` target of the origin session: the origin player's store, the session data, `origin.data`, the derived keys, then `data`.
+4. Emit `rr` with the decorated request as the transform argument.
+5. When the origin session is disposed, dispatch its queues at once.
+
+### Tick(target)
+
+For each live player in creation order, assemble with `t` and emit to this one target. With no players, emit one line from the session data alone. Then process the queue.
+
+### dispose()
+
+Session: set `disposed`, clear the timers, call `stopVisibility`, mark every player disposed, and dispatch every queue in full. Player: set `disposed`, remove the player from `players`, and delete its entries in every target. A late response for a disposed player still resolves through its origin, because the origin references the player object.
+
+## Delivery
+
+Per event target, `processQueue(drain)`:
+
+1. Return when the target is gone, the queue is empty, a send is in flight, or a retry timer is armed.
+2. Return when the queue is shorter than `batchSize` and `drain` is false.
+3. Splice the batch: the whole queue when `drain`, else `batchSize` lines.
+4. POST through the transport. Body: lines joined by `\n`. Headers: `Content-Type: application/cmcd` plus the target's headers.
+
+| Result | Action |
+|---|---|
+| 2xx or 3xx | `attempt = 0`, process the queue again |
+| 410 | `gone = true`, `queue.length = 0` |
+| 429, 5xx, or rejection | unshift the batch, `attempt += 1`, arm `retryTimer` for `min(1000 * 2 ** (attempt - 1), 60000)` ms, then process the queue with `drain` |
+| other 4xx | drop the batch, `attempt = 0` |
+
+`flush()` clears an armed retry timer and processes with `drain`. After `dispose()`, a failure at the 60 second step stops the retries. When the queue is longer than `maxQueueSize` after an unshift or a push, splice the oldest lines off the front.
+
+The default transport: `fetch(url, { method: 'POST', headers, body, keepalive: body.length < 65536 })`, returning `{ status }`. A network error rejects.
+
+## Key table
+
+One row per reserved key of CTA-5004-B Table 1. Empty cells mean not applicable. `both` means request and event mode. The `v1` column gives the version 1 form: `scalar` collapses an object-type list to the entry matching the report's `ot`, else the first entry, and `absent` drops the key.
+
+| key | type | header | modes | round | ot | supersededBy | onlyOn | requiredOn | omitDefault | max | v1 |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| ab | ot-list | Object | both | 1 | | br | | | | | absent |
+| bg | boolean | Status | both | | | | | b | false | | absent |
+| bl | ot-list | Request | both | 100 | | | | | | | scalar |
+| br | ot-list | Object | both | 1 | | | | bc | | | scalar |
+| bs | boolean | Status | both | | | | | | false | | |
+| bsa | ot-list | Status | both | 1 | | | | | | | absent |
+| bsd | ot-list | Status | both | 1 | | | | | | | absent |
+| bsda | ot-list | Status | both | 1 | | | | | | | absent |
+| cen | string | | event | | | | ce | ce | | 64 | absent |
+| cid | string | Session | both | | | | | c | | 128 | |
+| cmsdd | string | | event | | | | rr | | | | absent |
+| cmsds | string | | event | | | | rr | | | | absent |
+| cs | string | Request | both | | | | | | | | absent |
+| d | integer | Object | both | 1 | a v av tt c o | | | | | | |
+| dfa | integer | Request | both | 1 | | | | | | | absent |
+| dl | integer | Request | both | 100 | | | | | | | |
+| e | token | | event | | | | | always | | | absent |
+| ec | string-list | Status | both | | | | | e | | | absent |
+| h | string | | event | | | | | | | 128 | absent |
+| lab | ot-list | Object | both | 1 | | lb | | | | | absent |
+| lb | ot-list | Object | both | 1 | | | | | | | absent |
+| ltc | integer | Request | both | 1 | | | | | | | absent |
+| msd | integer | Session | both | 1 | | | | | | | absent |
+| mtp | ot-list | Request | both | 100 | | | | | | | scalar |
+| nor | string-list | Request | both | | | | | | | | string |
+| nr | boolean | Status | both | | | | | | false | | absent |
+| ot | token | Object | both | | | | | | | | |
+| pb | ot-list | Request | both | 1 | | | | | | | absent |
+| pr | decimal | Status | both | | | | | pr | 1 | | |
+| pt | integer | Status | both | 1 | | | | | | | absent |
+| rc | integer | | event | | | | rr | | | | absent |
+| rtp | integer | Status | both | 100 | | | | | | | |
+| sf | token | Session | both | | | | | | | | |
+| sid | string | Session | both | | | | | | | 64 | |
+| smrt | string | | event | | | | rr | | | | absent |
+| sn | integer | Request | both | | | | | | | | absent |
+| st | token | Session | both | | | | | | | | |
+| sta | token | Request | both | | | | | ps | | | absent |
+| su | boolean | Request | both | | | | | | false | | |
+| tab | ot-list | Object | both | 1 | | tb | | | | | absent |
+| tb | ot-list | Object | both | 1 | | | | | | | scalar |
+| tbl | ot-list | Request | both | 100 | | | | | | | absent |
+| tpb | ot-list | Object | both | 1 | a v av c | | | | | | absent |
+| ts | integer | | event | | | | | always | | | absent |
+| ttfb | integer | | event | | | | rr | | | | absent |
+| ttfbb | integer | | event | | | | rr | | | | absent |
+| ttlb | integer | | event | | | | rr | | | | absent |
+| url | string | | event | | | | rr | rr | | | absent |
+| v | integer | Session | both | | | | | always | 1 | | |
+
+Token values: `e` takes the 19 event tokens, `ot` takes `m a v av i c tt k o`, `sf` takes `d h e s o`, `st` takes `v l ll`, and `sta` takes `s p k r a w e f q d`. `nor` has a `format` function. It makes the path relative to the base URL and wraps the value in a list in version 2. It adds the `r` parameter from a range and percent-encodes the path in version 1. Version 1 also emits `nrr` from the first range. Custom keys are hyphenated, allowed in both modes, typed string or token, limited to 64 characters, and sharded by `headerMap`, default `CMCD-Request`.
+
+### Preparation loop
+
+```text
+for key of report keys, sorted:
+  spec = CMCD_KEY_SPECS[key] or custom spec, else skip
+  skip when spec.modes excludes the mode
+  skip when version is 1 and spec.v1 is absent
+  skip when spec.onlyOn is set and excludes the event
+  skip when spec.ot is set, the report has a valid ot, and spec.ot excludes it
+  skip when spec.supersededBy names a key with a non-empty value in the report
+  required = spec.requiredOn is always, or includes the event
+  skip when the target keys exclude key and not required
+  value = normalize(value, spec, version, baseUrl)
+  skip when value is empty
+  skip when value equals spec.omitDefault and not required
+  out[key] = value
+```
+
+`normalize` rounds by `spec.round`, or to an integer for `integer` and `ot-list` values without `round`. It turns a number or a per-object-type record into an inner list with parameters, and wraps tokens as `SfToken`. It applies `spec.format`, or the `formatters` option of `encodeCmcd` when present. `encodeCmcd`, `toCmcdHeaders`, and the validators move onto the table in a later plan with no signature change.
+
+## Performance
+
+| Path | Allocations |
+|---|---|
+| `update()` with no state change | the merge into the store |
+| `update()` with one state change | one report object per event target, plus one copy per target with a transform |
+| `decorate()` | the report, the prepared object, the request copy, the record, the origin |
+| `recordResponse()` | the report per `rr` target |
+| tick | one report per player per target |
+| idle | none |
+
+There is no per-call session lookup, no eviction pass, and no scan of past sessions. A late response follows one `WeakMap` read. `br` comparison in the diff is a loop over a short array.
+
+## Testing
+
+Tests import from `@svta/cml-cmcd` and run against the built package.
+
+| Area | Method |
+|---|---|
+| Spec conformance | one fixture per scenario in CTA-5004-B section 8: 8.1.1 to 8.1.8, 8.2.1 to 8.2.9, and 8.3. Drive the API with an injected clock and compare the wire string to the spec text, after removing the whitespace the document formatting adds |
+| Derivations | one test per row of the derived keys table in the RFC, including the supplied-value override |
+| State-change diff | order, dedup, `pr` while paused, `cid` at creation, `bg` on the session, `br` by value |
+| Multi-player | two players, one `sid`, `sn` continuity per target, one `t` line per player, `nr`, player dispose |
+| Late responses | after session dispose, with a spread copy of the request, after a JSON round trip, and with `{ url }` alone |
+| Delivery | mock transport with fake timers: batch size, flush, dispose, 410, 429 back-off sequence, 5xx, rejection, queue cap, `pagehide` keepalive |
+| Errors | configuration checks and their messages, encoder failure commits nothing, throwing transform isolation, `onError` on a tick |
+| Validation | every emitted line passes `validateCmcdEvents` or `validateCmcdRequest` |
+| Types | `@ts-expect-error` for a state-change type in `recordEvent`, `ce` without `cen`, `version` on an event target, `ec` in `CmcdPlayerData` |
+| Bundle | the bare-import side-effect probe, and a size probe against the baseline in `comparison.md` |
+
+## Sequencing
+
+A suggested order for `steps.md`.
+
+1. The key table, `normalizeValue`, `formatNor`, and `prepareReport`, with the spec fixtures for the wire strings.
+2. Session and player state, `update()`, the diff, and the transition tracking.
+3. Targets, `emitReport`, and `decorate()`.
+4. `recordResponse()` and the origins.
+5. Delivery, timers, and `dispose()`.
+6. The visibility listener, `onError`, and the configuration checks.
+7. Documentation: the user guide section, the README example, the changelog, and the API report review.
+8. A follow-up plan moves `encodeCmcd`, `toCmcdHeaders`, and the validators onto the key table.
+
+## Spec gaps found during the design
+
+These are independent of the RFC and can ship as fixes.
+
+| Gap | Where |
+|---|---|
+| The `h` event token is missing | `CmcdEventType`, `CMCD_TOKEN_VALUES.e`, `validateCmcdStructure` |
+| The `e` token for HESP is missing from `sf` | `CmcdStreamingFormat`, `CMCD_TOKEN_VALUES.sf` |
+| `cdn` is not a CTA-5004-B key | `CMCD_REQUEST_KEYS`, `CMCD_KEY_TYPES`, `CMCD_HEADER_MAP`, `CMCD_STRING_LENGTH_LIMITS` |
+
+## Open implementation questions
+
+1. Whether `CmcdSession` and `CmcdPlayer` are plain objects from a factory or classes. Plain objects match the `create*` pattern of the package and mangle better. Classes give `instanceof`.
+2. Whether the request origin should hold the player strongly. A strong reference keeps a disposed player alive until its requests complete, which is the intended retention.
+3. Whether the `t` tick for a session without players should emit a line at all.
+4. The exact configuration error type: `TypeError` for a wrong type and `RangeError` for a wrong value, or one `Error` with a code.

--- a/plans/cmcd-session-api/comparison.md
+++ b/plans/cmcd-session-api/comparison.md
@@ -32,8 +32,8 @@ The `CmcdReporter` sizes were measured on the built `dist` of this worktree, bun
 | Provenance record on `customData` | yes, symbol key | yes | no, a plain `cmcd` record |
 | `customData` type parameter `C` | yes | yes | no |
 | Dirty tracking, deferred eviction | no | yes | no |
-| Root and child reporters | proposed, PR #398 | landing zone prepared | no, players are peers |
-| `activate()` for interval reports | proposed, PR #398 | not yet | no, one line per player |
+| Root and child reporters | proposed, PR #398 | landing zone prepared | no, reporters are peers |
+| `activate()` for interval reports | proposed, PR #398 | not yet | no, one line per reporter |
 | Per-target state in request mode | `sn` and `msd` only | keyed map | full target state |
 | Derived keys | `sn`, `ts`, `v`, `e`, `url`, `rc`, `ttfb`, `ttlb` | same | plus `msd`, `bs`, `bsa`, `bsda`, `bsd`, `su`, `dl`, `h`, `bg`, `cmsds`, `cmsdd` |
 | Per-destination `ec` buffer | no | no | yes |
@@ -46,8 +46,8 @@ The `CmcdReporter` sizes were measured on the built `dist` of this worktree, bun
 | CTA-5004-B rule | `CmcdReporter` and PR #422 | Session API |
 |---|---|---|
 | `msd` once per session and mode, from starting to playing | gate only, value from the player | derived and gated |
-| `bs` since the last report per destination | player value | derived per target and player |
-| `ec` buffered per destination | player value, persists when pushed with `update()` | derived per target and player |
+| `bs` since the last report per destination | player value | derived per target and reporter |
+| `ec` buffered per destination | player value, persists when pushed with `update()` | derived per target and reporter |
 | `bsa`, `bsda`, `bsd` since session initiation | player values, planned derivation | derived |
 | `su` until stable playback | player value | derived default |
 | `dl` | player value | derived default |
@@ -55,7 +55,7 @@ The `CmcdReporter` sizes were measured on the built `dist` of this worktree, bun
 | `bg` over all players in a session | player value | session value, from document visibility |
 | `cmsds`, `cmsdd` from response headers | player values | derived |
 | `pr` event only while playing | not enforced | enforced |
-| One `sid`, one `sn` sequence per target across players | one reporter per player breaks it | native |
+| One `sid`, one `sn` sequence per target across players | one `CmcdReporter` per media player breaks it | native |
 | 429 back-off, 5xx retry, lost connectivity | re-queue, retry on the next event | exponential back-off with aggregation |
 | 410 for the rest of the session | yes | yes |
 | Per-target `Authorization` header, item 16 | no | `headers` per target |
@@ -82,7 +82,7 @@ Both players change under either path once they upgrade past 2.5. PR #422 keeps 
 
 | Work | PR #422 | Session API |
 |---|---|---|
-| Child reporters, PR #398 | a second facade over the ledger, `pid` on the provenance record, `activate()` | `createPlayer()` |
+| Child reporters, PR #398 | a second facade over the ledger, `pid` on the provenance record, `activate()` | `createReporter()` |
 | Starvation counters, `plans/cmcd-session-counters/` | transition detection in `acceptStateChange`, cursors in the commit step | in the transition tracking, same precedence rules |
 | Session retention, shipped in 2.6.0 | the ledger | object lifetime |
 | Transforms, shipped in 2.5.0 | `applyReportPolicy` | `emitReport`, same contract |

--- a/plans/cmcd-session-api/comparison.md
+++ b/plans/cmcd-session-api/comparison.md
@@ -27,7 +27,7 @@ The `CmcdReporter` sizes were measured on the built `dist` of this worktree, bun
 
 | Concept | `CmcdReporter` | PR #422 | Session API |
 |---|---|---|---|
-| `sid` rotation through `update({ sid })` | yes | yes | no, a `sid` is a session object |
+| `sid` rotation | `update({ sid })` | `update({ sid })` | `session.rotate(sid)`, one internal state per `sid`, no ledger |
 | Retention window and eviction | yes, `sessionRetention` | yes, in a ledger | no, object lifetime |
 | Provenance record on `customData` | yes, symbol key | yes | no, a plain `cmcd` record |
 | `customData` type parameter `C` | yes | yes | no |

--- a/plans/cmcd-session-api/comparison.md
+++ b/plans/cmcd-session-api/comparison.md
@@ -1,0 +1,102 @@
+# CMCD session API: comparison with `CmcdReporter` and PR #422
+
+Companion to [`rfc/cmcd-session-api.md`](../../rfc/cmcd-session-api.md) and [`architecture.md`](./architecture.md). It compares three paths for the CMCD version 2 reporter. All facts are as of 2026-09-09.
+
+## The three paths
+
+**`CmcdReporter` on `main`.** One class with the public API of 2.6.1. It gained state-change dedup in 2.4.0, transforms in 2.5.0, and session retention with provenance records in 2.6.0. Each feature added interactions with the earlier ones.
+
+**PR #422, the refactor.** Splits the class into a session ledger, playback state, a pure report pipeline, and per-target outboxes. The public API and every documented semantic remain unchanged. It fixes five defects from the 2.6.0 review. Its design record is [`plans/cmcd-reporter-architecture/`](../cmcd-reporter-architecture/).
+
+**The session API.** A second public API built for the version 2 spec, next to `CmcdReporter`. Three objects match the three scopes of the spec. The reporter derives the keys the spec defines in terms of observable state.
+
+## Size
+
+| Measure | `CmcdReporter` | PR #422 | Session API |
+|---|---|---|---|
+| Reporter source lines | 1318 | 1152 added, 610 removed, over 11 source files | 1500 to 1700, estimate |
+| Preparation source lines | 269 plus about 300 in tables | unchanged | 400 to 550 including the key table, estimate |
+| Reporter test lines | 4753 | 5315 | new suite, estimate 3000 to 4000 |
+| Minified bundle, reporter entry | 18.8 KB | not measured | at or below 18.8 KB, estimate |
+| Minified with gzip | 7.1 KB | not measured | at or below 7.1 KB, estimate |
+| Minified, `encodeCmcd` alone | 6.3 KB | 6.3 KB | 6.3 KB, unchanged |
+
+The `CmcdReporter` sizes were measured on the built `dist` of this worktree, bundled with `tsdown` and minified. The PR #422 line counts are from its diff against `main`, source files only. The session API numbers are estimates until a prototype exists.
+
+## Concepts
+
+| Concept | `CmcdReporter` | PR #422 | Session API |
+|---|---|---|---|
+| `sid` rotation through `update({ sid })` | yes | yes | no, a `sid` is a session object |
+| Retention window and eviction | yes, `sessionRetention` | yes, in a ledger | no, object lifetime |
+| Provenance record on `customData` | yes, symbol key | yes | no, a plain `cmcd` record |
+| `customData` type parameter `C` | yes | yes | no |
+| Dirty tracking, deferred eviction | no | yes | no |
+| Root and child reporters | proposed, PR #398 | landing zone prepared | no, players are peers |
+| `activate()` for interval reports | proposed, PR #398 | not yet | no, one line per player |
+| Per-target state in request mode | `sn` and `msd` only | keyed map | full target state |
+| Derived keys | `sn`, `ts`, `v`, `e`, `url`, `rc`, `ttfb`, `ttlb` | same | plus `msd`, `bs`, `bsa`, `bsda`, `bsd`, `su`, `dl`, `h`, `bg`, `cmsds`, `cmsdd` |
+| Per-destination `ec` buffer | no | no | yes |
+| Configuration errors | silent drop | silent drop | throw |
+| Transforms | per placement | per placement | per placement |
+| Formatters on the reporter | no | no | no |
+
+## Spec coverage
+
+| CTA-5004-B rule | `CmcdReporter` and PR #422 | Session API |
+|---|---|---|
+| `msd` once per session and mode, from starting to playing | gate only, value from the player | derived and gated |
+| `bs` since the last report per destination | player value | derived per target and player |
+| `ec` buffered per destination | player value, persists when pushed with `update()` | derived per target and player |
+| `bsa`, `bsda`, `bsd` since session initiation | player values, planned derivation | derived |
+| `su` until stable playback | player value | derived default |
+| `dl` | player value | derived default |
+| `h` hostname and its event | key only, no event token | derived, event added |
+| `bg` over all players in a session | player value | session value, from document visibility |
+| `cmsds`, `cmsdd` from response headers | player values | derived |
+| `pr` event only while playing | not enforced | enforced |
+| One `sid`, one `sn` sequence per target across players | one reporter per player breaks it | native |
+| 429 back-off, 5xx retry, lost connectivity | re-queue, retry on the next event | exponential back-off with aggregation |
+| 410 for the rest of the session | yes | yes |
+| Per-target `Authorization` header, item 16 | no | `headers` per target |
+| Existing `CMCD` parameter in the URL, item 6 | replaced | replaced |
+| Version 1 request mode with version 2 event mode | yes | yes |
+
+## Adopter impact
+
+Facts read from the hls.js `master` and dash.js `development` branches on 2026-09-09.
+
+| Finding | hls.js | dash.js |
+|---|---|---|
+| Pinned `@svta/cml-cmcd` | 2.4.0 | 2.3.2 |
+| `recordResponseReceived()` receives | `{ url }` from the loader context | a request whose `customData` has `cmcd` but no provenance record |
+| Result on 2.6 or later | every `rr` event dropped | every `rr` event dropped |
+| `update({ sta })` followed by `recordEvent(PLAY_STATE, data)` | no | yes, `data` lost on 2.4 or later |
+| Spec logic implemented by hand | `starved`, `buffering`, `dl` | `calculateMsd()`, rebuffer tracking with `bsd`, `su`, `dl`, `ec` persistence, CMSD base64 |
+| Rebuilds the reporter to change configuration | on every `MANIFEST_LOADING` | when manifest parameters arrive, with a comment about the `sid` and `sn` reset |
+| Interstitials under one `sid` | not possible | not applicable, single player |
+
+Both players change under either path once they upgrade past 2.5. PR #422 keeps the 2.6 contract, so the players must pass the decorated request back to keep `rr` events. The session API asks for the same request pass-back, and it removes the `msd`, `bs`, `su`, `dl`, and `ec` code from both players.
+
+## Where the queued work lands
+
+| Work | PR #422 | Session API |
+|---|---|---|
+| Child reporters, PR #398 | a second facade over the ledger, `pid` on the provenance record, `activate()` | `createPlayer()` |
+| Starvation counters, `plans/cmcd-session-counters/` | transition detection in `acceptStateChange`, cursors in the commit step | in the transition tracking, same precedence rules |
+| Session retention, shipped in 2.6.0 | the ledger | object lifetime |
+| Transforms, shipped in 2.5.0 | `applyReportPolicy` | `emitReport`, same contract |
+
+## Risks
+
+| Path | Risk |
+|---|---|
+| `CmcdReporter` as is | Each new feature multiplies interactions. Children and counters both wait on the refactor |
+| PR #422 | The public contract that both adopters break stays. The review is open with 4 unresolved threads, and the branch conflicts with `main` after PR #453 and PR #454 |
+| Session API | A new surface to document and test next to the old one. Wire changes during interstitials. Estimates until a prototype exists. Adoption needs hls.js and dash.js changes |
+
+## Reading
+
+PR #422 is the lower-risk step. It keeps every promise the package made in 2.6.0, and it lands in weeks. It also makes the 2.6.0 model permanent, and that model is the one both adopters have already failed to integrate against.
+
+The session API is the larger step. It spends its complexity on the spec instead of on session bookkeeping. It removes the concepts that produced most of the review history since 2.4.0. Its payoff is in the adoption priority. A player integration deletes code instead of adding it, and interstitials share one session with no new concept. The RFC review decides whether that payoff is worth a second API for one or two release cycles.

--- a/plans/cmcd-session-api/steps.md
+++ b/plans/cmcd-session-api/steps.md
@@ -1,0 +1,4621 @@
+# CMCD session API implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the CMCD session API of [`rfc/cmcd-session-api.md`](../../rfc/cmcd-session-api.md) in `@svta/cml-cmcd`, next to the existing `CmcdReporter`.
+
+**Architecture:** One `CmcdSession` per playback owns the configuration, the current `sid` state, the timers, and `bg`. One `CmcdSessionReporter` per media player pushes state, records events, decorates requests, and records responses. Internal target states hold the per-destination counters, gates, buffers, and queues. A key table drives report preparation. [`architecture.md`](./architecture.md) is the design record: read its State and Algorithms sections before each task.
+
+**Tech Stack:** TypeScript, Node 24 test runner (`node:test`, `node:assert`), `@svta/cml-structured-field-values` for the wire encoding, `@svta/cml-utils` for `uuid`, `HttpRequest`, and the URL helpers. Build with `npm run build -w libs/cmcd`. Tests run against the built `dist`.
+
+## Global constraints
+
+- Node 24 or later. `npm install` fails on older versions.
+- Tests import from `@svta/cml-cmcd`, never from `../src`. Build before every test run: `npm run build -w libs/cmcd`.
+- Run one test file with `node --no-warnings --test libs/cmcd/test/<file>.test.ts` from the repository root. Run `npm run typecheck` at the root after every task, because the tests typecheck against `dist/index.d.ts`.
+- Code style: tabs, no semicolons, single quotes, `type` not `interface`, no `enum`, and named exports only.
+- Relative imports carry the `.ts` extension. Use `readonly` where mutation is not intended, and bracket access for index signatures.
+- One export per file. `index.ts` uses `export type *` for type-only files and `export *` for the rest.
+- No code runs at module scope. Annotate a module-scope `new Map()`, `new Set()`, or `new WeakMap()` with `/* @__PURE__ */`.
+- Every public export has TSDoc with `@public`. Public functions have `@example {@includeCode ../test/<file>.test.ts#example}` and the test file has a `// #region example` block.
+- Every commit uses `git commit -s`, a Conventional Commits subject, and the trailer `Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>`. Never commit to `main`. Work on branch `feat/cmcd-session-api`.
+- Prose in TSDoc, the changelog, and the docs follows the writing rules of `AGENTS.md`. Sentences stay under 20 words, with no semicolons, no em dashes, no idioms, and one name per concept.
+- Spec text: CTA-5004-B at <https://cta-wave.github.io/Resources/common-media-client-data--cta-5004-b.html>. The wire examples of its section 8 are the conformance fixtures.
+- Two deliberate deviations from the design record are recorded in Task 14. The transform runs on the normalized report, so its `Cmcd` parameter type is exact. The `h` key is required on the `h` event.
+
+## File structure
+
+Public types, one per file in `libs/cmcd/src/`: `CmcdSession.ts`, `CmcdSessionConfig.ts`, `CmcdSessionReporter.ts`, `CmcdSessionReporterConfig.ts`, `CmcdPlaybackData.ts`, `CmcdMetric.ts`, `CmcdNextObject.ts`, `CmcdEventTargetConfig.ts`, `CmcdRequester.ts`, `CmcdRequestLike.ts`, `CmcdDecoratedRequest.ts`, `CmcdRequestRecord.ts`, `CmcdResponseInfo.ts`, `CmcdResourceTiming.ts`, `CmcdResponseData.ts`, `CmcdRequestTransform.ts`, `CmcdEventTransform.ts`, `CmcdDiscreteEventType.ts`.
+
+Public function: `createCmcdSession.ts`.
+
+Internal, in `libs/cmcd/src/`, not exported from `index.ts`:
+
+| File | Responsibility |
+|---|---|
+| `CmcdKeySpec.ts`, `CMCD_KEY_SPECS.ts`, `getKeySpec.ts` | the key table and its lookup, including custom keys |
+| `PrepareContext.ts`, `normalizeValue.ts`, `formatNor.ts`, `normalizeReport.ts`, `filterReport.ts` | preparation: plain values to structured-field values, then the spec rules and the key allowlist |
+| `NormalizedSessionConfig.ts`, `NormalizedEventTarget.ts`, `normalizeSessionConfig.ts`, `checkRequestSettings.ts` | configuration defaults and checks |
+| `SessionState.ts`, `SidState.ts`, `ReporterState.ts`, `TargetState.ts`, `TargetEntry.ts`, `RequestOrigin.ts`, `CMCD_REQUEST_ORIGINS.ts` | state types and the origin map |
+| `createSidState.ts`, `createTargetState.ts`, `getTargetEntry.ts` | state factories |
+| `assembleReport.ts`, `emitReport.ts`, `emitEvent.ts`, `pruneSpans.ts` | the report path for one target and the fan-out to event targets |
+| `trackTransition.ts`, `deriveStateEvents.ts` | the `sta` transition effects and the state-change diff |
+| `placeRequestReport.ts`, `copyPlaybackData.ts` | request decoration and the per-request data copy |
+| `toResponseKeys.ts`, `readHeader.ts` | the `rr` derivations |
+| `processQueue.ts`, `defaultRequester.ts`, `armTimers.ts`, `tickTarget.ts` | delivery and the interval timers |
+| `observeVisibility.ts`, `emitBackgroundChange.ts` | `bg` from document visibility |
+| `createSessionReporter.ts`, `rotateSession.ts`, `configureSession.ts`, `flushSession.ts`, `disposeSession.ts` | the reporter facade and the session operations |
+
+Tests in `libs/cmcd/test/`: `CmcdSessionTypes.test.ts`, `createCmcdSession.test.ts`, `CmcdSessionReporter.request.test.ts`, `CmcdSessionReporter.events.test.ts`, `CmcdSessionReporter.derived.test.ts`, `CmcdSessionReporter.responses.test.ts`, `CmcdSession.rotation.test.ts`, `CmcdSession.transforms.test.ts`, `CmcdSession.delivery.test.ts`, `CmcdSession.errors.test.ts`, `CmcdSession.validation.test.ts`, the fixtures in `test/data/CTA_5004_B_EXAMPLES.ts`, and the helpers in `test/helpers/cmcdSessionHarness.ts`.
+
+---
+
+### Task 1: Public types and the `h` event token
+
+**Files:**
+- Modify: `libs/cmcd/src/CmcdEventType.ts` (add the `h` event)
+- Modify: `libs/cmcd/src/CMCD_TOKEN_VALUES.ts` (add `h` to the `e` tokens)
+- Create: the 18 public type files listed under File structure
+- Modify: `libs/cmcd/src/index.ts`
+- Test: `libs/cmcd/test/CmcdSessionTypes.test.ts`
+
+**Interfaces:**
+- Produces: every public type of the RFC's Reference section, with the exact member names below. Every later task imports them.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// libs/cmcd/test/CmcdSessionTypes.test.ts
+import type { CmcdDecoratedRequest, CmcdPlaybackData, CmcdResponseData, CmcdSessionConfig, CmcdSessionReporter } from '@svta/cml-cmcd'
+import { CmcdEventType, validateCmcdEvents } from '@svta/cml-cmcd'
+import { equal } from 'node:assert'
+import { describe, it } from 'node:test'
+
+describe('CMCD session API types', () => {
+	it('exposes the h event', () => {
+		equal(CmcdEventType.HOSTNAME, 'h')
+		equal(validateCmcdEvents('e=h,h="example.com",sid="s",ts=1,v=2').valid, true)
+	})
+
+	it('compiles the documented shapes', () => {
+		const data: CmcdPlaybackData = { sta: 'p', bl: { v: 3200, a: 1800 }, br: 3000, nor: [{ url: 'seg.m4s', range: '0-99' }], 'com.example-key': 'x', ts: 1 }
+		// @ts-expect-error ec is not a member, errors go through recordError()
+		const bad: CmcdPlaybackData = { ec: ['x'] }
+		const response: CmcdResponseData = { ...data, ttfbb: 12, smrt: 'abc' }
+		// @ts-expect-error sn is reporter-owned
+		const badResponse: CmcdResponseData = { sn: 1 }
+		const config: CmcdSessionConfig = { derive: { bg: false }, eventTargets: [{ url: 'https://c.example/cmcd' }] }
+		type Decorated = CmcdDecoratedRequest<{ url: string; retries: number }>
+		const decorated = { url: 'u', retries: 1, cmcd: { sid: 's', data: {} } } as Decorated
+		const headers: Readonly<Record<string, string>> | undefined = decorated.headers
+		type Recorder = CmcdSessionReporter['recordEvent']
+		const recordEvent: Recorder = () => {}
+		// @ts-expect-error ps is derived from update(), not recordable
+		recordEvent('ps')
+		equal([data, bad, response, badResponse, config, headers].length, 6)
+	})
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionTypes.test.ts`
+Expected: FAIL, `CmcdEventType.HOSTNAME` is `undefined`. `npm run typecheck` also fails on the missing types.
+
+- [ ] **Step 3: Add the `h` event**
+
+In `libs/cmcd/src/CmcdEventType.ts`, after the `CMCD_EVENT_CUSTOM_EVENT` constant:
+
+```ts
+/**
+ * CMCD event type for the 'h' key (hostname). The player reports the host of the request URL when it changes.
+ *
+ * @public
+ */
+export const CMCD_EVENT_HOSTNAME = 'h' as const
+```
+
+In the `CmcdEventType` collector object, after `CUSTOM_EVENT`:
+
+```ts
+	/**
+	 * The host of the request URL changed.
+	 */
+	HOSTNAME: CMCD_EVENT_HOSTNAME as typeof CMCD_EVENT_HOSTNAME,
+```
+
+In `libs/cmcd/src/CMCD_TOKEN_VALUES.ts`, add `'h'` to the `e` list, after `'ce'`.
+
+- [ ] **Step 4: Create the type files**
+
+```ts
+// libs/cmcd/src/CmcdMetric.ts
+import type { CmcdObjectType } from './CmcdObjectType.ts'
+
+/**
+ * A value that the spec allows per object type. A number applies to the whole report.
+ * A record gives one value per object type, for example `{ v: 3000, a: 128 }`.
+ *
+ * @public
+ */
+export type CmcdMetric = number | Readonly<Partial<Record<CmcdObjectType, number>>>
+```
+
+```ts
+// libs/cmcd/src/CmcdNextObject.ts
+/**
+ * A next object request for the `nor` key: a URL, or a URL with a byte range.
+ *
+ * @public
+ */
+export type CmcdNextObject = string | { readonly url: string; readonly range?: string }
+```
+
+```ts
+// libs/cmcd/src/CmcdPlaybackData.ts
+import type { CmcdCustomValue } from './CmcdCustomValue.ts'
+import type { CmcdMetric } from './CmcdMetric.ts'
+import type { CmcdNextObject } from './CmcdNextObject.ts'
+import type { CmcdObjectType } from './CmcdObjectType.ts'
+import type { CmcdPlayerState } from './CmcdPlayerState.ts'
+import type { CmcdStreamType } from './CmcdStreamType.ts'
+import type { CmcdStreamingFormat } from './CmcdStreamingFormat.ts'
+
+/**
+ * The playback data a player gives to a `CmcdSessionReporter`. Every member is optional.
+ * Values are plain: numbers in the spec's units, booleans, and tokens as strings.
+ * The reporter rounds and encodes them. `ts` is the time of the transition and is not stored.
+ * `ec` is not a member. Errors go through `recordError()`.
+ *
+ * @public
+ */
+export type CmcdPlaybackData = {
+	readonly [key: `${string}-${string}`]: CmcdCustomValue | undefined
+	readonly ab?: CmcdMetric
+	readonly bg?: boolean
+	readonly bl?: CmcdMetric
+	readonly br?: CmcdMetric
+	readonly bs?: boolean
+	readonly bsa?: CmcdMetric
+	readonly bsd?: CmcdMetric
+	readonly bsda?: CmcdMetric
+	readonly cid?: string
+	readonly cs?: string
+	readonly d?: number
+	readonly dfa?: number
+	readonly dl?: number
+	readonly h?: string
+	readonly lab?: CmcdMetric
+	readonly lb?: CmcdMetric
+	readonly ltc?: number
+	readonly msd?: number
+	readonly mtp?: CmcdMetric
+	readonly nor?: CmcdNextObject | readonly CmcdNextObject[]
+	readonly nr?: boolean
+	readonly ot?: CmcdObjectType
+	readonly pb?: CmcdMetric
+	readonly pr?: number
+	readonly pt?: number
+	readonly rtp?: number
+	readonly sf?: CmcdStreamingFormat
+	readonly st?: CmcdStreamType
+	readonly sta?: CmcdPlayerState
+	readonly su?: boolean
+	readonly tab?: CmcdMetric
+	readonly tb?: CmcdMetric
+	readonly tbl?: CmcdMetric
+	readonly tpb?: CmcdMetric
+	readonly ts?: number
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdResponseData.ts
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+
+/**
+ * The data argument of `recordResponse()`: the playback data plus the response keys.
+ * A supplied response key wins over the derived value for that report.
+ *
+ * @public
+ */
+export type CmcdResponseData = CmcdPlaybackData & {
+	readonly ttfb?: number
+	readonly ttlb?: number
+	readonly ttfbb?: number
+	readonly smrt?: string
+	readonly cmsds?: string
+	readonly cmsdd?: string
+	readonly rc?: number
+	readonly url?: string
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdDiscreteEventType.ts
+/**
+ * The events a player records with `recordEvent()`. The other event types are derived by the reporter.
+ *
+ * @public
+ */
+export type CmcdDiscreteEventType = 'as' | 'ae' | 'abs' | 'abe' | 'sk' | 'm' | 'um' | 'pe' | 'pc' | 'ce'
+```
+
+```ts
+// libs/cmcd/src/CmcdRequester.ts
+import type { HttpRequest } from '@svta/cml-utils'
+
+/**
+ * Sends one event-mode POST and resolves with the response status. The default uses `fetch` with `keepalive`.
+ *
+ * @public
+ */
+export type CmcdRequester = (request: HttpRequest) => Promise<{ status: number }>
+```
+
+```ts
+// libs/cmcd/src/CmcdEventTransform.ts
+import type { Cmcd } from './Cmcd.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+
+/**
+ * Changes or cancels one event report before it is encoded. Return `null` to cancel.
+ * `request` is the decorated request for an `rr` report, else `undefined`.
+ *
+ * @public
+ */
+export type CmcdEventTransform = (data: Cmcd, request: Readonly<CmcdRequestLike> | undefined) => Cmcd | null
+```
+
+```ts
+// libs/cmcd/src/CmcdRequestTransform.ts
+import type { Cmcd } from './Cmcd.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+
+/**
+ * Changes or cancels one request-mode report before it is placed on the request. Return `null` to cancel.
+ *
+ * @public
+ */
+export type CmcdRequestTransform = (data: Cmcd, request: Readonly<CmcdRequestLike>) => Cmcd | null
+```
+
+```ts
+// libs/cmcd/src/CmcdEventTargetConfig.ts
+import type { CmcdEventTransform } from './CmcdEventTransform.ts'
+import type { CmcdEventType } from './CmcdEventType.ts'
+import type { CmcdKey } from './CmcdKey.ts'
+
+/**
+ * One event-mode destination. `{ url }` is a complete configuration.
+ *
+ * @public
+ */
+export type CmcdEventTargetConfig = {
+	readonly url: string
+	/** Default `['ps', 'e', 't', 'rr']`. */
+	readonly events?: readonly CmcdEventType[]
+	/** Key allowlist. Default: every event key. */
+	readonly keys?: readonly CmcdKey[]
+	/** Seconds between `t` reports. Default 30. `0` disables them. */
+	readonly interval?: number
+	/** Lines per POST. Default 1. */
+	readonly batchSize?: number
+	/** Queued lines kept while the destination is unreachable. Default 500. */
+	readonly maxQueueSize?: number
+	/** Headers sent with every POST. */
+	readonly headers?: Readonly<Record<string, string>>
+	readonly transform?: CmcdEventTransform
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdSessionConfig.ts
+import type { CmcdEventTargetConfig } from './CmcdEventTargetConfig.ts'
+import type { CmcdHeaderMap } from './CmcdHeaderMap.ts'
+import type { CmcdKey } from './CmcdKey.ts'
+import type { CmcdRequestTransform } from './CmcdRequestTransform.ts'
+import type { CmcdRequester } from './CmcdRequester.ts'
+import type { CmcdTransmissionMode } from './CmcdTransmissionMode.ts'
+import type { CmcdVersion } from './CmcdVersion.ts'
+
+/**
+ * Configuration of `createCmcdSession()`. Every member is optional.
+ * `version`, `transmissionMode`, `keys`, `headerMap`, and `transform` apply to request mode.
+ *
+ * @public
+ */
+export type CmcdSessionConfig = {
+	/** Default: a new UUID. */
+	readonly sid?: string
+	/** Default `CMCD_V2`. */
+	readonly version?: CmcdVersion
+	/** `CMCD_QUERY` or `CMCD_HEADERS`. Default `CMCD_QUERY`. */
+	readonly transmissionMode?: CmcdTransmissionMode
+	/** Request-mode key allowlist. Default: every key of the version. */
+	readonly keys?: readonly CmcdKey[]
+	/** Header shard per custom key. */
+	readonly headerMap?: Partial<CmcdHeaderMap>
+	readonly transform?: CmcdRequestTransform
+	readonly eventTargets?: readonly CmcdEventTargetConfig[]
+	/** Sends the event-mode POST requests. Default: `fetch` with `keepalive`. */
+	readonly requester?: CmcdRequester
+	/** Observations the reporter turns into defaults. Each is on by default. */
+	readonly derive?: Partial<Record<'bg' | 'dl' | 'su', boolean>>
+	/** Receives errors that have no caller: interval reports and a requester that fails after the back-off cap. */
+	readonly onError?: (error: unknown) => void
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdSessionReporterConfig.ts
+/**
+ * Configuration of `session.createReporter()`.
+ *
+ * @public
+ */
+export type CmcdSessionReporterConfig = {
+	/** The content ID of this media player. */
+	readonly cid?: string
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdRequestLike.ts
+/**
+ * The shape `decorate()` and `recordResponse()` accept: a URL and optional headers.
+ *
+ * @public
+ */
+export type CmcdRequestLike = {
+	readonly url: string
+	readonly headers?: Readonly<Record<string, string>>
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdRequestRecord.ts
+import type { Cmcd } from './Cmcd.ts'
+
+/**
+ * The record `decorate()` puts on the returned request as `cmcd`. `data` is the report as sent.
+ * The record object is the key that attributes a late response, so keep it on the request.
+ *
+ * @public
+ */
+export type CmcdRequestRecord = {
+	readonly sid: string
+	readonly data: Readonly<Cmcd>
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdDecoratedRequest.ts
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import type { CmcdRequestRecord } from './CmcdRequestRecord.ts'
+
+/**
+ * The return type of `decorate()`. `url` carries the query parameter in query mode.
+ * `headers` carries the `CMCD-` headers in header mode. Every other member of the input passes through.
+ *
+ * @public
+ */
+export type CmcdDecoratedRequest<R extends CmcdRequestLike> = Omit<R, 'url' | 'headers' | 'cmcd'> & {
+	readonly url: string
+	readonly headers?: Readonly<Record<string, string>>
+	readonly cmcd: CmcdRequestRecord
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdResourceTiming.ts
+/**
+ * The members of a `PerformanceResourceTiming` entry that `recordResponse()` reads.
+ *
+ * @public
+ */
+export type CmcdResourceTiming = {
+	readonly startTime: number
+	readonly responseStart?: number
+	readonly responseEnd?: number
+	readonly duration?: number
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdResponseInfo.ts
+import type { CmcdResourceTiming } from './CmcdResourceTiming.ts'
+
+/**
+ * What the player knows about a response. Every member is optional.
+ *
+ * @public
+ */
+export type CmcdResponseInfo = {
+	/** The HTTP status. `rc` is `0` when absent. */
+	readonly status?: number
+	readonly headers?: Headers | Readonly<Record<string, string>>
+	readonly timing?: CmcdResourceTiming
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdSessionReporter.ts
+import type { CmcdDecoratedRequest } from './CmcdDecoratedRequest.ts'
+import type { CmcdDiscreteEventType } from './CmcdDiscreteEventType.ts'
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import type { CmcdResponseData } from './CmcdResponseData.ts'
+import type { CmcdResponseInfo } from './CmcdResponseInfo.ts'
+import type { CmcdSession } from './CmcdSession.ts'
+
+/**
+ * Reports for one media player inside a `CmcdSession`.
+ *
+ * @public
+ */
+export type CmcdSessionReporter = {
+	readonly session: CmcdSession
+	/** Merges `data` into the store and emits the state-change events it implies. */
+	update(data: CmcdPlaybackData): void
+	/** Emits one discrete event. */
+	recordEvent(type: Exclude<CmcdDiscreteEventType, 'ce'>, data?: CmcdPlaybackData): void
+	recordEvent(type: 'ce', data: CmcdPlaybackData & { readonly cen: string }): void
+	/** Buffers error codes per destination and emits an `e` event. */
+	recordError(code: string | readonly string[], data?: CmcdPlaybackData): void
+	/** Returns a copy of `request` with the request-mode report placed on it. */
+	decorate<R extends CmcdRequestLike>(request: R, data?: CmcdPlaybackData): CmcdDecoratedRequest<R>
+	/** Emits an `rr` event for a response. Pass the request returned by `decorate()`. */
+	recordResponse(request: CmcdRequestLike, response: CmcdResponseInfo, data?: CmcdResponseData): void
+	dispose(): void
+}
+```
+
+```ts
+// libs/cmcd/src/CmcdSession.ts
+import type { CmcdSessionConfig } from './CmcdSessionConfig.ts'
+import type { CmcdSessionReporter } from './CmcdSessionReporter.ts'
+import type { CmcdSessionReporterConfig } from './CmcdSessionReporterConfig.ts'
+
+/**
+ * One CMCD session. It reports under one `sid` at a time and owns the targets, the requester, the timers, and `bg`.
+ *
+ * @public
+ */
+export type CmcdSession = {
+	/** The current `sid`. */
+	readonly sid: string
+	createReporter(config?: CmcdSessionReporterConfig): CmcdSessionReporter
+	/** Starts the next `sid` for every reporter. A new UUID when omitted. Emits nothing. */
+	rotate(sid?: string): void
+	/** Replaces the request-mode settings. Emits nothing and resets no counter. */
+	configure(settings: Pick<CmcdSessionConfig, 'version' | 'transmissionMode' | 'keys' | 'headerMap'>): void
+	/** Sends every queued event line now. */
+	flush(): void
+	dispose(): void
+}
+```
+
+- [ ] **Step 5: Export the types**
+
+Add to `libs/cmcd/src/index.ts`, in alphabetical position among the existing lines:
+
+```ts
+export type * from './CmcdDecoratedRequest.ts'
+export type * from './CmcdDiscreteEventType.ts'
+export type * from './CmcdEventTargetConfig.ts'
+export type * from './CmcdEventTransform.ts'
+export type * from './CmcdMetric.ts'
+export type * from './CmcdNextObject.ts'
+export type * from './CmcdPlaybackData.ts'
+export type * from './CmcdRequestLike.ts'
+export type * from './CmcdRequestRecord.ts'
+export type * from './CmcdRequestTransform.ts'
+export type * from './CmcdRequester.ts'
+export type * from './CmcdResourceTiming.ts'
+export type * from './CmcdResponseData.ts'
+export type * from './CmcdResponseInfo.ts'
+export type * from './CmcdSession.ts'
+export type * from './CmcdSessionConfig.ts'
+export type * from './CmcdSessionReporter.ts'
+export type * from './CmcdSessionReporterConfig.ts'
+```
+
+- [ ] **Step 6: Run the test and the typecheck**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionTypes.test.ts && npm run typecheck`
+Expected: PASS, and the typecheck reports no error. If `@ts-expect-error` reports "Unused directive", the type is too loose. Fix the type, not the test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test/CmcdSessionTypes.test.ts
+git commit -s -m "feat(cmcd): add the session API types and the h event token" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Key table, preparation, and request-mode decoration
+
+**Files:**
+- Create, in `libs/cmcd/src/`, the preparation files: `CmcdKeySpec.ts`, `CMCD_KEY_SPECS.ts`, `getKeySpec.ts`, `PrepareContext.ts`, `normalizeValue.ts`, `formatNor.ts`, `normalizeReport.ts`, `filterReport.ts`
+- Create the configuration files: `NormalizedSessionConfig.ts`, `NormalizedEventTarget.ts`, `normalizeSessionConfig.ts`, `defaultRequester.ts`
+- Create the state files: `SessionState.ts`, `SidState.ts`, `ReporterState.ts`, `TargetState.ts`, `TargetEntry.ts`, `RequestOrigin.ts`, `CMCD_REQUEST_ORIGINS.ts`, `createSidState.ts`, `createTargetState.ts`, `getTargetEntry.ts`
+- Create the report path files: `assembleReport.ts`, `emitReport.ts`, `pruneSpans.ts`, `placeRequestReport.ts`, `copyPlaybackData.ts`
+- Create the facade files: `createSessionReporter.ts`, `createCmcdSession.ts`
+- Modify: `libs/cmcd/src/index.ts`
+- Test: `libs/cmcd/test/data/CTA_5004_B_EXAMPLES.ts`, `libs/cmcd/test/helpers/cmcdSessionHarness.ts`, `libs/cmcd/test/CmcdSessionReporter.request.test.ts`
+
+**Interfaces:**
+- Consumes: the types of Task 1.
+- Produces: `createCmcdSession(config?)`, `reporter.update()` as a store merge, `reporter.decorate()` in query and header mode, `reporter.recordError()` buffering into every target's entry. The internal functions below keep these signatures in every later task: `assembleReport(session, sidState, target, reporter, event, data, ts): AssembledReport`, `emitReport(session, sidState, target, reporter, assembled, event, request): EmittedReport | undefined`, `normalizeReport(report, context)`, `filterReport(normalized, context)`.
+
+This task ships request mode end to end. Configuration errors, state-change events, derived keys, and delivery follow in later tasks. `rotate()`, `flush()`, and `dispose()` get their first implementation here and their full behavior in Tasks 9, 11, and 12.
+
+- [ ] **Step 1: Write the fixtures and the harness**
+
+The fixtures are the raw key lines of CTA-5004-B section 8.1. Only the derived `sn` is adapted, because a fixture cannot reproduce a counter of 129.
+
+```ts
+// libs/cmcd/test/data/CTA_5004_B_EXAMPLES.ts
+/** Raw key lines of CTA-5004-B section 8.1, request mode. */
+export const EX_8_1_1 = 'bl=(2000),br=(3000;v),cid="content-id-123",d=4000,dl=1000,mtp=(15000),nor=("next-seg.mp4"),ot=v,rtp=12000,sf=d,sid="session-id-123",st=v,sta=p,tb=(6000;v),v=2'
+export const EX_8_1_1_HEADERS = {
+	'CMCD-Request': 'bl=(2000),dl=1000,mtp=(15000),nor=("next-seg.mp4"),sta=p',
+	'CMCD-Object': 'br=(3000;v),d=4000,ot=v,tb=(6000;v)',
+	'CMCD-Status': 'rtp=12000',
+	'CMCD-Session': 'cid="content-id-123",sf=d,sid="session-id-123",st=v,v=2',
+}
+export const EX_8_1_2 = 'bl=(2000),br=(320),cid="content-id-123",d=2000,mtp=(15000),ot=a,sid="session-id-123",st=v,v=2'
+export const EX_8_1_3 = 'cid="content-id-123",sid="session-id-123",v=2'
+export const EX_8_1_4 = [
+	'cid="content-id-123",ot=m,sf=d,sid="session-id-123",st=v,su,v=2',
+	'bl=(0),br=(3000;v),cid="content-id-123",mtp=(15000),nor=("seg-1.m4v" "seg-2.m4v"),ot=i,sid="session-id-123",st=v,sta=s,su,v=2',
+	'bl=(0),br=(3000;v),cid="content-id-123",d=4000,mtp=(15000),nor=("seg-2.m4v" "seg-3.m4v"),ot=v,sid="session-id-123",st=v,sta=s,su,v=2',
+	'bl=(4000),br=(3000;v),cid="content-id-123",d=4000,msd=200,mtp=(15000),nor=("seg-3.m4v" "seg-4.m4v"),ot=v,sid="session-id-123",st=v,sta=p,v=2',
+]
+export const EX_8_1_5 = [
+	'cid="content-id-123",ec=("CODEC_NOT_SUPPORTED"),sid="session-id-123",sta=p,v=2',
+	'cid="content-id-123",ec=("DRM_NOT_SUPPORTED" "PLAYBACK_FAILED"),sid="session-id-123",sta=f,v=2',
+]
+export const EX_8_1_6 = [
+	'bl=(0),bs,cid="content-id-123",ot=v,sid="session-id-123",sta=r,v=2',
+	'bl=(0;v 2000;a),bs,cid="content-id-123",ot=v,sid="session-id-123",sta=r,v=2',
+]
+export const EX_8_1_7 = {
+	primary: 'cid="movie-123",ot=v,sid="session-common-1",v=2',
+	ad: 'cid="ad-555",nr,ot=v,sid="session-common-1",v=2',
+	primaryHidden: 'cid="movie-123",nr,ot=v,sid="session-common-1",v=2',
+	adShown: 'cid="ad-555",ot=v,sid="session-common-1",v=2',
+}
+/** 8.1.8 with `sn=129` replaced by the first sequence number of a fresh session. */
+export const EX_8_1_8 = 'bg,bl=(2100;v 1800;a),br=(3000;v 164;a),bs,bsa=(3;v),bsd=(1200;v 100;a),bsda=(4150;v 300;a),cid="content-id-123",cs="g48djn236sk2",d=4000,dfa=32,dl=1000,ec=("2001"),lb=(500;v 32;a),ltc=13500,msd=1700,mtp=(15000;v 6000;a),nor=("next-seg.mp4"),nr,ot=v,pb=(2000;v 164;a),pr=1.1,pt=632782,rtp=12000,sf=d,sid="session-id-123",sn=0,st=l,sta=p,su,tb=(6000;v 350;a),tbl=(2000;v 2000;a),tpb=(5000;v 164;a),v=2'
+
+/** POST bodies of section 8.2, event mode. Document whitespace removed. */
+export const EX_8_2_1 = 'e=t,ts=1764752400000,v=2'
+export const EX_8_2_2 = [
+	'bl=(0),cid="content-id-123",e=t,h="example.com",pt=0,sid="session-id-123",sn=1,sta=s,su,ts=1764752400000,v=2',
+	'bl=(6000),br=(4200;v 256;a),cid="content-id-123",e=t,h="example.com",lb=(523;v 64;a),msd=812,mtp=(87000;v 49000;a),pb=(4200;v 256;a),pt=29188,sf=d,sid="session-id-123",sn=2,st=v,sta=p,tb=(4200;v 256;a),tpb=(4200;v 256;a),ts=1764752430000,v=2',
+	'bl=(3200),br=(4200;v 256;a),bs,bsd=(720;v),cid="content-id-123",e=t,ec=("MEDIA_ERR_NETWORK"),h="example.com",lb=(523;v 64;a),mtp=(89000;v 52000;a),pb=(4200;v 256;a),pt=59188,sf=d,sid="session-id-123",sn=3,st=v,sta=p,tb=(4200;v 256;a),tpb=(4200;v 256;a),ts=1764752460000,v=2',
+	'bl=(6000),br=(4200;v 256;a),cid="content-id-123",e=t,h="example.com",lb=(523;v 64;a),mtp=(81000;v 55000;a),pb=(4200;v 256;a),pt=89188,sf=d,sid="session-id-123",sn=4,st=v,sta=p,tb=(4200;v 256;a),tpb=(4200;v 256;a),ts=1764752490000,v=2',
+	'bl=(0),br=(4200;v 256;a),cid="content-id-123",e=t,h="example.com",lb=(523;v 64;a),mtp=(82000;v 55000;a),pb=(4200;v 256;a),pr=0,pt=111000,sf=d,sid="session-id-123",sn=5,st=v,sta=e,tb=(4200;v 256;a),tpb=(4200;v 256;a),ts=1764752520000,v=2',
+]
+export const EX_8_2_3 = 'cid="bbb",cmsdd="ZXRwPTEyNTAwO3J0dD0zNTttYj02MDAwO3JkPTIwMA==",cmsds="c2lkPSI5YTNiLTIxY2QiO2JyPTQ1MDA7ZD00MDAwO290PXY7c3Q9dg==",e=rr,nor=("video/segment-6.m4v"),ot=v,rc=200,sid="session1",ts=1763657019723,ttfb=180,ttlb=200,url="video/segment-5.m4v",v=2'
+export const EX_8_2_4 = 'cid="content-id-123",e=e,ec=("CODEC_NOT_SUPPORTED"),sid="session-id-123",ts=1764269150213,v=2'
+/** 8.2.5. The first line carries `bs`, which the example omits. See the derived test for the reason. */
+export const EX_8_2_5 = [
+	'bs,cid="content-id-123",e=ps,sid="session-id-123",sta=r,ts=1764269150889,v=2',
+	'bs,bsd=(1500),cid="content-id-123",e=ps,sid="session-id-123",sta=p,ts=1764269152389,v=2',
+]
+export const EX_8_2_6 = 'bl=(0),cid="content-id-123",e=ps,pt=30000,sid="session-id-123",sta=k,ts=1764269150529,v=2'
+export const EX_8_2_7 = 'cid="ad-content-555",e=sk,sid="session-id-123",ts=1764269150076,v=2'
+export const EX_8_2_8 = [
+	'cid="movie-123",e=abs,nr,sid="session-id-123",ts=1764269150186,v=2',
+	'cid="ad-001",e=as,sid="session-id-123",ts=1764269150934,v=2',
+	'cid="ad-001",e=ae,nr,sid="session-id-123",ts=1764269170901,v=2',
+	'cid="movie-123",e=abe,sid="session-id-123",ts=1764269170331,v=2',
+]
+```
+
+The spec's 8.2.5 second `ts` is earlier than the first in the document. The fixture uses the first `ts` plus the 1500 millisecond stall, so that `bsd` derives from the clock. Example 8.2.9 is not a fixture. Its `smrt` value has no derivation, and 8.1.8 and 8.2.3 cover its other keys.
+
+```ts
+// libs/cmcd/test/helpers/cmcdSessionHarness.ts
+import type { HttpRequest } from '@svta/cml-utils'
+
+export type MockRequester = {
+	requester: (request: HttpRequest) => Promise<{ status: number }>
+	requests: HttpRequest[]
+	bodies: () => string[]
+	status: number
+}
+
+/** A requester that records every POST and answers with `status`. Change `status` between calls. */
+export function createMockRequester(status: number = 200): MockRequester {
+	const requests: HttpRequest[] = []
+	const mock: MockRequester = {
+		requests,
+		status,
+		bodies: () => requests.map(request => request.body as string),
+		requester: async (request) => {
+			requests.push(request)
+			return { status: mock.status }
+		},
+	}
+	return mock
+}
+
+/** Lets the requester promises settle. `setImmediate` is not part of the mocked timers. */
+export function flushPromises(): Promise<void> {
+	return new Promise(resolve => setImmediate(resolve))
+}
+
+/** The `CMCD` query value of a decorated URL, decoded. */
+export function queryValue(url: string): string {
+	const match = /[?&]CMCD=([^&#]*)/.exec(url)
+	return match ? decodeURIComponent(match[1]) : ''
+}
+```
+
+- [ ] **Step 2: Write the failing request-mode tests**
+
+```ts
+// libs/cmcd/test/CmcdSessionReporter.request.test.ts
+import { CmcdTransmissionMode, createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal } from 'node:assert'
+import { describe, it } from 'node:test'
+import { EX_8_1_1, EX_8_1_1_HEADERS, EX_8_1_2, EX_8_1_3, EX_8_1_5, EX_8_1_6, EX_8_1_7, EX_8_1_8 } from './data/CTA_5004_B_EXAMPLES.ts'
+import { queryValue } from './helpers/cmcdSessionHarness.ts'
+
+const SEGMENT = 'https://cdn.example.com/seg-1.m4s'
+
+describe('CmcdSessionReporter request mode', () => {
+	it('reproduces 8.1.1 in query mode', () => {
+		const session = createCmcdSession({ sid: 'session-id-123', keys: ['bl', 'br', 'cid', 'd', 'dl', 'mtp', 'nor', 'ot', 'rtp', 'sf', 'sid', 'st', 'sta', 'tb'] })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ sf: 'd', st: 'v', sta: 'p', bl: 2000, mtp: 15000, rtp: 12000 })
+		const req = reporter.decorate({ url: SEGMENT }, { br: { v: 3000 }, d: 4000, dl: 1000, nor: 'https://cdn.example.com/next-seg.mp4', ot: 'v', tb: { v: 6000 } })
+		equal(queryValue(req.url), EX_8_1_1)
+		equal(req.url.startsWith(`${SEGMENT}?CMCD=`), true)
+		equal(req.cmcd.sid, 'session-id-123')
+		equal(req.cmcd.data.d, 4000)
+	})
+
+	it('reproduces 8.1.1 in header mode', () => {
+		const session = createCmcdSession({ sid: 'session-id-123', transmissionMode: CmcdTransmissionMode.HEADERS, keys: ['bl', 'br', 'cid', 'd', 'dl', 'mtp', 'nor', 'ot', 'rtp', 'sf', 'sid', 'st', 'sta', 'tb'] })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ sf: 'd', st: 'v', sta: 'p', bl: 2000, mtp: 15000, rtp: 12000 })
+		const req = reporter.decorate({ url: SEGMENT, headers: { Accept: '*/*' } }, { br: { v: 3000 }, d: 4000, dl: 1000, nor: 'https://cdn.example.com/next-seg.mp4', ot: 'v', tb: { v: 6000 } })
+		deepEqual(req.headers, { Accept: '*/*', ...EX_8_1_1_HEADERS })
+		equal(req.url, SEGMENT)
+	})
+
+	it('reproduces 8.1.2 and 8.1.3', () => {
+		const audio = createCmcdSession({ sid: 'session-id-123', keys: ['bl', 'br', 'cid', 'd', 'mtp', 'ot', 'sid', 'st'] })
+		const reporter = audio.createReporter({ cid: 'content-id-123' })
+		reporter.update({ st: 'v', bl: 2000, mtp: 15000 })
+		equal(queryValue(reporter.decorate({ url: SEGMENT }, { br: 320, d: 2000, ot: 'a' }).url), EX_8_1_2)
+
+		const minimal = createCmcdSession({ sid: 'session-id-123', keys: ['cid', 'sid'] })
+		equal(queryValue(minimal.createReporter({ cid: 'content-id-123' }).decorate({ url: SEGMENT }).url), EX_8_1_3)
+	})
+
+	it('reproduces 8.1.5 with buffered error codes', () => {
+		const session = createCmcdSession({ sid: 'session-id-123', keys: ['cid', 'ec', 'sid', 'sta'] })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ sta: 'p' })
+		reporter.recordError('CODEC_NOT_SUPPORTED')
+		equal(queryValue(reporter.decorate({ url: SEGMENT }).url), EX_8_1_5[0])
+		equal(queryValue(reporter.decorate({ url: SEGMENT }).url), 'cid="content-id-123",sid="session-id-123",sta=p,v=2')
+		reporter.recordError(['DRM_NOT_SUPPORTED', 'PLAYBACK_FAILED'])
+		reporter.update({ sta: 'f' })
+		equal(queryValue(reporter.decorate({ url: SEGMENT }).url), EX_8_1_5[1])
+	})
+
+	it('reproduces 8.1.6 with supplied bs', () => {
+		const session = createCmcdSession({ sid: 'session-id-123', keys: ['bl', 'bs', 'cid', 'ot', 'sid', 'sta'] })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ sta: 'r', bl: 0 })
+		equal(queryValue(reporter.decorate({ url: SEGMENT }, { ot: 'v', bs: true }).url), EX_8_1_6[0])
+		equal(queryValue(reporter.decorate({ url: SEGMENT }, { ot: 'v', bs: true, bl: { v: 0, a: 2000 } }).url), EX_8_1_6[1])
+	})
+
+	it('reproduces 8.1.7 with two reporters in one session', () => {
+		const session = createCmcdSession({ sid: 'session-common-1', keys: ['cid', 'nr', 'ot', 'sid'] })
+		const primary = session.createReporter({ cid: 'movie-123' })
+		const ad = session.createReporter({ cid: 'ad-555' })
+		ad.update({ nr: true })
+		equal(queryValue(primary.decorate({ url: SEGMENT }, { ot: 'v' }).url), EX_8_1_7.primary)
+		equal(queryValue(ad.decorate({ url: SEGMENT }, { ot: 'v' }).url), EX_8_1_7.ad)
+		primary.update({ nr: true })
+		ad.update({ nr: undefined })
+		equal(queryValue(primary.decorate({ url: SEGMENT }, { ot: 'v' }).url), EX_8_1_7.primaryHidden)
+		equal(queryValue(ad.decorate({ url: SEGMENT }, { ot: 'v' }).url), EX_8_1_7.adShown)
+	})
+
+	it('reproduces 8.1.8 with every request-mode key', () => {
+		const session = createCmcdSession({ sid: 'session-id-123' })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ bg: true, bsa: { v: 3 }, bsd: { v: 1200, a: 100 }, bsda: { v: 4150, a: 300 }, cs: 'g48djn236sk2', dfa: 32, ltc: 13500, msd: 1700, pr: 1.1, pt: 632782, rtp: 12000, sf: 'd', st: 'l', sta: 'p', su: true, nr: true })
+		reporter.recordError('2001')
+		const req = reporter.decorate({ url: SEGMENT }, { bl: { v: 2100, a: 1800 }, br: { v: 3000, a: 164 }, bs: true, d: 4000, dl: 1000, lb: { v: 500, a: 32 }, mtp: { v: 15000, a: 6000 }, nor: 'https://cdn.example.com/next-seg.mp4', ot: 'v', pb: { v: 2000, a: 164 }, tb: { v: 6000, a: 350 }, tbl: { v: 2000, a: 2000 }, tpb: { v: 5000, a: 164 } })
+		equal(queryValue(req.url), EX_8_1_8)
+	})
+
+	it('numbers request-mode reports from zero and replaces an existing CMCD parameter', () => {
+		const session = createCmcdSession({ sid: 's', keys: ['sid', 'sn'] })
+		const reporter = session.createReporter()
+		const first = reporter.decorate({ url: 'https://cdn.example.com/a?x=1#frag' })
+		equal(first.url, 'https://cdn.example.com/a?x=1&CMCD=sid%3D%22s%22%2Csn%3D0%2Cv%3D2#frag')
+		const second = reporter.decorate(first)
+		equal(second.url, 'https://cdn.example.com/a?x=1&CMCD=sid%3D%22s%22%2Csn%3D1%2Cv%3D2#frag')
+	})
+
+	it('encodes version 1 request mode', () => {
+		const session = createCmcdSession({ sid: 's', version: 1 })
+		const reporter = session.createReporter({ cid: 'c' })
+		reporter.update({ sf: 'd', st: 'v', bl: { v: 2000, a: 1000 }, mtp: 15000 })
+		const req = reporter.decorate({ url: SEGMENT }, { br: { v: 3000 }, d: 4000, ot: 'v', nor: { url: 'https://cdn.example.com/next seg.mp4', range: '0-99' } })
+		equal(queryValue(req.url), 'bl=2000,br=3000,cid="c",d=4000,mtp=15000,nor="next%20seg.mp4",nrr="0-99",ot=v,sf=d,st=v')
+	})
+})
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.request.test.ts`
+Expected: FAIL, `createCmcdSession` is not exported.
+
+- [ ] **Step 4: Write the key table**
+
+```ts
+// libs/cmcd/src/CmcdKeySpec.ts
+/**
+ * One row of the key table. `requiredOn` is `'always'` or an event type. `v1` says what version 1 does with the key:
+ * absent drops it, scalar collapses an object-type list to one number, string keeps the first `nor` entry.
+ */
+export type CmcdKeySpec = {
+	readonly type: 'boolean' | 'integer' | 'decimal' | 'string' | 'token' | 'string-list' | 'ot-list' | 'nor' | 'custom'
+	readonly modes: 'both' | 'event'
+	readonly round?: number
+	readonly ot?: readonly string[]
+	readonly supersededBy?: string
+	readonly onlyOn?: string
+	readonly requiredOn?: string
+	readonly omitDefault?: boolean | number
+	readonly max?: number
+	readonly v1?: 'absent' | 'scalar' | 'string'
+	readonly tokens?: readonly string[]
+}
+```
+
+```ts
+// libs/cmcd/src/CMCD_KEY_SPECS.ts
+import type { CmcdKeySpec } from './CmcdKeySpec.ts'
+
+const EVENTS = ['bc', 'ps', 'pr', 'e', 't', 'c', 'b', 'm', 'um', 'pe', 'pc', 'rr', 'as', 'ae', 'abs', 'abe', 'sk', 'ce', 'h']
+const MEDIA = ['a', 'v', 'av', 'tt', 'c', 'o']
+
+/** One row per reserved key of CTA-5004-B Table 1, plus the version 1 `nrr` key. */
+export const CMCD_KEY_SPECS: Readonly<Record<string, CmcdKeySpec>> = {
+	ab: { type: 'ot-list', modes: 'both', round: 1, supersededBy: 'br', v1: 'absent' },
+	bg: { type: 'boolean', modes: 'both', requiredOn: 'b', omitDefault: false, v1: 'absent' },
+	bl: { type: 'ot-list', modes: 'both', round: 100, v1: 'scalar' },
+	br: { type: 'ot-list', modes: 'both', round: 1, requiredOn: 'bc', v1: 'scalar' },
+	bs: { type: 'boolean', modes: 'both', omitDefault: false },
+	bsa: { type: 'ot-list', modes: 'both', round: 1, v1: 'absent' },
+	bsd: { type: 'ot-list', modes: 'both', round: 1, v1: 'absent' },
+	bsda: { type: 'ot-list', modes: 'both', round: 1, v1: 'absent' },
+	cen: { type: 'string', modes: 'event', onlyOn: 'ce', requiredOn: 'ce', max: 64 },
+	cid: { type: 'string', modes: 'both', requiredOn: 'c', max: 128 },
+	cmsdd: { type: 'string', modes: 'event', onlyOn: 'rr' },
+	cmsds: { type: 'string', modes: 'event', onlyOn: 'rr' },
+	cs: { type: 'string', modes: 'both', v1: 'absent' },
+	d: { type: 'integer', modes: 'both', round: 1, ot: MEDIA },
+	dfa: { type: 'integer', modes: 'both', round: 1, v1: 'absent' },
+	dl: { type: 'integer', modes: 'both', round: 100 },
+	e: { type: 'token', modes: 'event', requiredOn: 'always', tokens: EVENTS },
+	ec: { type: 'string-list', modes: 'both', requiredOn: 'e', v1: 'absent' },
+	h: { type: 'string', modes: 'event', requiredOn: 'h', max: 128 },
+	lab: { type: 'ot-list', modes: 'both', round: 1, supersededBy: 'lb', v1: 'absent' },
+	lb: { type: 'ot-list', modes: 'both', round: 1, v1: 'absent' },
+	ltc: { type: 'integer', modes: 'both', round: 1, v1: 'absent' },
+	msd: { type: 'integer', modes: 'both', round: 1, v1: 'absent' },
+	mtp: { type: 'ot-list', modes: 'both', round: 100, v1: 'scalar' },
+	nor: { type: 'nor', modes: 'both', v1: 'string' },
+	nr: { type: 'boolean', modes: 'both', omitDefault: false, v1: 'absent' },
+	nrr: { type: 'string', modes: 'both' },
+	ot: { type: 'token', modes: 'both', tokens: ['m', 'a', 'v', 'av', 'i', 'c', 'tt', 'k', 'o'] },
+	pb: { type: 'ot-list', modes: 'both', round: 1, v1: 'absent' },
+	pr: { type: 'decimal', modes: 'both', requiredOn: 'pr', omitDefault: 1 },
+	pt: { type: 'integer', modes: 'both', round: 1, v1: 'absent' },
+	rc: { type: 'integer', modes: 'event', round: 1, onlyOn: 'rr' },
+	rtp: { type: 'integer', modes: 'both', round: 100 },
+	sf: { type: 'token', modes: 'both', tokens: ['d', 'h', 'e', 's', 'o'] },
+	sid: { type: 'string', modes: 'both', max: 64 },
+	smrt: { type: 'string', modes: 'event', onlyOn: 'rr' },
+	sn: { type: 'integer', modes: 'both', round: 1, v1: 'absent' },
+	st: { type: 'token', modes: 'both', tokens: ['v', 'l', 'll'] },
+	sta: { type: 'token', modes: 'both', requiredOn: 'ps', tokens: ['s', 'p', 'k', 'r', 'a', 'w', 'e', 'f', 'q', 'd'], v1: 'absent' },
+	su: { type: 'boolean', modes: 'both', omitDefault: false },
+	tab: { type: 'ot-list', modes: 'both', round: 1, supersededBy: 'tb', v1: 'absent' },
+	tb: { type: 'ot-list', modes: 'both', round: 1, v1: 'scalar' },
+	tbl: { type: 'ot-list', modes: 'both', round: 100, v1: 'absent' },
+	tpb: { type: 'ot-list', modes: 'both', round: 1, ot: ['a', 'v', 'av', 'c'], v1: 'absent' },
+	ts: { type: 'integer', modes: 'event', round: 1, requiredOn: 'always' },
+	ttfb: { type: 'integer', modes: 'event', round: 1, onlyOn: 'rr' },
+	ttfbb: { type: 'integer', modes: 'event', round: 1, onlyOn: 'rr' },
+	ttlb: { type: 'integer', modes: 'event', round: 1, onlyOn: 'rr' },
+	url: { type: 'string', modes: 'event', onlyOn: 'rr', requiredOn: 'rr' },
+	v: { type: 'integer', modes: 'both', round: 1, requiredOn: 'always', omitDefault: 1, v1: 'absent' },
+}
+```
+
+```ts
+// libs/cmcd/src/getKeySpec.ts
+import { CMCD_KEY_SPECS } from './CMCD_KEY_SPECS.ts'
+import type { CmcdKeySpec } from './CmcdKeySpec.ts'
+
+const CUSTOM_KEY = /^[a-z0-9.]+-[a-z0-9.-]+$/
+const CUSTOM_SPEC: CmcdKeySpec = { type: 'custom', modes: 'both', max: 64 }
+
+/** The spec of a reserved key, the custom spec for a hyphenated lowercase key, else `undefined`. */
+export function getKeySpec(key: string): CmcdKeySpec | undefined {
+	return CMCD_KEY_SPECS[key] ?? (CUSTOM_KEY.test(key) ? CUSTOM_SPEC : undefined)
+}
+```
+
+- [ ] **Step 5: Write the value normalization**
+
+```ts
+// libs/cmcd/src/PrepareContext.ts
+import type { CmcdReportingMode } from './CmcdReportingMode.ts'
+import type { CmcdVersion } from './CmcdVersion.ts'
+
+/** What preparation needs to know about the report it prepares. */
+export type PrepareContext = {
+	readonly version: CmcdVersion
+	readonly mode: CmcdReportingMode
+	readonly event: string | undefined
+	readonly keys: ReadonlySet<string> | undefined
+	readonly baseUrl: string | undefined
+}
+```
+
+```ts
+// libs/cmcd/src/normalizeValue.ts
+import { SfItem, SfToken, symbolToStr } from '@svta/cml-structured-field-values'
+import type { CmcdKeySpec } from './CmcdKeySpec.ts'
+import type { PrepareContext } from './PrepareContext.ts'
+
+type OtItem = number | SfItem<number, Record<string, boolean>>
+
+function roundTo(value: number, step: number): number {
+	return Math.round(value / step) * step
+}
+
+/** The text of a token given as a string, a symbol, an `SfToken`, or an `SfItem` of one of those. */
+export function toTokenText(value: unknown): string | undefined {
+	if (value instanceof SfItem) {
+		return toTokenText(value.value)
+	}
+	if (typeof value === 'string') {
+		return value
+	}
+	if (typeof value === 'symbol' || value instanceof SfToken) {
+		return symbolToStr(value)
+	}
+	return undefined
+}
+
+function toOtItems(value: unknown, step: number): OtItem[] {
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? [roundTo(value, step)] : []
+	}
+	if (value instanceof SfItem) {
+		return typeof value.value === 'number' && Number.isFinite(value.value) ? [new SfItem(roundTo(value.value, step), value.params)] : []
+	}
+	if (Array.isArray(value)) {
+		return value.flatMap(item => toOtItems(item, step))
+	}
+	if (value && typeof value === 'object') {
+		const items: OtItem[] = []
+		for (const [ot, amount] of Object.entries(value)) {
+			if (typeof amount === 'number' && Number.isFinite(amount)) {
+				items.push(new SfItem(roundTo(amount, step), { [ot]: true }))
+			}
+		}
+		return items
+	}
+	return []
+}
+
+function collapse(items: OtItem[], reportOt: string | undefined): number {
+	const match = reportOt === undefined ? undefined : items.find(item => item instanceof SfItem && item.params?.[reportOt] === true)
+	const first = match ?? items[0]
+	return first instanceof SfItem ? first.value : first
+}
+
+/**
+ * Turns one plain value into its structured-field form, or `undefined` when the value is empty or invalid for the key.
+ * `reportOt` is the report's object type, used to collapse a list in version 1.
+ */
+export function normalizeValue(value: unknown, spec: CmcdKeySpec, context: PrepareContext, reportOt: string | undefined): unknown {
+	switch (spec.type) {
+		case 'boolean':
+			return typeof value === 'boolean' ? value : undefined
+		case 'integer':
+			return typeof value === 'number' && Number.isFinite(value) ? roundTo(value, spec.round ?? 1) : undefined
+		case 'decimal':
+			return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+		case 'string':
+			return typeof value === 'string' && value !== '' && (spec.max === undefined || value.length <= spec.max) ? value : undefined
+		case 'token': {
+			const text = toTokenText(value)
+			return text !== undefined && text !== '' && (spec.tokens === undefined || spec.tokens.includes(text)) ? new SfToken(text) : undefined
+		}
+		case 'string-list': {
+			const list = (Array.isArray(value) ? value : [value]).filter(item => typeof item === 'string' && item !== '')
+			return list.length > 0 ? list : undefined
+		}
+		case 'ot-list': {
+			const items = toOtItems(value, spec.round ?? 1)
+			if (items.length === 0) {
+				return undefined
+			}
+			return context.version === 1 && spec.v1 === 'scalar' ? collapse(items, reportOt) : items
+		}
+		case 'custom': {
+			if (typeof value === 'string') {
+				return value !== '' && value.length <= (spec.max ?? Infinity) ? value : undefined
+			}
+			if (typeof value === 'number') {
+				return Number.isFinite(value) ? value : undefined
+			}
+			if (Array.isArray(value)) {
+				return value.length > 0 ? [...value] : undefined
+			}
+			return typeof value === 'boolean' || typeof value === 'symbol' || value instanceof SfToken || value instanceof SfItem ? value : undefined
+		}
+		default:
+			return undefined
+	}
+}
+```
+
+```ts
+// libs/cmcd/src/formatNor.ts
+import { SfItem } from '@svta/cml-structured-field-values'
+import { getBaseUrl, urlToRelativePath } from '@svta/cml-utils'
+import type { CmcdNextObject } from './CmcdNextObject.ts'
+import type { PrepareContext } from './PrepareContext.ts'
+
+type Entry = { readonly path: string; readonly range: string | undefined }
+
+function toEntries(value: unknown, baseUrl: string | undefined): Entry[] {
+	const items = Array.isArray(value) ? value : [value]
+	const base = baseUrl === undefined ? undefined : getBaseUrl(baseUrl)
+	const entries: Entry[] = []
+	for (const item of items as CmcdNextObject[]) {
+		const url = typeof item === 'string' ? item : item?.url
+		if (typeof url !== 'string' || url === '') {
+			continue
+		}
+		const range = typeof item === 'string' ? undefined : item.range
+		entries.push({ path: base === undefined ? url : urlToRelativePath(url, base), range: range === '' ? undefined : range })
+	}
+	return entries
+}
+
+/** The wire form of `nor`. Version 2 is a list, version 1 is one percent-encoded path plus `nrr`. */
+export function formatNor(value: unknown, context: PrepareContext): { nor?: unknown; nrr?: string } {
+	const entries = toEntries(value, context.baseUrl)
+	if (entries.length === 0) {
+		return {}
+	}
+	if (context.version === 1) {
+		const [first] = entries
+		return first.range === undefined ? { nor: encodeURIComponent(first.path) } : { nor: encodeURIComponent(first.path), nrr: first.range }
+	}
+	return { nor: entries.map(entry => entry.range === undefined ? entry.path : new SfItem(entry.path, { r: entry.range })) }
+}
+```
+
+`getBaseUrl` throws on a relative base. `decorate()` always passes the request URL, and `urlToRelativePath` returns a relative `nor` value unchanged, so a relative segment URL only breaks the `nor` relativization. Guard the `getBaseUrl` call with a `try` that falls back to `undefined` when the base is not absolute:
+
+```ts
+function safeBase(baseUrl: string | undefined): string | undefined {
+	if (baseUrl === undefined) {
+		return undefined
+	}
+	try {
+		return getBaseUrl(baseUrl)
+	}
+	catch {
+		return undefined
+	}
+}
+```
+
+Use `safeBase(baseUrl)` in place of the `getBaseUrl(baseUrl)` call in `toEntries`.
+
+```ts
+// libs/cmcd/src/normalizeReport.ts
+import { formatNor } from './formatNor.ts'
+import { getKeySpec } from './getKeySpec.ts'
+import { normalizeValue, toTokenText } from './normalizeValue.ts'
+import type { PrepareContext } from './PrepareContext.ts'
+import { CMCD_EVENT_MODE } from './CmcdReportingMode.ts'
+
+/** Plain report values to structured-field values, in sorted key order. Keys of the other mode and version 1 drops are removed. */
+export function normalizeReport(report: Record<string, unknown>, context: PrepareContext): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+	const reportOt = toTokenText(report['ot'])
+	for (const key of Object.keys(report).sort()) {
+		const spec = getKeySpec(key)
+		const value = report[key]
+		if (!spec || value === undefined || value === null) {
+			continue
+		}
+		if (spec.modes === 'event' && context.mode !== CMCD_EVENT_MODE) {
+			continue
+		}
+		if (context.version === 1 && spec.v1 === 'absent') {
+			continue
+		}
+		if (spec.type === 'nor') {
+			const { nor, nrr } = formatNor(value, context)
+			if (nor !== undefined) {
+				out['nor'] = nor
+			}
+			if (nrr !== undefined) {
+				out['nrr'] = nrr
+			}
+			continue
+		}
+		const normalized = normalizeValue(value, spec, context, reportOt)
+		if (normalized !== undefined) {
+			out[key] = normalized
+		}
+	}
+	return out
+}
+```
+
+```ts
+// libs/cmcd/src/filterReport.ts
+import { getKeySpec } from './getKeySpec.ts'
+import type { CmcdKeySpec } from './CmcdKeySpec.ts'
+import { toTokenText } from './normalizeValue.ts'
+import type { PrepareContext } from './PrepareContext.ts'
+
+/** Whether the spec rules make `key` required on the report's event. */
+export function isRequired(spec: CmcdKeySpec, event: string | undefined): boolean {
+	return spec.requiredOn === 'always' || (spec.requiredOn !== undefined && spec.requiredOn === event)
+}
+
+function isPresent(value: unknown): boolean {
+	return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== null
+}
+
+/** Applies the key allowlist and the spec rules to a normalized report. Keys stay in sorted order. */
+export function filterReport(normalized: Record<string, unknown>, context: PrepareContext): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+	const reportOt = toTokenText(normalized['ot'])
+	for (const key of Object.keys(normalized)) {
+		const spec = getKeySpec(key)
+		const value = normalized[key]
+		if (!spec) {
+			continue
+		}
+		if (spec.onlyOn !== undefined && spec.onlyOn !== context.event) {
+			continue
+		}
+		if (spec.ot !== undefined && context.version === 2 && reportOt !== undefined && !spec.ot.includes(reportOt)) {
+			continue
+		}
+		if (spec.supersededBy !== undefined && isPresent(normalized[spec.supersededBy])) {
+			continue
+		}
+		const required = isRequired(spec, context.event)
+		if (context.keys !== undefined && !context.keys.has(key) && !required) {
+			continue
+		}
+		if (spec.omitDefault !== undefined && value === spec.omitDefault && !required) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+```
+
+- [ ] **Step 6: Write the configuration normalization and the state types**
+
+```ts
+// libs/cmcd/src/NormalizedEventTarget.ts
+import type { CmcdEventTransform } from './CmcdEventTransform.ts'
+
+/** An event target with every default applied. `interval` is in milliseconds. */
+export type NormalizedEventTarget = {
+	readonly url: string
+	readonly events: ReadonlySet<string>
+	readonly keys: ReadonlySet<string> | undefined
+	readonly interval: number
+	readonly batchSize: number
+	readonly maxQueueSize: number
+	readonly headers: Readonly<Record<string, string>> | undefined
+	readonly transform: CmcdEventTransform | undefined
+}
+```
+
+```ts
+// libs/cmcd/src/NormalizedSessionConfig.ts
+import type { CmcdHeaderMap } from './CmcdHeaderMap.ts'
+import type { CmcdRequestTransform } from './CmcdRequestTransform.ts'
+import type { CmcdRequester } from './CmcdRequester.ts'
+import type { CmcdTransmissionMode } from './CmcdTransmissionMode.ts'
+import type { CmcdVersion } from './CmcdVersion.ts'
+import type { NormalizedEventTarget } from './NormalizedEventTarget.ts'
+
+/** The session configuration with every default applied. The request-mode members change through `configure()`. */
+export type NormalizedSessionConfig = {
+	version: CmcdVersion
+	transmissionMode: CmcdTransmissionMode
+	keys: ReadonlySet<string> | undefined
+	headerMap: Partial<CmcdHeaderMap> | undefined
+	readonly transform: CmcdRequestTransform | undefined
+	readonly eventTargets: readonly NormalizedEventTarget[]
+	readonly requester: CmcdRequester
+	readonly derive: { readonly bg: boolean; readonly dl: boolean; readonly su: boolean }
+	readonly onError: ((error: unknown) => void) | undefined
+}
+```
+
+```ts
+// libs/cmcd/src/normalizeSessionConfig.ts
+import { CMCD_DEFAULT_TIME_INTERVAL } from './CMCD_DEFAULT_TIME_INTERVAL.ts'
+import { CMCD_V2 } from './CMCD_V2.ts'
+import type { CmcdEventTargetConfig } from './CmcdEventTargetConfig.ts'
+import type { CmcdSessionConfig } from './CmcdSessionConfig.ts'
+import { CMCD_QUERY } from './CmcdTransmissionMode.ts'
+import { defaultRequester } from './defaultRequester.ts'
+import type { NormalizedEventTarget } from './NormalizedEventTarget.ts'
+import type { NormalizedSessionConfig } from './NormalizedSessionConfig.ts'
+
+const DEFAULT_EVENTS = ['ps', 'e', 't', 'rr']
+
+function normalizeTarget(target: CmcdEventTargetConfig): NormalizedEventTarget {
+	return {
+		url: target.url,
+		events: new Set(target.events ?? DEFAULT_EVENTS),
+		keys: target.keys === undefined ? undefined : new Set(target.keys),
+		interval: (target.interval ?? CMCD_DEFAULT_TIME_INTERVAL) * 1000,
+		batchSize: target.batchSize ?? 1,
+		maxQueueSize: target.maxQueueSize ?? 500,
+		headers: target.headers === undefined ? undefined : { ...target.headers },
+		transform: target.transform,
+	}
+}
+
+/** Applies the defaults. Task 3 adds the checks. */
+export function normalizeSessionConfig(config: CmcdSessionConfig): NormalizedSessionConfig {
+	return {
+		version: config.version ?? CMCD_V2,
+		transmissionMode: config.transmissionMode ?? CMCD_QUERY,
+		keys: config.keys === undefined ? undefined : new Set(config.keys),
+		headerMap: config.headerMap,
+		transform: config.transform,
+		eventTargets: (config.eventTargets ?? []).map(normalizeTarget),
+		requester: config.requester ?? defaultRequester,
+		derive: { bg: config.derive?.bg ?? true, dl: config.derive?.dl ?? true, su: config.derive?.su ?? true },
+		onError: config.onError,
+	}
+}
+```
+
+Check that `CMCD_DEFAULT_TIME_INTERVAL` is `30` in seconds. If the constant holds milliseconds, drop the `* 1000`.
+
+```ts
+// libs/cmcd/src/defaultRequester.ts
+import type { HttpRequest } from '@svta/cml-utils'
+
+/** POSTs through `fetch` with `keepalive` for bodies under 64 KB, so a flush on `pagehide` completes. */
+export function defaultRequester(request: HttpRequest): Promise<{ status: number }> {
+	const body = typeof request.body === 'string' ? request.body : ''
+	return fetch(request.url, { method: request.method, headers: request.headers, body, keepalive: body.length < 65536 })
+}
+```
+
+```ts
+// libs/cmcd/src/TargetEntry.ts
+/** The per-reporter state of one target: the `bs` flag and the `ec` buffer. */
+export type TargetEntry = { bs: boolean; readonly ec: string[] }
+```
+
+```ts
+// libs/cmcd/src/TargetState.ts
+import type { CmcdReportingMode } from './CmcdReportingMode.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { TargetEntry } from './TargetEntry.ts'
+
+/** One destination inside one `sid` state. `index` is the position in the event target list, `-1` for the request target. */
+export type TargetState = {
+	readonly kind: CmcdReportingMode
+	readonly index: number
+	sn: number
+	msdSent: boolean
+	readonly bsdCursors: Map<string, number>
+	readonly entries: Map<ReporterState, TargetEntry>
+	readonly queue: string[]
+	attempt: number
+	retryTimer: ReturnType<typeof setTimeout> | undefined
+	sending: boolean
+	drainRequested: boolean
+	gone: boolean
+}
+```
+
+```ts
+// libs/cmcd/src/SidState.ts
+import type { CmcdMetric } from './CmcdMetric.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { TargetState } from './TargetState.ts'
+
+/** Everything that resets with a `sid`. `pending` holds the `bsd` samples per cause, automatic spans under the empty key. */
+export type SidState = {
+	readonly sid: string
+	ended: boolean
+	readonly requestTarget: TargetState
+	readonly eventTargets: readonly TargetState[]
+	bgReported: boolean | undefined
+	msd: number | undefined
+	msdSupplied: boolean
+	msdStart: number | undefined
+	bsa: number
+	bsda: number
+	bsaSupplied: CmcdMetric | undefined
+	bsdaSupplied: CmcdMetric | undefined
+	bsdSupplied: boolean
+	readonly pending: Map<string, number[]>
+	readonly stores: Map<ReporterState, Record<string, unknown>>
+}
+```
+
+```ts
+// libs/cmcd/src/ReporterState.ts
+import type { SessionState } from './SessionState.ts'
+
+/** The state of one reporter. `reported` holds the last reported value of each tracked field. */
+export type ReporterState = {
+	readonly session: SessionState
+	readonly store: Record<string, unknown>
+	readonly reported: { sta?: unknown; pr?: unknown; cid?: unknown; br?: unknown }
+	host: string | undefined
+	hSupplied: boolean
+	su: boolean | undefined
+	suSupplied: boolean
+	dlSupplied: boolean
+	spanOpenedAt: number | undefined
+	disposed: boolean
+}
+```
+
+```ts
+// libs/cmcd/src/SessionState.ts
+import type { NormalizedSessionConfig } from './NormalizedSessionConfig.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SidState } from './SidState.ts'
+
+/** The state of one session. `reporters` is in creation order. */
+export type SessionState = {
+	config: NormalizedSessionConfig
+	readonly reporters: Set<ReporterState>
+	current: SidState
+	readonly timers: ReturnType<typeof setInterval>[]
+	bg: boolean | undefined
+	bgSupplied: boolean
+	stopVisibility: (() => void) | undefined
+	disposed: boolean
+}
+```
+
+```ts
+// libs/cmcd/src/RequestOrigin.ts
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SidState } from './SidState.ts'
+
+/** What a decorated request remembers for its response. `data` is a copy. */
+export type RequestOrigin = {
+	readonly reporter: ReporterState
+	readonly sidState: SidState
+	readonly cid: string | undefined
+	readonly data: CmcdPlaybackData | undefined
+	readonly startedAt: number
+}
+```
+
+```ts
+// libs/cmcd/src/CMCD_REQUEST_ORIGINS.ts
+import type { RequestOrigin } from './RequestOrigin.ts'
+
+/** Keyed by the `cmcd` record on a decorated request. An entry lives as long as the record. */
+export const CMCD_REQUEST_ORIGINS: WeakMap<object, RequestOrigin> = /* @__PURE__ */ new WeakMap()
+```
+
+```ts
+// libs/cmcd/src/createTargetState.ts
+import type { CmcdReportingMode } from './CmcdReportingMode.ts'
+import type { TargetState } from './TargetState.ts'
+
+export function createTargetState(kind: CmcdReportingMode, index: number): TargetState {
+	return {
+		kind,
+		index,
+		sn: 0,
+		msdSent: false,
+		bsdCursors: new Map(),
+		entries: new Map(),
+		queue: [],
+		attempt: 0,
+		retryTimer: undefined,
+		sending: false,
+		drainRequested: false,
+		gone: false,
+	}
+}
+```
+
+```ts
+// libs/cmcd/src/createSidState.ts
+import { CMCD_EVENT_MODE, CMCD_REQUEST_MODE } from './CmcdReportingMode.ts'
+import { createTargetState } from './createTargetState.ts'
+import type { NormalizedSessionConfig } from './NormalizedSessionConfig.ts'
+import type { SidState } from './SidState.ts'
+
+export function createSidState(sid: string, config: NormalizedSessionConfig): SidState {
+	return {
+		sid,
+		ended: false,
+		requestTarget: createTargetState(CMCD_REQUEST_MODE, -1),
+		eventTargets: config.eventTargets.map((_, index) => createTargetState(CMCD_EVENT_MODE, index)),
+		bgReported: undefined,
+		msd: undefined,
+		msdSupplied: false,
+		msdStart: undefined,
+		bsa: 0,
+		bsda: 0,
+		bsaSupplied: undefined,
+		bsdaSupplied: undefined,
+		bsdSupplied: false,
+		pending: new Map(),
+		stores: new Map(),
+	}
+}
+```
+
+```ts
+// libs/cmcd/src/getTargetEntry.ts
+import type { ReporterState } from './ReporterState.ts'
+import type { TargetEntry } from './TargetEntry.ts'
+import type { TargetState } from './TargetState.ts'
+
+/** The target's entry for a reporter, created on first use. */
+export function getTargetEntry(target: TargetState, reporter: ReporterState): TargetEntry {
+	let entry = target.entries.get(reporter)
+	if (!entry) {
+		entry = { bs: false, ec: [] }
+		target.entries.set(reporter, entry)
+	}
+	return entry
+}
+```
+
+- [ ] **Step 7: Write the report path**
+
+```ts
+// libs/cmcd/src/assembleReport.ts
+import { SfItem } from '@svta/cml-structured-field-values'
+import { CMCD_V2 } from './CMCD_V2.ts'
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+import { CMCD_EVENT_MODE } from './CmcdReportingMode.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SessionState } from './SessionState.ts'
+import type { SidState } from './SidState.ts'
+import type { TargetState } from './TargetState.ts'
+
+/** The plain report before preparation, and the `bsd` causes it carries, for the commit step. */
+export type AssembledReport = {
+	readonly report: Record<string, unknown>
+	readonly bsdCauses: readonly string[]
+}
+
+function pickLevel(bl: unknown, ot: unknown): number | undefined {
+	if (typeof bl === 'number') {
+		return bl
+	}
+	if (bl && typeof bl === 'object' && !Array.isArray(bl)) {
+		const levels = bl as Record<string, unknown>
+		const own = typeof ot === 'string' ? levels[ot] : undefined
+		const first = Object.values(levels).find(value => typeof value === 'number')
+		return typeof own === 'number' ? own : typeof first === 'number' ? first : undefined
+	}
+	return undefined
+}
+
+/** `dl` is `bl` divided by `pr`. The key table rounds it to 100 milliseconds. */
+export function deriveDl(bl: unknown, pr: unknown, ot: unknown): number | undefined {
+	const rate = typeof pr === 'number' ? pr : 1
+	const level = pickLevel(bl, ot)
+	return level !== undefined && Number.isFinite(level) && rate > 0 ? level / rate : undefined
+}
+
+/**
+ * Merges, in this order and later wins: the store, the session data, the per-call data, the target's entry for the reporter,
+ * the derived defaults, and the event stamp. `reporter` is `undefined` for a session-only interval line.
+ */
+export function assembleReport(session: SessionState, sidState: SidState, target: TargetState, reporter: ReporterState | undefined, event: string | undefined, data: CmcdPlaybackData | undefined, ts: number): AssembledReport {
+	const config = session.config
+	const report: Record<string, unknown> = reporter ? { ...reporter.store } : {}
+	const bsdCauses: string[] = []
+
+	report['sid'] = sidState.sid
+	if (target.kind === CMCD_EVENT_MODE || config.version === CMCD_V2) {
+		report['v'] = CMCD_V2
+	}
+	if (session.bg) {
+		report['bg'] = true
+	}
+	if (sidState.msd !== undefined && !target.msdSent) {
+		report['msd'] = sidState.msd
+	}
+	const bsa = sidState.bsaSupplied ?? (sidState.bsa > 0 ? sidState.bsa : undefined)
+	if (bsa !== undefined) {
+		report['bsa'] = bsa
+	}
+	const bsda = sidState.bsdaSupplied ?? (sidState.bsda > 0 ? sidState.bsda : undefined)
+	if (bsda !== undefined) {
+		report['bsda'] = bsda
+	}
+	const bsd: (number | SfItem<number, Record<string, boolean>>)[] = []
+	for (const [cause, samples] of sidState.pending) {
+		const cursor = target.bsdCursors.get(cause) ?? 0
+		if (cursor < samples.length) {
+			bsd.push(cause === '' ? samples[cursor] : new SfItem(samples[cursor], { [cause]: true }))
+			bsdCauses.push(cause)
+		}
+	}
+	if (bsd.length > 0) {
+		report['bsd'] = bsd
+	}
+	if (target.kind === CMCD_EVENT_MODE && reporter?.host !== undefined && report['h'] === undefined) {
+		report['h'] = reporter.host
+	}
+
+	if (data) {
+		for (const [key, value] of Object.entries(data)) {
+			if (value !== undefined) {
+				report[key] = value
+			}
+		}
+	}
+
+	if (reporter) {
+		const entry = target.entries.get(reporter)
+		if (entry?.bs && report['bs'] === undefined) {
+			report['bs'] = true
+		}
+		if (entry && entry.ec.length > 0 && report['ec'] === undefined) {
+			report['ec'] = [...entry.ec]
+		}
+		if (config.derive.su && !reporter.suSupplied && report['su'] === undefined && reporter.su !== undefined) {
+			report['su'] = reporter.su
+		}
+		if (config.derive.dl && !reporter.dlSupplied && report['dl'] === undefined) {
+			const dl = deriveDl(report['bl'], report['pr'], report['ot'])
+			if (dl !== undefined) {
+				report['dl'] = dl
+			}
+		}
+	}
+
+	if (event !== undefined) {
+		report['e'] = event
+		report['ts'] = ts
+	}
+	return { report, bsdCauses }
+}
+```
+
+```ts
+// libs/cmcd/src/pruneSpans.ts
+import { CMCD_V2 } from './CMCD_V2.ts'
+import { CMCD_REQUEST_MODE } from './CmcdReportingMode.ts'
+import type { SessionState } from './SessionState.ts'
+import type { SidState } from './SidState.ts'
+import type { TargetState } from './TargetState.ts'
+
+/** The most pending samples kept per cause. Older samples are dropped past the cap. */
+export const BSD_PENDING_CAP = 100
+
+/** Whether a target can ever carry `bsd`: not gone, `bsd` in its keys, and version 2 for the request target. */
+export function isBsdEligible(session: SessionState, target: TargetState): boolean {
+	if (target.gone) {
+		return false
+	}
+	if (target.kind === CMCD_REQUEST_MODE) {
+		return session.config.version === CMCD_V2 && (session.config.keys === undefined || session.config.keys.has('bsd'))
+	}
+	const keys = session.config.eventTargets[target.index]?.keys
+	return keys === undefined || keys.has('bsd')
+}
+
+/** Drops from every pending list the prefix that every eligible target has consumed, and moves the cursors back. */
+export function pruneSpans(session: SessionState, sidState: SidState): void {
+	const eligible = [sidState.requestTarget, ...sidState.eventTargets].filter(target => isBsdEligible(session, target))
+	for (const [cause, samples] of sidState.pending) {
+		const consumed = eligible.length === 0 ? samples.length : Math.min(...eligible.map(target => target.bsdCursors.get(cause) ?? 0))
+		if (consumed === 0) {
+			continue
+		}
+		samples.splice(0, consumed)
+		for (const target of [sidState.requestTarget, ...sidState.eventTargets]) {
+			target.bsdCursors.set(cause, Math.max(0, (target.bsdCursors.get(cause) ?? 0) - consumed))
+		}
+		if (samples.length === 0) {
+			sidState.pending.delete(cause)
+		}
+	}
+}
+
+/** Appends one `bsd` sample when a target can carry it, and enforces the cap. */
+export function addSpan(session: SessionState, sidState: SidState, cause: string, duration: number): void {
+	const targets = [sidState.requestTarget, ...sidState.eventTargets]
+	if (!targets.some(target => isBsdEligible(session, target))) {
+		return
+	}
+	let samples = sidState.pending.get(cause)
+	if (!samples) {
+		samples = []
+		sidState.pending.set(cause, samples)
+	}
+	samples.push(duration)
+	if (samples.length > BSD_PENDING_CAP) {
+		samples.shift()
+		for (const target of targets) {
+			target.bsdCursors.set(cause, Math.max(0, (target.bsdCursors.get(cause) ?? 0) - 1))
+		}
+	}
+}
+```
+
+`pruneSpans.ts` has three exports. That is the one exception to the one-export rule in this plan, because the three functions share the eligibility rule and the cursor arithmetic.
+
+```ts
+// libs/cmcd/src/emitReport.ts
+import { CMCD_V2 } from './CMCD_V2.ts'
+import type { Cmcd } from './Cmcd.ts'
+import type { CmcdEventTransform } from './CmcdEventTransform.ts'
+import { CMCD_EVENT_MODE } from './CmcdReportingMode.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import type { AssembledReport } from './assembleReport.ts'
+import { encodePreparedCmcd } from './encodePreparedCmcd.ts'
+import { filterReport, isRequired } from './filterReport.ts'
+import { getKeySpec } from './getKeySpec.ts'
+import { normalizeReport } from './normalizeReport.ts'
+import type { PrepareContext } from './PrepareContext.ts'
+import { pruneSpans } from './pruneSpans.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SessionState } from './SessionState.ts'
+import type { SidState } from './SidState.ts'
+import type { TargetState } from './TargetState.ts'
+
+/** The prepared report and its encoded line. */
+export type EmittedReport = {
+	readonly prepared: Record<string, unknown>
+	readonly line: string
+}
+
+/**
+ * Normalizes, transforms, filters, encodes, and commits one report for one target.
+ * Returns `undefined` when the transform cancels. An encoder error propagates and commits nothing.
+ */
+export function emitReport(session: SessionState, sidState: SidState, target: TargetState, reporter: ReporterState | undefined, assembled: AssembledReport, event: string | undefined, request: Readonly<CmcdRequestLike> | undefined): EmittedReport | undefined {
+	const config = session.config
+	const targetConfig = target.kind === CMCD_EVENT_MODE ? config.eventTargets[target.index] : undefined
+	const context: PrepareContext = {
+		version: targetConfig ? CMCD_V2 : config.version,
+		mode: target.kind,
+		event,
+		keys: targetConfig ? targetConfig.keys : config.keys,
+		baseUrl: request?.url,
+	}
+	let normalized = normalizeReport(assembled.report, context)
+	const transform = targetConfig ? targetConfig.transform : config.transform
+	if (transform) {
+		const before = normalized
+		const result = (transform as CmcdEventTransform)(before as Cmcd, request)
+		if (result === null) {
+			return undefined
+		}
+		normalized = normalizeReport(result as Record<string, unknown>, context)
+		for (const key of Object.keys(before)) {
+			const spec = getKeySpec(key)
+			if (spec && isRequired(spec, event) && normalized[key] === undefined) {
+				normalized[key] = before[key]
+			}
+		}
+		normalized['sid'] = before['sid']
+		if (event !== undefined) {
+			normalized['e'] = before['e']
+			normalized['ts'] = before['ts']
+		}
+	}
+	normalized['sn'] = target.sn
+	const prepared = filterReport(normalized, context)
+	const line = encodePreparedCmcd(prepared as Cmcd)
+
+	target.sn += 1
+	if (prepared['msd'] !== undefined) {
+		target.msdSent = true
+	}
+	if (reporter) {
+		const entry = target.entries.get(reporter)
+		if (entry) {
+			entry.ec.length = 0
+			if (reporter.store['sta'] !== 'r') {
+				entry.bs = false
+			}
+		}
+	}
+	if (prepared['bsd'] !== undefined) {
+		for (const cause of assembled.bsdCauses) {
+			target.bsdCursors.set(cause, (target.bsdCursors.get(cause) ?? 0) + 1)
+		}
+		pruneSpans(session, sidState)
+	}
+	if (targetConfig) {
+		target.queue.push(line)
+		if (target.queue.length > targetConfig.maxQueueSize) {
+			target.queue.splice(0, target.queue.length - targetConfig.maxQueueSize)
+		}
+	}
+	return { prepared, line }
+}
+```
+
+```ts
+// libs/cmcd/src/placeRequestReport.ts
+import { CMCD_PARAM } from './CMCD_PARAM.ts'
+import type { Cmcd } from './Cmcd.ts'
+import type { CmcdHeaderMap } from './CmcdHeaderMap.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import { CMCD_HEADERS, type CmcdTransmissionMode } from './CmcdTransmissionMode.ts'
+import type { EmittedReport } from './emitReport.ts'
+import { toPreparedCmcdHeaders } from './toPreparedCmcdHeaders.ts'
+
+const CMCD_QUERY_PARAM = /([?&])CMCD=[^&#]*&?/
+
+/** The URL without its `CMCD` parameter. */
+export function removeCmcdQuery(url: string): string {
+	return url.replace(CMCD_QUERY_PARAM, (match, separator: string) => match.endsWith('&') ? separator : '')
+}
+
+function removeCmcdHeaders(headers: Readonly<Record<string, string>>): Record<string, string> {
+	const copy: Record<string, string> = {}
+	for (const [name, value] of Object.entries(headers)) {
+		if (!name.toLowerCase().startsWith('cmcd-')) {
+			copy[name] = value
+		}
+	}
+	return copy
+}
+
+function appendQuery(url: string, query: string): string {
+	const hash = url.indexOf('#')
+	const base = hash < 0 ? url : url.slice(0, hash)
+	const fragment = hash < 0 ? '' : url.slice(hash)
+	return `${base}${base.includes('?') ? '&' : '?'}${query}${fragment}`
+}
+
+/** Removes any earlier CMCD placement from the request, then adds the report in the configured mode. */
+export function placeRequestReport(request: CmcdRequestLike, emitted: EmittedReport | undefined, mode: CmcdTransmissionMode, headerMap: Partial<CmcdHeaderMap> | undefined): { url: string; headers: Record<string, string> | undefined } {
+	let url = removeCmcdQuery(request.url)
+	let headers = request.headers ? removeCmcdHeaders(request.headers) : undefined
+	if (!emitted) {
+		return { url, headers }
+	}
+	if (mode === CMCD_HEADERS) {
+		headers = { ...(headers ?? {}), ...toPreparedCmcdHeaders(emitted.prepared as Cmcd, headerMap) }
+	}
+	else if (emitted.line !== '') {
+		url = appendQuery(url, `${CMCD_PARAM}=${encodeURIComponent(emitted.line)}`)
+	}
+	return { url, headers }
+}
+```
+
+`placeRequestReport.ts` exports two functions. `removeCmcdQuery` is reused by `toResponseKeys` in Task 8.
+
+```ts
+// libs/cmcd/src/copyPlaybackData.ts
+import { SfItem, SfToken } from '@svta/cml-structured-field-values'
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+
+/** A copy of per-call data, with nested records and arrays copied, so a later mutation by the player does not change a late report. */
+export function copyPlaybackData<D extends CmcdPlaybackData>(data: D | undefined): D | undefined {
+	if (!data) {
+		return undefined
+	}
+	const copy: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(data)) {
+		if (Array.isArray(value)) {
+			copy[key] = [...value]
+		}
+		else if (value && typeof value === 'object' && !(value instanceof SfItem) && !(value instanceof SfToken)) {
+			copy[key] = { ...value }
+		}
+		else {
+			copy[key] = value
+		}
+	}
+	return copy as D
+}
+```
+
+- [ ] **Step 8: Write the reporter facade and the session factory**
+
+```ts
+// libs/cmcd/src/createSessionReporter.ts
+import type { Cmcd } from './Cmcd.ts'
+import { CMCD_REQUEST_ORIGINS } from './CMCD_REQUEST_ORIGINS.ts'
+import type { CmcdDecoratedRequest } from './CmcdDecoratedRequest.ts'
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import type { CmcdRequestRecord } from './CmcdRequestRecord.ts'
+import type { CmcdSession } from './CmcdSession.ts'
+import type { CmcdSessionReporter } from './CmcdSessionReporter.ts'
+import type { CmcdSessionReporterConfig } from './CmcdSessionReporterConfig.ts'
+import { assembleReport } from './assembleReport.ts'
+import { copyPlaybackData } from './copyPlaybackData.ts'
+import { emitReport } from './emitReport.ts'
+import { getTargetEntry } from './getTargetEntry.ts'
+import { placeRequestReport } from './placeRequestReport.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { RequestOrigin } from './RequestOrigin.ts'
+import type { SessionState } from './SessionState.ts'
+import type { SidState } from './SidState.ts'
+
+const SESSION_FACTS = ['bg', 'msd', 'bsa', 'bsda', 'bsd'] as const
+
+function writeSessionFact(state: SessionState, sidState: SidState, key: typeof SESSION_FACTS[number], value: unknown): void {
+	if (key === 'bg') {
+		state.bg = value === true ? true : undefined
+		state.bgSupplied = true
+		state.stopVisibility?.()
+		state.stopVisibility = undefined
+	}
+	else if (key === 'msd') {
+		sidState.msd = typeof value === 'number' ? value : undefined
+		sidState.msdSupplied = true
+	}
+	else if (key === 'bsa') {
+		sidState.bsaSupplied = value as SidState['bsaSupplied']
+	}
+	else if (key === 'bsda') {
+		sidState.bsdaSupplied = value as SidState['bsdaSupplied']
+	}
+	else {
+		sidState.bsdSupplied = true
+		const samples = typeof value === 'number' ? { '': value } : (value ?? {}) as Record<string, number>
+		for (const [cause, duration] of Object.entries(samples)) {
+			if (typeof duration === 'number' && Number.isFinite(duration)) {
+				let list = sidState.pending.get(cause)
+				if (!list) {
+					list = []
+					sidState.pending.set(cause, list)
+				}
+				list.push(duration)
+			}
+		}
+	}
+}
+
+/** Merges `data` into the store. Session facts go to the session or the `sid` state. Returns the transition time. */
+export function mergeUpdate(state: SessionState, reporter: ReporterState, data: CmcdPlaybackData): number {
+	const sidState = state.current
+	const ts = typeof data.ts === 'number' ? data.ts : Date.now()
+	for (const [key, value] of Object.entries(data)) {
+		if (key === 'ts') {
+			continue
+		}
+		if ((SESSION_FACTS as readonly string[]).includes(key)) {
+			writeSessionFact(state, sidState, key as typeof SESSION_FACTS[number], value)
+			continue
+		}
+		if (value === undefined) {
+			delete reporter.store[key]
+		}
+		else {
+			reporter.store[key] = value
+		}
+		if (key === 'su') {
+			reporter.suSupplied = true
+		}
+		if (key === 'dl') {
+			reporter.dlSupplied = true
+		}
+		if (key === 'h') {
+			reporter.hSupplied = true
+		}
+	}
+	return ts
+}
+
+export function createSessionReporter(state: SessionState, session: CmcdSession, config: CmcdSessionReporterConfig = {}): CmcdSessionReporter {
+	const reporter: ReporterState = {
+		session: state,
+		store: config.cid === undefined ? {} : { cid: config.cid },
+		reported: { cid: config.cid },
+		host: undefined,
+		hSupplied: false,
+		su: undefined,
+		suSupplied: false,
+		dlSupplied: false,
+		spanOpenedAt: undefined,
+		disposed: false,
+	}
+	state.reporters.add(reporter)
+
+	const facade: CmcdSessionReporter = {
+		session,
+		update(data) {
+			if (reporter.disposed || state.disposed) {
+				return
+			}
+			mergeUpdate(state, reporter, data)
+		},
+		recordEvent() {},
+		recordError(code) {
+			if (reporter.disposed || state.disposed) {
+				return
+			}
+			const codes = (typeof code === 'string' ? [code] : [...code]).filter(item => item !== '')
+			const sidState = state.current
+			for (const target of [sidState.requestTarget, ...sidState.eventTargets]) {
+				getTargetEntry(target, reporter).ec.push(...codes)
+			}
+		},
+		decorate<R extends CmcdRequestLike>(request: R, data?: CmcdPlaybackData): CmcdDecoratedRequest<R> {
+			const sidState = state.current
+			const mode = state.config.transmissionMode
+			if (reporter.disposed || state.disposed) {
+				const placed = placeRequestReport(request, undefined, mode, state.config.headerMap)
+				return finish(request, placed, { sid: sidState.sid, data: {} })
+			}
+			const dataCopy = copyPlaybackData(data)
+			const origin: RequestOrigin = { reporter, sidState, cid: reporter.store['cid'] as string | undefined, data: dataCopy, startedAt: Date.now() }
+			const assembled = assembleReport(state, sidState, sidState.requestTarget, reporter, undefined, dataCopy, origin.startedAt)
+			const emitted = emitReport(state, sidState, sidState.requestTarget, reporter, assembled, undefined, request)
+			const placed = placeRequestReport(request, emitted, mode, state.config.headerMap)
+			const record: CmcdRequestRecord = { sid: sidState.sid, data: (emitted?.prepared ?? {}) as Readonly<Cmcd> }
+			CMCD_REQUEST_ORIGINS.set(record, origin)
+			return finish(request, placed, record)
+		},
+		recordResponse() {},
+		dispose() {
+			reporter.disposed = true
+			state.reporters.delete(reporter)
+			for (const target of [state.current.requestTarget, ...state.current.eventTargets]) {
+				target.entries.delete(reporter)
+			}
+		},
+	}
+	return facade
+}
+
+function finish<R extends CmcdRequestLike>(request: R, placed: { url: string; headers: Record<string, string> | undefined }, record: CmcdRequestRecord): CmcdDecoratedRequest<R> {
+	const decorated: Record<string, unknown> = { ...request, url: placed.url, cmcd: record }
+	if (placed.headers) {
+		decorated['headers'] = placed.headers
+	}
+	else {
+		delete decorated['headers']
+	}
+	return decorated as CmcdDecoratedRequest<R>
+}
+```
+
+`recordEvent` and `recordResponse` are empty here because event delivery does not exist yet. Task 5 and Task 8 replace them. `createSessionReporter.ts` exports two functions, `mergeUpdate` for Tasks 5 and 6 and the factory.
+
+```ts
+// libs/cmcd/src/createCmcdSession.ts
+import { uuid } from '@svta/cml-utils'
+import type { CmcdSession } from './CmcdSession.ts'
+import type { CmcdSessionConfig } from './CmcdSessionConfig.ts'
+import { createSessionReporter } from './createSessionReporter.ts'
+import { createSidState } from './createSidState.ts'
+import { normalizeSessionConfig } from './normalizeSessionConfig.ts'
+import type { SessionState } from './SessionState.ts'
+
+/**
+ * Creates a CMCD session. One session per playback, one reporter per media player.
+ *
+ * @example
+ * {@includeCode ../test/createCmcdSession.test.ts#example}
+ *
+ * @public
+ */
+export function createCmcdSession(config: CmcdSessionConfig = {}): CmcdSession {
+	const normalized = normalizeSessionConfig(config)
+	const state: SessionState = {
+		config: normalized,
+		reporters: new Set(),
+		current: createSidState(config.sid ?? uuid(), normalized),
+		timers: [],
+		bg: undefined,
+		bgSupplied: false,
+		stopVisibility: undefined,
+		disposed: false,
+	}
+	const session: CmcdSession = {
+		get sid() {
+			return state.current.sid
+		},
+		createReporter: reporterConfig => createSessionReporter(state, session, reporterConfig),
+		rotate(sid) {
+			if (state.disposed) {
+				return
+			}
+			const next = sid ?? uuid()
+			if (next === state.current.sid) {
+				return
+			}
+			state.current.ended = true
+			state.current = createSidState(next, state.config)
+			for (const reporter of state.reporters) {
+				reporter.reported.sta = undefined
+				reporter.reported.pr = undefined
+				reporter.reported.cid = undefined
+				reporter.reported.br = undefined
+				reporter.spanOpenedAt = undefined
+			}
+		},
+		configure(settings) {
+			if (state.disposed) {
+				return
+			}
+			if (settings.version !== undefined) {
+				state.config.version = settings.version
+			}
+			if (settings.transmissionMode !== undefined) {
+				state.config.transmissionMode = settings.transmissionMode
+			}
+			if (settings.keys !== undefined) {
+				state.config.keys = new Set(settings.keys)
+			}
+			if (settings.headerMap !== undefined) {
+				state.config.headerMap = settings.headerMap
+			}
+		},
+		flush() {},
+		dispose() {
+			state.disposed = true
+			state.current.ended = true
+			for (const reporter of state.reporters) {
+				reporter.disposed = true
+			}
+		},
+	}
+	return session
+}
+```
+
+Add `export * from './createCmcdSession.ts'` to `libs/cmcd/src/index.ts`. The example region comes with the Task 3 test file. Until then the `{@includeCode}` tag points at a file that does not exist, and the build warns. Create `libs/cmcd/test/createCmcdSession.test.ts` now with only the example:
+
+```ts
+// libs/cmcd/test/createCmcdSession.test.ts
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { equal } from 'node:assert'
+import { describe, it } from 'node:test'
+
+describe('createCmcdSession', () => {
+	it('provides a valid example', () => {
+		// #region example
+		const session = createCmcdSession({
+			keys: ['br', 'bl', 'd', 'ot', 'sid', 'cid', 'mtp', 'sf', 'st', 'su', 'nor'],
+		})
+		const reporter = session.createReporter({ cid: 'movie-42' })
+		reporter.update({ sf: 'h', st: 'v', sta: 'p', bl: 3200, mtp: 15000 })
+		const req = reporter.decorate({ url: 'https://cdn.example.com/seg-1.m4s' }, { ot: 'v', d: 4000, br: 3000 })
+		// req.url carries the CMCD query parameter, req.cmcd.data is the report as sent
+		session.dispose()
+		// #endregion example
+		equal(req.url.includes('CMCD='), true)
+	})
+})
+```
+
+- [ ] **Step 9: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.request.test.ts libs/cmcd/test/createCmcdSession.test.ts && npm run typecheck`
+Expected: PASS for every fixture. If 8.1.1 differs only in `nor`, check `formatNor` against `urlToRelativePath`: the expected relative path of `https://cdn.example.com/next-seg.mp4` from `https://cdn.example.com/seg-1.m4s` is `next-seg.mp4`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): add the key table, report preparation, and request-mode decoration for the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Configuration checks and `configure()`
+
+**Files:**
+- Create: `libs/cmcd/src/checkRequestSettings.ts`, `libs/cmcd/src/configureSession.ts`
+- Modify: `libs/cmcd/src/normalizeSessionConfig.ts`, `libs/cmcd/src/createSessionReporter.ts`, `libs/cmcd/src/createCmcdSession.ts`
+- Test: `libs/cmcd/test/createCmcdSession.test.ts`
+
+**Interfaces:**
+- Produces: `checkSid(sid)`, `checkCid(cid)`, `checkRequestSettings(settings)`, `configError(parameter, expected, received)` in `checkRequestSettings.ts`, and `configureSession(state, settings)`. Task 9 calls `checkSid` from `rotate()`.
+
+Every message has the form `CmcdSession: <parameter> must be <expected>, received <value>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/cmcd/test/createCmcdSession.test.ts`, inside the `describe`:
+
+```ts
+	it('uses a UUID when no sid is given', () => {
+		const session = createCmcdSession()
+		equal(/^[0-9a-f-]{36}$/.test(session.sid), true)
+		equal(createCmcdSession({ sid: 'given' }).sid, 'given')
+	})
+
+	it('rejects invalid configuration with an actionable message', () => {
+		const long = 'x'.repeat(65)
+		throws(() => createCmcdSession({ sid: long }), { message: `CmcdSession: sid must be a string of at most 64 characters, received ${long}` })
+		throws(() => createCmcdSession().createReporter({ cid: 'y'.repeat(129) }), { message: /^CmcdSession: cid must be a string of at most 128 characters/ })
+		throws(() => createCmcdSession({ keys: ['br', 'nope' as never] }), { message: 'CmcdSession: keys must be reserved keys or hyphenated custom keys, received nope' })
+		throws(() => createCmcdSession({ transmissionMode: 'json' }), { message: 'CmcdSession: transmissionMode must be query or headers, received json' })
+		throws(() => createCmcdSession({ version: 3 as never }), { message: 'CmcdSession: version must be 1 or 2, received 3' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: '' }] }), { message: 'CmcdSession: eventTargets[0].url must be a non-empty string, received ' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: 'https://c.example', events: ['zz' as never] }] }), { message: 'CmcdSession: eventTargets[0].events must be event types, received zz' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: 'https://c.example', interval: -1 }] }), { message: 'CmcdSession: eventTargets[0].interval must be a finite number of seconds, 0 or more, received -1' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: 'https://c.example', batchSize: 0 }] }), { message: 'CmcdSession: eventTargets[0].batchSize must be a positive integer, received 0' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: 'https://c.example', batchSize: 1000 }] }), { message: 'CmcdSession: eventTargets[0].batchSize must be at most maxQueueSize (500), received 1000' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: 'https://c.example', maxQueueSize: 2.5 }] }), { message: 'CmcdSession: eventTargets[0].maxQueueSize must be a positive integer, received 2.5' })
+		throws(() => createCmcdSession({ eventTargets: [{ url: 'https://c.example', version: 2 } as never] }), { message: 'CmcdSession: eventTargets[0].version must be absent, event mode is version 2, received 2' })
+	})
+
+	it('configure() replaces the request settings and keeps the counters', () => {
+		const session = createCmcdSession({ sid: 's', keys: ['sid', 'sn'] })
+		const reporter = session.createReporter()
+		reporter.decorate({ url: 'https://cdn.example.com/a' })
+		session.configure({ transmissionMode: CmcdTransmissionMode.HEADERS, keys: ['sid', 'sn', 'ot'] })
+		const req = reporter.decorate({ url: 'https://cdn.example.com/b' }, { ot: 'v' })
+		equal(req.url, 'https://cdn.example.com/b')
+		deepEqual(req.headers, { 'CMCD-Object': 'ot=v', 'CMCD-Request': 'sn=1', 'CMCD-Session': 'sid="s",v=2' })
+		throws(() => session.configure({ keys: ['bad key' as never] }), { message: 'CmcdSession: keys must be reserved keys or hyphenated custom keys, received bad key' })
+	})
+```
+
+Add `CmcdTransmissionMode` to the value import and `deepEqual, throws` to the assert import of that file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/createCmcdSession.test.ts`
+Expected: FAIL, nothing throws.
+
+- [ ] **Step 3: Write the checks**
+
+```ts
+// libs/cmcd/src/checkRequestSettings.ts
+import { CMCD_KEY_SPECS } from './CMCD_KEY_SPECS.ts'
+import type { CmcdSessionConfig } from './CmcdSessionConfig.ts'
+import { CMCD_HEADERS, CMCD_QUERY } from './CmcdTransmissionMode.ts'
+import { getKeySpec } from './getKeySpec.ts'
+
+/** The error every configuration check throws. */
+export function configError(parameter: string, expected: string, received: unknown): Error {
+	return new Error(`CmcdSession: ${parameter} must be ${expected}, received ${String(received)}`)
+}
+
+export function checkSid(sid: unknown): void {
+	if (typeof sid !== 'string' || sid === '' || sid.length > 64) {
+		throw configError('sid', 'a string of at most 64 characters', sid)
+	}
+}
+
+export function checkCid(cid: unknown): void {
+	if (typeof cid !== 'string' || cid.length > 128) {
+		throw configError('cid', 'a string of at most 128 characters', cid)
+	}
+}
+
+export function checkKeys(parameter: string, keys: readonly string[]): void {
+	for (const key of keys) {
+		if (getKeySpec(key) === undefined) {
+			throw configError(parameter, 'reserved keys or hyphenated custom keys', key)
+		}
+	}
+}
+
+export function checkEvents(parameter: string, events: readonly string[]): void {
+	const tokens = CMCD_KEY_SPECS['e'].tokens ?? []
+	for (const event of events) {
+		if (!tokens.includes(event)) {
+			throw configError(parameter, 'event types', event)
+		}
+	}
+}
+
+/** The request-mode settings that `createCmcdSession()` and `configure()` share. */
+export function checkRequestSettings(settings: Pick<CmcdSessionConfig, 'version' | 'transmissionMode' | 'keys' | 'headerMap'>): void {
+	if (settings.version !== undefined && settings.version !== 1 && settings.version !== 2) {
+		throw configError('version', '1 or 2', settings.version)
+	}
+	if (settings.transmissionMode !== undefined && settings.transmissionMode !== CMCD_QUERY && settings.transmissionMode !== CMCD_HEADERS) {
+		throw configError('transmissionMode', 'query or headers', settings.transmissionMode)
+	}
+	if (settings.keys !== undefined) {
+		checkKeys('keys', settings.keys)
+	}
+	if (settings.headerMap !== undefined) {
+		for (const keys of Object.values(settings.headerMap)) {
+			checkKeys('headerMap', keys ?? [])
+		}
+	}
+}
+```
+
+`checkRequestSettings.ts` exports the checks together because they share `configError`.
+
+- [ ] **Step 4: Call the checks**
+
+In `libs/cmcd/src/normalizeSessionConfig.ts`, add the import `import { checkEvents, checkKeys, checkRequestSettings, checkSid, configError } from './checkRequestSettings.ts'` and replace `normalizeTarget` and the start of `normalizeSessionConfig` with:
+
+```ts
+function isPositiveInteger(value: unknown): value is number {
+	return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function normalizeTarget(target: CmcdEventTargetConfig, index: number): NormalizedEventTarget {
+	const name = `eventTargets[${index}]`
+	if (typeof target.url !== 'string' || target.url === '') {
+		throw configError(`${name}.url`, 'a non-empty string', target.url)
+	}
+	if ('version' in target) {
+		throw configError(`${name}.version`, 'absent, event mode is version 2', (target as { version?: unknown }).version)
+	}
+	if (target.events !== undefined) {
+		checkEvents(`${name}.events`, target.events)
+	}
+	if (target.keys !== undefined) {
+		checkKeys(`${name}.keys`, target.keys)
+	}
+	const interval = target.interval ?? CMCD_DEFAULT_TIME_INTERVAL
+	if (typeof interval !== 'number' || !Number.isFinite(interval) || interval < 0) {
+		throw configError(`${name}.interval`, 'a finite number of seconds, 0 or more', target.interval)
+	}
+	const maxQueueSize = target.maxQueueSize ?? 500
+	if (!isPositiveInteger(maxQueueSize)) {
+		throw configError(`${name}.maxQueueSize`, 'a positive integer', target.maxQueueSize)
+	}
+	const batchSize = target.batchSize ?? 1
+	if (!isPositiveInteger(batchSize)) {
+		throw configError(`${name}.batchSize`, 'a positive integer', target.batchSize)
+	}
+	if (batchSize > maxQueueSize) {
+		throw configError(`${name}.batchSize`, `at most maxQueueSize (${maxQueueSize})`, batchSize)
+	}
+	return {
+		url: target.url,
+		events: new Set(target.events ?? DEFAULT_EVENTS),
+		keys: target.keys === undefined ? undefined : new Set(target.keys),
+		interval: interval * 1000,
+		batchSize,
+		maxQueueSize,
+		headers: target.headers === undefined ? undefined : { ...target.headers },
+		transform: target.transform,
+	}
+}
+
+/** Applies the defaults and throws on the first invalid setting. */
+export function normalizeSessionConfig(config: CmcdSessionConfig): NormalizedSessionConfig {
+	if (config.sid !== undefined) {
+		checkSid(config.sid)
+	}
+	checkRequestSettings(config)
+	return {
+```
+
+The rest of the returned object stays as in Task 2, with `eventTargets: (config.eventTargets ?? []).map(normalizeTarget)`.
+
+```ts
+// libs/cmcd/src/configureSession.ts
+import type { CmcdSessionConfig } from './CmcdSessionConfig.ts'
+import { checkRequestSettings } from './checkRequestSettings.ts'
+import type { SessionState } from './SessionState.ts'
+
+/** Replaces the request-mode settings. The request target reads them at the next `decorate()`. Nothing else changes. */
+export function configureSession(state: SessionState, settings: Pick<CmcdSessionConfig, 'version' | 'transmissionMode' | 'keys' | 'headerMap'>): void {
+	if (state.disposed) {
+		return
+	}
+	checkRequestSettings(settings)
+	if (settings.version !== undefined) {
+		state.config.version = settings.version
+	}
+	if (settings.transmissionMode !== undefined) {
+		state.config.transmissionMode = settings.transmissionMode
+	}
+	if (settings.keys !== undefined) {
+		state.config.keys = new Set(settings.keys)
+	}
+	if (settings.headerMap !== undefined) {
+		state.config.headerMap = settings.headerMap
+	}
+}
+```
+
+In `createCmcdSession.ts`, replace the inline `configure` body with `configure: settings => configureSession(state, settings),` and import `configureSession`. In `createSessionReporter.ts`, call `checkCid(config.cid)` at the top of `createSessionReporter` when `config.cid !== undefined`, and throw `configError('createReporter', 'a live session', 'a disposed session')` when `state.disposed`. Import both from `./checkRequestSettings.ts`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/createCmcdSession.test.ts libs/cmcd/test/CmcdSessionReporter.request.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): validate the session configuration and add configure()" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Event targets, interval reports, and delivery
+
+**Files:**
+- Create: `libs/cmcd/src/processQueue.ts`, `libs/cmcd/src/emitEvent.ts`, `libs/cmcd/src/tickTarget.ts`, `libs/cmcd/src/armTimers.ts`, `libs/cmcd/src/flushSession.ts`, `libs/cmcd/src/disposeSession.ts`, `libs/cmcd/src/reportSessionError.ts`
+- Modify: `libs/cmcd/src/createCmcdSession.ts`
+- Test: `libs/cmcd/test/CmcdSession.delivery.test.ts`
+
+**Interfaces:**
+- Produces: `emitEvent(session, reporter, event, data, request, ts): void` for Tasks 5 to 8, `processQueue(session, sidState, target, drain)`, `flushSession(state)`, `disposeSession(state)`, `reportSessionError(session, error)`.
+
+Delivery semantics come from the design record's Delivery section. A batch is sent when the queue reaches `batchSize`, on a drain, or on a retry. A 2xx or 3xx response succeeds. A 410 silences the target for the `sid`. A 429, a 5xx, or a rejection retries with a doubling back-off from one second to a 60 second cap. Any other 4xx drops the batch.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSession.delivery.test.ts
+import { CMCD_MIME_TYPE, createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal } from 'node:assert'
+import { describe, it } from 'node:test'
+import { EX_8_2_1 } from './data/CTA_5004_B_EXAMPLES.ts'
+import { createMockRequester, flushPromises } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const TIMERS = { apis: ['Date', 'setTimeout', 'setInterval'] as ('Date' | 'setTimeout' | 'setInterval')[], now: 1764752370000 }
+
+describe('CmcdSession delivery', () => {
+	it('reproduces 8.2.1: a minimal t report after one interval', async (context) => {
+		context.mock.timers.enable(TIMERS)
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'session-id-123', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: [] }] })
+		session.createReporter({ cid: 'content-id-123' })
+		context.mock.timers.tick(29999)
+		await flushPromises()
+		equal(mock.requests.length, 0)
+		context.mock.timers.tick(1)
+		await flushPromises()
+		deepEqual(mock.bodies(), [EX_8_2_1])
+		equal(mock.requests[0].method, 'POST')
+		equal(mock.requests[0].url, COLLECTOR)
+		deepEqual(mock.requests[0].headers, { 'Content-Type': CMCD_MIME_TYPE })
+		session.dispose()
+	})
+
+	it('emits one t line per live reporter, in creation order, with the same ts and consecutive sn', async (context) => {
+		context.mock.timers.enable(TIMERS)
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['cid', 'sid', 'sn'], batchSize: 2 }] })
+		session.createReporter({ cid: 'movie' })
+		session.createReporter({ cid: 'ad' })
+		context.mock.timers.tick(30000)
+		await flushPromises()
+		deepEqual(mock.bodies(), ['cid="movie",e=t,sid="s",sn=0,ts=1764752400000,v=2\ncid="ad",e=t,sid="s",sn=1,ts=1764752400000,v=2'])
+		session.dispose()
+	})
+
+	it('emits a session-only line when the session has no reporter', async (context) => {
+		context.mock.timers.enable(TIMERS)
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['sid'] }] })
+		context.mock.timers.tick(30000)
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=t,sid="s",ts=1764752400000,v=2'])
+		session.dispose()
+	})
+
+	it('honors interval, batchSize, headers, and flush()', async (context) => {
+		context.mock.timers.enable(TIMERS)
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['sid'], interval: 10, batchSize: 3, headers: { Authorization: 'Bearer x' } }] })
+		session.createReporter()
+		context.mock.timers.tick(20000)
+		await flushPromises()
+		equal(mock.requests.length, 0)
+		session.flush()
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=t,sid="s",ts=1764752380000,v=2\ne=t,sid="s",ts=1764752390000,v=2'])
+		deepEqual(mock.requests[0].headers, { 'Content-Type': CMCD_MIME_TYPE, Authorization: 'Bearer x' })
+		context.mock.timers.tick(30000)
+		await flushPromises()
+		equal(mock.requests.length, 2)
+		session.dispose()
+	})
+
+	it('drains on dispose() and stops the timers', async (context) => {
+		context.mock.timers.enable(TIMERS)
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['sid'], batchSize: 5 }] })
+		session.createReporter()
+		context.mock.timers.tick(30000)
+		session.dispose()
+		await flushPromises()
+		equal(mock.requests.length, 1)
+		context.mock.timers.tick(60000)
+		await flushPromises()
+		equal(mock.requests.length, 1)
+	})
+
+	it('disables t with interval 0', async (context) => {
+		context.mock.timers.enable(TIMERS)
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, interval: 0 }] })
+		session.createReporter()
+		context.mock.timers.tick(120000)
+		await flushPromises()
+		equal(mock.requests.length, 0)
+		session.dispose()
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.delivery.test.ts`
+Expected: FAIL, no request is sent.
+
+- [ ] **Step 3: Write delivery**
+
+```ts
+// libs/cmcd/src/reportSessionError.ts
+import type { SessionState } from './SessionState.ts'
+
+/** Gives an error that has no caller to `onError`, or throws it from a timer callback when `onError` is absent. */
+export function reportSessionError(session: SessionState, error: unknown): void {
+	if (session.config.onError) {
+		session.config.onError(error)
+		return
+	}
+	setTimeout(() => {
+		throw error
+	}, 0)
+}
+```
+
+```ts
+// libs/cmcd/src/processQueue.ts
+import type { HttpRequest } from '@svta/cml-utils'
+import { CMCD_MIME_TYPE } from './CMCD_MIME_TYPE.ts'
+import { reportSessionError } from './reportSessionError.ts'
+import type { SessionState } from './SessionState.ts'
+import type { SidState } from './SidState.ts'
+import type { TargetState } from './TargetState.ts'
+
+const BACK_OFF_CAP = 60000
+const ATTEMPTS_TO_CAP = 7
+
+function settle(session: SessionState, sidState: SidState, target: TargetState, batch: string[], status: number): void {
+	const config = session.config.eventTargets[target.index]
+	target.sending = false
+	if (status >= 200 && status < 400) {
+		target.attempt = 0
+		if (target.queue.length === 0) {
+			target.drainRequested = false
+		}
+		processQueue(session, sidState, target, false)
+		return
+	}
+	if (status === 410) {
+		target.gone = true
+		target.queue.length = 0
+		target.drainRequested = false
+		return
+	}
+	if (status === 429 || status >= 500 || status === 0) {
+		target.queue.unshift(...batch)
+		if (target.queue.length > config.maxQueueSize) {
+			target.queue.splice(0, target.queue.length - config.maxQueueSize)
+		}
+		target.attempt += 1
+		if (sidState.ended && target.attempt > ATTEMPTS_TO_CAP) {
+			target.queue.length = 0
+			target.drainRequested = false
+			reportSessionError(session, new Error(`CmcdSession: send failed for target ${config.url} after the back-off cap, status ${status}`))
+			return
+		}
+		const delay = Math.min(1000 * 2 ** (target.attempt - 1), BACK_OFF_CAP)
+		target.retryTimer = setTimeout(() => {
+			target.retryTimer = undefined
+			processQueue(session, sidState, target, true)
+		}, delay)
+		return
+	}
+	target.attempt = 0
+	processQueue(session, sidState, target, false)
+}
+
+/**
+ * Sends the next batch of one event target when the queue is ready. `drain` asks for the whole queue and is remembered
+ * until the queue is empty, so a drain requested during a send is not lost.
+ */
+export function processQueue(session: SessionState, sidState: SidState, target: TargetState, drain: boolean): void {
+	const config = session.config.eventTargets[target.index]
+	if (!config) {
+		return
+	}
+	if (drain) {
+		target.drainRequested = true
+	}
+	if (target.gone || target.queue.length === 0 || target.sending || target.retryTimer !== undefined) {
+		return
+	}
+	if (target.queue.length < config.batchSize && !target.drainRequested) {
+		return
+	}
+	const batch = target.drainRequested ? target.queue.splice(0) : target.queue.splice(0, config.batchSize)
+	const request: HttpRequest = {
+		url: config.url,
+		method: 'POST',
+		headers: { 'Content-Type': CMCD_MIME_TYPE, ...(config.headers ?? {}) },
+		body: batch.join('\n'),
+	}
+	target.sending = true
+	let response: Promise<{ status: number }>
+	try {
+		response = session.config.requester(request)
+	}
+	catch {
+		response = Promise.resolve({ status: 0 })
+	}
+	response.then(
+		result => settle(session, sidState, target, batch, result.status),
+		() => settle(session, sidState, target, batch, 0),
+	)
+}
+```
+
+```ts
+// libs/cmcd/src/emitEvent.ts
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import { assembleReport } from './assembleReport.ts'
+import { emitReport } from './emitReport.ts'
+import { processQueue } from './processQueue.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SessionState } from './SessionState.ts'
+import type { TargetState } from './TargetState.ts'
+
+/**
+ * Emits one event for one reporter to every event target of the current `sid` state that lists it.
+ * The `sid` state is captured once, so a transform that rotates does not move the remaining targets.
+ * The first error is rethrown after every target ran.
+ */
+export function emitEvent(session: SessionState, reporter: ReporterState, event: string, data: CmcdPlaybackData | undefined, request: Readonly<CmcdRequestLike> | undefined, ts: number): void {
+	const sidState = session.current
+	const targets: TargetState[] = []
+	let failure: unknown
+	let failed = false
+	for (const target of sidState.eventTargets) {
+		if (target.gone || !session.config.eventTargets[target.index].events.has(event)) {
+			continue
+		}
+		try {
+			const assembled = assembleReport(session, sidState, target, reporter, event, data, ts)
+			emitReport(session, sidState, target, reporter, assembled, event, request)
+			targets.push(target)
+		}
+		catch (error) {
+			if (!failed) {
+				failed = true
+				failure = error
+			}
+		}
+	}
+	for (const target of targets) {
+		processQueue(session, sidState, target, false)
+	}
+	if (failed) {
+		throw failure
+	}
+}
+```
+
+```ts
+// libs/cmcd/src/tickTarget.ts
+import { CMCD_EVENT_TIME_INTERVAL } from './CmcdEventType.ts'
+import { assembleReport } from './assembleReport.ts'
+import { emitReport } from './emitReport.ts'
+import { processQueue } from './processQueue.ts'
+import { reportSessionError } from './reportSessionError.ts'
+import type { SessionState } from './SessionState.ts'
+
+/** One interval tick of one event target: one `t` line per live reporter, or one session-only line. */
+export function tickTarget(session: SessionState, index: number): void {
+	if (session.disposed) {
+		return
+	}
+	const sidState = session.current
+	const target = sidState.eventTargets[index]
+	if (!target || target.gone) {
+		return
+	}
+	const ts = Date.now()
+	const reporters = session.reporters.size > 0 ? [...session.reporters] : [undefined]
+	let failure: unknown
+	let failed = false
+	for (const reporter of reporters) {
+		try {
+			const assembled = assembleReport(session, sidState, target, reporter, CMCD_EVENT_TIME_INTERVAL, undefined, ts)
+			emitReport(session, sidState, target, reporter, assembled, CMCD_EVENT_TIME_INTERVAL, undefined)
+		}
+		catch (error) {
+			if (!failed) {
+				failed = true
+				failure = error
+			}
+		}
+	}
+	processQueue(session, sidState, target, false)
+	if (failed) {
+		reportSessionError(session, failure)
+	}
+}
+```
+
+```ts
+// libs/cmcd/src/armTimers.ts
+import { CMCD_EVENT_TIME_INTERVAL } from './CmcdEventType.ts'
+import type { SessionState } from './SessionState.ts'
+import { tickTarget } from './tickTarget.ts'
+
+/** One interval timer per event target that lists `t` with an interval over zero. */
+export function armTimers(session: SessionState): void {
+	session.config.eventTargets.forEach((target, index) => {
+		if (target.interval > 0 && target.events.has(CMCD_EVENT_TIME_INTERVAL)) {
+			session.timers.push(setInterval(() => tickTarget(session, index), target.interval))
+		}
+	})
+}
+```
+
+```ts
+// libs/cmcd/src/flushSession.ts
+import { processQueue } from './processQueue.ts'
+import type { SessionState } from './SessionState.ts'
+
+/** Sends every queued line of the current `sid` state now. An armed retry fires at once. */
+export function flushSession(session: SessionState): void {
+	if (session.disposed) {
+		return
+	}
+	for (const target of session.current.eventTargets) {
+		if (target.retryTimer !== undefined) {
+			clearTimeout(target.retryTimer)
+			target.retryTimer = undefined
+		}
+		processQueue(session, session.current, target, true)
+	}
+}
+```
+
+```ts
+// libs/cmcd/src/disposeSession.ts
+import { processQueue } from './processQueue.ts'
+import type { SessionState } from './SessionState.ts'
+
+/** Ends the session: timers off, reporters disposed, the current `sid` state ended, every queue drained. */
+export function disposeSession(session: SessionState): void {
+	if (session.disposed) {
+		return
+	}
+	session.disposed = true
+	for (const timer of session.timers) {
+		clearInterval(timer)
+	}
+	session.timers.length = 0
+	session.stopVisibility?.()
+	session.stopVisibility = undefined
+	for (const reporter of session.reporters) {
+		reporter.disposed = true
+	}
+	const sidState = session.current
+	sidState.ended = true
+	for (const target of sidState.eventTargets) {
+		if (target.retryTimer !== undefined) {
+			clearTimeout(target.retryTimer)
+			target.retryTimer = undefined
+		}
+		processQueue(session, sidState, target, true)
+	}
+}
+```
+
+In `createCmcdSession.ts`: import `armTimers`, `flushSession`, and `disposeSession`. Call `armTimers(state)` before `return session`. Replace the `flush` and `dispose` members with `flush: () => flushSession(state),` and `dispose: () => disposeSession(state),`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.delivery.test.ts && npm run typecheck`
+Expected: PASS. If the batching test sends after the second tick, check that `processQueue` compares `queue.length < batchSize` before splicing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): add event targets, interval reports, and delivery to the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: State-change events, discrete events, and errors
+
+**Files:**
+- Create: `libs/cmcd/src/deriveStateEvents.ts`
+- Modify: `libs/cmcd/src/createSessionReporter.ts`
+- Test: `libs/cmcd/test/CmcdSessionReporter.events.test.ts`
+
+**Interfaces:**
+- Consumes: `emitEvent()` from Task 4, `mergeUpdate()` from Task 2.
+- Produces: `deriveStateEvents(session, reporter, ts)`. Task 7 adds the `bg` comparison to it.
+
+`update()` emits `ps` for `sta`, `pr` for `pr` while playing, `c` for `cid`, and `bc` for `br`. Each fires when the value differs from the last value that reporter reported. `recordEvent()` emits one discrete event with per-call data. `recordError()` buffers the codes on every target and emits `e`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSessionReporter.events.test.ts
+import type { CmcdEventType, CmcdKey } from '@svta/cml-cmcd'
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal } from 'node:assert'
+import { describe, it } from 'node:test'
+import { EX_8_2_4, EX_8_2_6, EX_8_2_7, EX_8_2_8 } from './data/CTA_5004_B_EXAMPLES.ts'
+import { createMockRequester, flushPromises } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+
+function harness(events: CmcdEventType[], keys: CmcdKey[], cid: string | undefined = 'content-id-123') {
+	const mock = createMockRequester()
+	const session = createCmcdSession({ sid: 'session-id-123', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events, keys, interval: 0 }] })
+	const reporter = session.createReporter(cid === undefined ? {} : { cid })
+	return { mock, session, reporter }
+}
+
+describe('CmcdSessionReporter events', () => {
+	it('reproduces 8.2.4: recordError emits e with the codes', async () => {
+		const { mock, reporter } = harness(['e'], ['cid', 'ec', 'sid'])
+		reporter.recordError('CODEC_NOT_SUPPORTED', { ts: 1764269150213 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [EX_8_2_4])
+	})
+
+	it('reproduces 8.2.6: a play-state change reports the merged store', async () => {
+		const { mock, reporter } = harness(['ps'], ['bl', 'cid', 'pt', 'sid', 'sta'])
+		reporter.update({ sta: 'k', bl: 0, pt: 30000, ts: 1764269150529 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [EX_8_2_6])
+	})
+
+	it('reproduces 8.2.7 and 8.2.8: discrete events with per-call data', async () => {
+		const { mock, reporter } = harness(['sk', 'abs', 'as', 'ae', 'abe'], ['cid', 'nr', 'sid'], 'movie-123')
+		reporter.recordEvent('sk', { cid: 'ad-content-555', ts: 1764269150076 })
+		reporter.recordEvent('abs', { nr: true, ts: 1764269150186 })
+		reporter.recordEvent('as', { cid: 'ad-001', ts: 1764269150934 })
+		reporter.recordEvent('ae', { cid: 'ad-001', nr: true, ts: 1764269170901 })
+		reporter.recordEvent('abe', { ts: 1764269170331 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [EX_8_2_7, ...EX_8_2_8])
+	})
+
+	it('dedups state-change events and fires pr only while playing', async () => {
+		const { mock, reporter } = harness(['ps', 'pr', 'bc', 'c'], ['br', 'cid', 'pr', 'sid', 'sta'], undefined)
+		reporter.update({ sta: 'p', ts: 1 })
+		reporter.update({ sta: 'p', ts: 2 })
+		reporter.update({ pr: 2, ts: 3 })
+		reporter.update({ sta: 'a', ts: 4 })
+		reporter.update({ pr: 1, ts: 5 })
+		reporter.update({ sta: 'p', ts: 6 })
+		reporter.update({ br: { v: 3000 }, ts: 7 })
+		reporter.update({ br: { v: 3000 }, ts: 8 })
+		reporter.update({ br: { v: 3000, a: 128 }, ts: 9 })
+		reporter.update({ cid: 'next', ts: 10 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			'e=ps,sid="session-id-123",sta=p,ts=1,v=2',
+			'e=pr,pr=2,sid="session-id-123",sta=p,ts=3,v=2',
+			'e=ps,pr=2,sid="session-id-123",sta=a,ts=4,v=2',
+			'e=ps,sid="session-id-123",sta=p,ts=6,v=2',
+			'e=pr,pr=1,sid="session-id-123",sta=p,ts=6,v=2',
+			'br=(3000;v),e=bc,sid="session-id-123",sta=p,ts=7,v=2',
+			'br=(3000;v 128;a),e=bc,sid="session-id-123",sta=p,ts=9,v=2',
+			'br=(3000;v 128;a),cid="next",e=c,sid="session-id-123",sta=p,ts=10,v=2',
+		])
+	})
+
+	it('does not emit c for the cid given at creation, and emits ce with cen', async () => {
+		const { mock, reporter } = harness(['c', 'ce'], ['cen', 'cid', 'sid'])
+		reporter.update({ sf: 'd' })
+		reporter.recordEvent('ce', { cen: 'seek-ui', ts: 5 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['cen="seek-ui",cid="content-id-123",e=ce,sid="session-id-123",ts=5,v=2'])
+	})
+
+	it('buffers error codes for a target that does not list e until its next report', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [
+			{ url: `${COLLECTOR}/errors`, events: ['e'], keys: ['ec', 'sid'] },
+			{ url: `${COLLECTOR}/interval`, events: ['t'], keys: ['ec', 'sid'], interval: 1 },
+		] })
+		const reporter = session.createReporter()
+		reporter.recordError(['E1', 'E2'])
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=e,ec=("E1" "E2"),sid="s",ts=1000,v=2'])
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(mock.bodies()[1], 'e=t,ec=("E1" "E2"),sid="s",ts=2000,v=2')
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(mock.bodies()[2], 'e=t,sid="s",ts=3000,v=2')
+		session.dispose()
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.events.test.ts`
+Expected: FAIL, no body is sent.
+
+- [ ] **Step 3: Write the diff**
+
+```ts
+// libs/cmcd/src/deriveStateEvents.ts
+import { CMCD_EVENT_BITRATE_CHANGE, CMCD_EVENT_CONTENT_ID, CMCD_EVENT_PLAY_STATE, CMCD_EVENT_PLAYBACK_RATE } from './CmcdEventType.ts'
+import { emitEvent } from './emitEvent.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SessionState } from './SessionState.ts'
+
+/** Two metric values are the same when they are the same number, or records with the same entries. */
+export function sameMetric(a: unknown, b: unknown): boolean {
+	if (a === b) {
+		return true
+	}
+	if (!a || !b || typeof a !== 'object' || typeof b !== 'object') {
+		return false
+	}
+	const left = a as Record<string, unknown>
+	const right = b as Record<string, unknown>
+	const keys = Object.keys(left)
+	return keys.length === Object.keys(right).length && keys.every(key => left[key] === right[key])
+}
+
+/**
+ * Emits the state-change events the store implies, in the order `sta`, `pr`, `cid`, `br`. A field emits when its
+ * value is defined and differs from the last value this reporter reported. `pr` emits only while `sta` is `p`.
+ */
+export function deriveStateEvents(session: SessionState, reporter: ReporterState, ts: number): void {
+	const { store, reported } = reporter
+	if (store['sta'] !== undefined && store['sta'] !== reported.sta) {
+		reported.sta = store['sta']
+		emitEvent(session, reporter, CMCD_EVENT_PLAY_STATE, undefined, undefined, ts)
+	}
+	if (store['sta'] === 'p' && store['pr'] !== undefined && store['pr'] !== reported.pr) {
+		reported.pr = store['pr']
+		emitEvent(session, reporter, CMCD_EVENT_PLAYBACK_RATE, undefined, undefined, ts)
+	}
+	if (store['cid'] !== undefined && store['cid'] !== reported.cid) {
+		reported.cid = store['cid']
+		emitEvent(session, reporter, CMCD_EVENT_CONTENT_ID, undefined, undefined, ts)
+	}
+	if (store['br'] !== undefined && !sameMetric(store['br'], reported.br)) {
+		reported.br = typeof store['br'] === 'object' ? { ...(store['br'] as Record<string, unknown>) } : store['br']
+		emitEvent(session, reporter, CMCD_EVENT_BITRATE_CHANGE, undefined, undefined, ts)
+	}
+}
+```
+
+- [ ] **Step 4: Wire the reporter methods**
+
+In `libs/cmcd/src/createSessionReporter.ts`, import `deriveStateEvents` from `./deriveStateEvents.ts`, `emitEvent` from `./emitEvent.ts`, `CMCD_EVENT_ERROR` from `./CmcdEventType.ts`, and `CmcdDiscreteEventType` as a type. Replace `update`, `recordEvent`, and `recordError`:
+
+```ts
+		update(data) {
+			if (reporter.disposed || state.disposed) {
+				return
+			}
+			const ts = mergeUpdate(state, reporter, data)
+			deriveStateEvents(state, reporter, ts)
+		},
+		recordEvent(type: CmcdDiscreteEventType, data?: CmcdPlaybackData) {
+			if (reporter.disposed || state.disposed) {
+				return
+			}
+			emitEvent(state, reporter, type, data, undefined, typeof data?.ts === 'number' ? data.ts : Date.now())
+		},
+		recordError(code, data) {
+			if (reporter.disposed || state.disposed) {
+				return
+			}
+			const codes = (typeof code === 'string' ? [code] : [...code]).filter(item => item !== '')
+			const sidState = state.current
+			for (const target of [sidState.requestTarget, ...sidState.eventTargets]) {
+				getTargetEntry(target, reporter).ec.push(...codes)
+			}
+			emitEvent(state, reporter, CMCD_EVENT_ERROR, data, undefined, typeof data?.ts === 'number' ? data.ts : Date.now())
+		},
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.events.test.ts libs/cmcd/test/CmcdSessionReporter.request.test.ts && npm run typecheck`
+Expected: PASS. The request-mode tests still pass, because a session without event targets emits nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): derive state-change events and record discrete events and errors in the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Transition-derived keys
+
+**Files:**
+- Create: `libs/cmcd/src/trackTransition.ts`
+- Modify: `libs/cmcd/src/createSessionReporter.ts`
+- Test: `libs/cmcd/test/CmcdSessionReporter.derived.test.ts`
+
+**Interfaces:**
+- Consumes: `addSpan()` from `pruneSpans.ts`, `getTargetEntry()`.
+- Produces: `trackTransition(session, reporter, previous, next, ts)`. Task 9 reuses the `bs` and span rules in `rotate()`.
+
+The `sta` transitions derive `msd`, `bs`, `bsa`, `bsda`, `bsd`, and `su`. `dl` is derived at assembly and was written in Task 2. The rules are the transition table of the design record. `bsd` is one stall per entry: each destination receives each completed stall once, in order, at most one entry per cause per report, never summed.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSessionReporter.derived.test.ts
+import type { CmcdSession, CmcdSessionReporter } from '@svta/cml-cmcd'
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal } from 'node:assert'
+import { describe, it, type TestContext } from 'node:test'
+import { EX_8_1_4, EX_8_2_2, EX_8_2_5 } from './data/CTA_5004_B_EXAMPLES.ts'
+import { createMockRequester, flushPromises, queryValue } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const CDN = 'https://cdn.example.com'
+const KEYS_8_2_2 = ['bl', 'br', 'bs', 'bsd', 'cid', 'ec', 'h', 'lb', 'msd', 'mtp', 'pb', 'pr', 'pt', 'sf', 'sid', 'sn', 'st', 'sta', 'su', 'tb', 'tpb'] as const
+
+/** The example numbers its reports from 1. The reporter numbers from 0, per the reset-to-zero rule. */
+function fromZero(line: string): string {
+	return line.replace(/sn=(\d+)/, (_, n: string) => `sn=${Number(n) - 1}`)
+}
+
+/** Drives the player state of example 8.2.2 through five interval ticks. */
+async function runExample822(context: TestContext, session: CmcdSession, reporter: CmcdSessionReporter): Promise<void> {
+	reporter.update({ h: 'example.com', sf: 'd', st: 'v' })
+	reporter.update({ sta: 's', bl: 0, pt: 0, ts: 1764752399000 })
+	context.mock.timers.tick(30000)
+	reporter.update({ sta: 'p', ts: 1764752399812 })
+	reporter.update({ bl: 6000, br: { v: 4200, a: 256 }, lb: { v: 523, a: 64 }, mtp: { v: 87000, a: 49000 }, pb: { v: 4200, a: 256 }, pt: 29188, tb: { v: 4200, a: 256 }, tpb: { v: 4200, a: 256 } })
+	context.mock.timers.tick(30000)
+	reporter.update({ sta: 'r', ts: 1764752458000 })
+	reporter.update({ bsd: { v: 720 } })
+	reporter.update({ sta: 'p', ts: 1764752458720 })
+	reporter.recordError('MEDIA_ERR_NETWORK')
+	reporter.update({ bl: 3200, mtp: { v: 89000, a: 52000 }, pt: 59188 })
+	context.mock.timers.tick(30000)
+	reporter.update({ bl: 6000, mtp: { v: 81000, a: 55000 }, pt: 89188 })
+	context.mock.timers.tick(30000)
+	reporter.update({ sta: 'e', pr: 0, bl: 0, mtp: { v: 82000, a: 55000 }, pt: 111000 })
+	context.mock.timers.tick(30000)
+	await flushPromises()
+	session.dispose()
+}
+
+describe('CmcdSessionReporter derived keys', () => {
+	it('reproduces 8.1.4: su until playing, msd once', () => {
+		const session = createCmcdSession({ sid: 'session-id-123', keys: ['bl', 'br', 'cid', 'd', 'msd', 'mtp', 'nor', 'ot', 'sf', 'sid', 'st', 'sta', 'su'] })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ sf: 'd', st: 'v' })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/manifest.mpd` }, { ot: 'm', su: true }).url), EX_8_1_4[0])
+		reporter.update({ sta: 's', bl: 0, mtp: 15000, ts: 1000 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/init.m4v` }, { br: { v: 3000 }, nor: [`${CDN}/seg-1.m4v`, `${CDN}/seg-2.m4v`], ot: 'i' }).url), EX_8_1_4[1])
+		equal(queryValue(reporter.decorate({ url: `${CDN}/seg-1.m4v` }, { br: { v: 3000 }, d: 4000, nor: [`${CDN}/seg-2.m4v`, `${CDN}/seg-3.m4v`], ot: 'v' }).url), EX_8_1_4[2])
+		reporter.update({ sta: 'p', bl: 4000, ts: 1200 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/seg-2.m4v` }, { br: { v: 3000 }, d: 4000, nor: [`${CDN}/seg-3.m4v`, `${CDN}/seg-4.m4v`], ot: 'v' }).url), EX_8_1_4[3])
+		equal(queryValue(reporter.decorate({ url: `${CDN}/seg-3.m4v` }, { ot: 'v' }).url).includes('msd'), false)
+	})
+
+	it('reproduces 8.2.2: five interval reports', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1764752370000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'session-id-123', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: [...KEYS_8_2_2] }] })
+		await runExample822(context, session, session.createReporter({ cid: 'content-id-123' }))
+		deepEqual(mock.bodies(), EX_8_2_2.map(fromZero))
+	})
+
+	it('reproduces 8.3: the first three reports of 8.2.2 in one batch', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1764752370000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'session-id-123', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: [...KEYS_8_2_2], batchSize: 3 }] })
+		await runExample822(context, session, session.createReporter({ cid: 'content-id-123' }))
+		equal(mock.bodies()[0], EX_8_2_2.slice(0, 3).map(fromZero).join('\n'))
+	})
+
+	it('reproduces 8.2.5: bs while rebuffering and bsd on recovery', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'session-id-123', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['bs', 'bsd', 'cid', 'sid', 'sta'], interval: 0 }] })
+		const reporter = session.createReporter({ cid: 'content-id-123' })
+		reporter.update({ sta: 'r', ts: 1764269150889 })
+		reporter.update({ sta: 'p', ts: 1764269152389 })
+		await flushPromises()
+		deepEqual(mock.bodies(), EX_8_2_5)
+	})
+
+	it('keeps bs set during a stall and once after recovery, per destination', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['bs', 'sid', 'sta'], interval: 1 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p' })
+		reporter.update({ sta: 'r' })
+		context.mock.timers.tick(1000)
+		context.mock.timers.tick(1000)
+		reporter.update({ sta: 'p' })
+		context.mock.timers.tick(1000)
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			'bs,e=t,sid="s",sta=r,ts=2000,v=2',
+			'bs,e=t,sid="s",sta=r,ts=3000,v=2',
+			'bs,e=t,sid="s",sta=p,ts=4000,v=2',
+			'e=t,sid="s",sta=p,ts=5000,v=2',
+		])
+		session.dispose()
+	})
+
+	it('reports one stall per bsd entry, one per cause per report, in order', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['bsa', 'bsd', 'bsda', 'sid'], interval: 1 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1000 })
+		reporter.update({ sta: 'r', ts: 1000 })
+		reporter.update({ sta: 'p', ts: 1300 })
+		reporter.update({ sta: 'r', ts: 1400 })
+		reporter.update({ sta: 'p', ts: 2100 })
+		context.mock.timers.tick(1000)
+		context.mock.timers.tick(1000)
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			'bsa=(2),bsd=(300),bsda=(1000),e=t,sid="s",ts=2000,v=2',
+			'bsa=(2),bsd=(700),bsda=(1000),e=t,sid="s",ts=3000,v=2',
+			'bsa=(2),bsda=(1000),e=t,sid="s",ts=4000,v=2',
+		])
+		session.dispose()
+	})
+
+	it('treats a supplied bsd as pending samples per cause and stops automatic detection', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['bsd', 'sid'], interval: 1 }] })
+		const reporter = session.createReporter()
+		reporter.update({ bsd: { v: 100, a: 50 } })
+		reporter.update({ bsd: { v: 200 } })
+		reporter.update({ sta: 'r', ts: 1000 })
+		reporter.update({ sta: 'p', ts: 1900 })
+		context.mock.timers.tick(1000)
+		context.mock.timers.tick(1000)
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			'bsd=(100;v 50;a),e=t,sid="s",ts=2000,v=2',
+			'bsd=(200;v),e=t,sid="s",ts=3000,v=2',
+			'e=t,sid="s",ts=4000,v=2',
+		])
+		session.dispose()
+	})
+
+	it('caps the pending samples at 100 per cause', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['bsd', 'sid'], interval: 1 }] })
+		const reporter = session.createReporter()
+		let ts = 1000
+		for (let i = 1; i <= 101; i++) {
+			reporter.update({ sta: 'r', ts })
+			ts += i * 10
+			reporter.update({ sta: 'p', ts })
+		}
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(mock.bodies()[0], 'bsd=(20),e=t,sid="s",ts=2000,v=2')
+		session.dispose()
+	})
+
+	it('keeps no samples when no destination can report bsd', () => {
+		const session = createCmcdSession({ sid: 's', version: 1 })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'r', ts: 1000 })
+		reporter.update({ sta: 'p', ts: 1500 })
+		session.configure({ version: 2, keys: ['bsd', 'sid'] })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'sid="s",v=2')
+	})
+
+	it('derives dl from bl and pr, and the derive switches turn su and dl off', () => {
+		const session = createCmcdSession({ sid: 's', keys: ['dl', 'sid', 'su'] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 's', bl: 3250, pr: 1 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'dl=3300,sid="s",su,v=2')
+		reporter.update({ sta: 'p', bl: 3200, pr: 2 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'dl=1600,sid="s",v=2')
+		reporter.update({ dl: 500 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'dl=500,sid="s",v=2')
+
+		const off = createCmcdSession({ sid: 's', keys: ['dl', 'sid', 'su'], derive: { dl: false, su: false } })
+		const quiet = off.createReporter()
+		quiet.update({ sta: 's', bl: 3200 })
+		equal(queryValue(quiet.decorate({ url: `${CDN}/a` }).url), 'sid="s",v=2')
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.derived.test.ts`
+Expected: FAIL on `msd`, `bs`, `bsd`, and `su`. The `dl` assertions may already pass.
+
+- [ ] **Step 3: Write the transition tracking**
+
+```ts
+// libs/cmcd/src/trackTransition.ts
+import { getTargetEntry } from './getTargetEntry.ts'
+import { addSpan } from './pruneSpans.ts'
+import type { ReporterState } from './ReporterState.ts'
+import type { SessionState } from './SessionState.ts'
+
+/**
+ * The effects of a `sta` transition, per the design record's transition table. Runs before the state-change diff,
+ * so the `ps` report carries what the transition derived.
+ */
+export function trackTransition(session: SessionState, reporter: ReporterState, previous: unknown, next: unknown, ts: number): void {
+	const sidState = session.current
+	if (next === 's' && sidState.msdStart === undefined) {
+		sidState.msdStart = ts
+	}
+	if (next === 'p' && sidState.msdStart !== undefined && sidState.msd === undefined && !sidState.msdSupplied) {
+		sidState.msd = Math.max(0, ts - sidState.msdStart)
+	}
+	if (next === 'r') {
+		reporter.spanOpenedAt = ts
+		if (sidState.bsaSupplied === undefined) {
+			sidState.bsa += 1
+		}
+		for (const target of [sidState.requestTarget, ...sidState.eventTargets]) {
+			getTargetEntry(target, reporter).bs = true
+		}
+	}
+	if (previous === 'r' && next !== 'r' && reporter.spanOpenedAt !== undefined) {
+		const duration = Math.max(0, ts - reporter.spanOpenedAt)
+		reporter.spanOpenedAt = undefined
+		if (sidState.bsdaSupplied === undefined) {
+			sidState.bsda += duration
+		}
+		if (!sidState.bsdSupplied) {
+			addSpan(session, sidState, '', duration)
+		}
+	}
+	if (next === 's' || next === 'k' || next === 'r') {
+		reporter.su = true
+	}
+	else if (next === 'p') {
+		reporter.su = false
+	}
+}
+```
+
+In `libs/cmcd/src/createSessionReporter.ts`, import `trackTransition` and replace `update`:
+
+```ts
+		update(data) {
+			if (reporter.disposed || state.disposed) {
+				return
+			}
+			const previous = reporter.store['sta']
+			const ts = mergeUpdate(state, reporter, data)
+			const next = reporter.store['sta']
+			if (data.sta !== undefined && next !== previous) {
+				trackTransition(state, reporter, previous, next, ts)
+			}
+			deriveStateEvents(state, reporter, ts)
+		},
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.derived.test.ts libs/cmcd/test/CmcdSessionReporter.events.test.ts libs/cmcd/test/CmcdSessionReporter.request.test.ts && npm run typecheck`
+Expected: PASS. If 8.2.2 line 3 lacks `bs`, check that `emitReport` clears the flag only when `store.sta` is not `r`. If it shows `bsd=(720 720;v)`, the supplied `bsd` did not stop automatic detection: `bsdSupplied` must be set in `writeSessionFact`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): derive msd, bs, bsa, bsda, bsd, and su from the play state in the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Host and background derivation
+
+**Files:**
+- Create: `libs/cmcd/src/observeVisibility.ts`, `libs/cmcd/src/emitBackgroundChange.ts`
+- Modify: `libs/cmcd/src/emitEvent.ts`, `libs/cmcd/src/deriveStateEvents.ts`, `libs/cmcd/src/createSessionReporter.ts`, `libs/cmcd/src/createCmcdSession.ts`
+- Test: `libs/cmcd/test/CmcdSessionReporter.derived.test.ts` (new `describe` block)
+
+**Interfaces:**
+- Produces: `emitBackgroundChange(session, ts)`, `observeVisibility(onChange): (() => void) | undefined`. `emitEvent()` now accepts `reporter: ReporterState | undefined` for session-only lines.
+
+`h` is the hostname of the decorated request URL. A change emits an `h` event and later event reports carry `h`. A pushed `h` wins and stops tracking. `bg` comes from `document.visibilityState` when `derive.bg` is on. Hidden emits `b` with `bg`, visible emits a bare `b`, one line per live reporter. A pushed `bg` wins and stops the listener. The session takes the initial visibility without emitting.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a second `describe` to `libs/cmcd/test/CmcdSessionReporter.derived.test.ts`:
+
+```ts
+type FakeDocument = { visibilityState: string; readonly listeners: Set<() => void>; addEventListener(type: string, listener: () => void): void; removeEventListener(type: string, listener: () => void): void }
+
+function installDocument(context: TestContext, visibilityState: string): FakeDocument {
+	const fake: FakeDocument = {
+		visibilityState,
+		listeners: new Set(),
+		addEventListener: (_type, listener) => fake.listeners.add(listener),
+		removeEventListener: (_type, listener) => fake.listeners.delete(listener),
+	}
+	const globals = globalThis as { document?: unknown }
+	globals.document = fake
+	context.after(() => {
+		delete globals.document
+	})
+	return fake
+}
+
+describe('CmcdSessionReporter host and background', () => {
+	it('emits h when the request host changes, and event reports carry h', async (context) => {
+		context.mock.timers.enable({ apis: ['Date'], now: 1000 })
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['h', 'ps'], keys: ['h', 'sid'], interval: 0 }] })
+		const reporter = session.createReporter()
+		reporter.decorate({ url: 'https://a.example.com/seg-1.m4s' })
+		reporter.decorate({ url: 'https://a.example.com/seg-2.m4s' })
+		reporter.decorate({ url: 'https://b.example.com/seg-3.m4s' })
+		reporter.update({ sta: 'p', ts: 5 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			'e=h,h="a.example.com",sid="s",ts=1000,v=2',
+			'e=h,h="b.example.com",sid="s",ts=1000,v=2',
+			'e=ps,h="b.example.com",sid="s",sta=p,ts=5,v=2',
+		])
+		equal(queryValue(reporter.decorate({ url: 'https://b.example.com/seg-4.m4s' }).url).includes('h='), false)
+	})
+
+	it('a pushed h wins and stops tracking', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['h', 'ps'], keys: ['h', 'sid'], interval: 0 }] })
+		const reporter = session.createReporter()
+		reporter.update({ h: 'cdn.example' })
+		reporter.decorate({ url: 'https://a.example.com/seg-1.m4s' })
+		reporter.update({ sta: 'p', ts: 5 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=ps,h="cdn.example",sid="s",sta=p,ts=5,v=2'])
+	})
+
+	it('derives bg from document visibility, one b line per reporter', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1000 })
+		const fake = installDocument(context, 'visible')
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['b', 't'], keys: ['bg', 'cid', 'sid'], interval: 1 }] })
+		session.createReporter({ cid: 'a' })
+		session.createReporter({ cid: 'b' })
+		equal(fake.listeners.size, 1)
+		fake.visibilityState = 'hidden'
+		fake.listeners.forEach(listener => listener())
+		context.mock.timers.tick(1000)
+		fake.visibilityState = 'visible'
+		fake.listeners.forEach(listener => listener())
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			'bg,cid="a",e=b,sid="s",ts=1000,v=2',
+			'bg,cid="b",e=b,sid="s",ts=1000,v=2',
+			'bg,cid="a",e=t,sid="s",ts=2000,v=2',
+			'bg,cid="b",e=t,sid="s",ts=2000,v=2',
+			'cid="a",e=b,sid="s",ts=2000,v=2',
+			'cid="b",e=b,sid="s",ts=2000,v=2',
+			'cid="a",e=t,sid="s",ts=3000,v=2',
+			'cid="b",e=t,sid="s",ts=3000,v=2',
+		])
+		session.dispose()
+		equal(fake.listeners.size, 0)
+	})
+
+	it('takes the initial visibility without emitting, and a pushed bg stops the listener', async (context) => {
+		context.mock.timers.enable({ apis: ['Date'], now: 1000 })
+		const fake = installDocument(context, 'hidden')
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['b', 'ps'], keys: ['bg', 'sid'], interval: 0 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1 })
+		reporter.update({ bg: false, ts: 2 })
+		equal(fake.listeners.size, 0)
+		fake.visibilityState = 'visible'
+		await flushPromises()
+		deepEqual(mock.bodies(), ['bg,e=ps,sid="s",sta=p,ts=1,v=2', 'e=b,sid="s",ts=2,v=2'])
+	})
+
+	it('installs no listener with derive.bg off', (context) => {
+		const fake = installDocument(context, 'visible')
+		const session = createCmcdSession({ sid: 's', derive: { bg: false } })
+		equal(fake.listeners.size, 0)
+		session.dispose()
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.derived.test.ts`
+Expected: FAIL, no `h` and no `b` lines.
+
+- [ ] **Step 3: Write the visibility observer and the background event**
+
+```ts
+// libs/cmcd/src/observeVisibility.ts
+/**
+ * Listens to `visibilitychange` when a document exists. Returns the function that removes the listener,
+ * or `undefined` outside a document. Does not call `onChange` for the initial state.
+ */
+export function observeVisibility(onChange: (hidden: boolean) => void): (() => void) | undefined {
+	if (typeof document === 'undefined' || typeof document.addEventListener !== 'function') {
+		return undefined
+	}
+	const listener = (): void => onChange(document.visibilityState === 'hidden')
+	document.addEventListener('visibilitychange', listener)
+	return () => document.removeEventListener('visibilitychange', listener)
+}
+```
+
+```ts
+// libs/cmcd/src/emitBackgroundChange.ts
+import { CMCD_EVENT_BACKGROUNDED_MODE } from './CmcdEventType.ts'
+import { emitEvent } from './emitEvent.ts'
+import type { SessionState } from './SessionState.ts'
+
+/** Emits `b` for every live reporter when the session `bg` differs from the last reported value of the current `sid`. */
+export function emitBackgroundChange(session: SessionState, ts: number): void {
+	const sidState = session.current
+	if (session.bg === sidState.bgReported) {
+		return
+	}
+	sidState.bgReported = session.bg
+	const reporters = session.reporters.size > 0 ? [...session.reporters] : [undefined]
+	let failure: unknown
+	let failed = false
+	for (const reporter of reporters) {
+		try {
+			emitEvent(session, reporter, CMCD_EVENT_BACKGROUNDED_MODE, undefined, undefined, ts)
+		}
+		catch (error) {
+			if (!failed) {
+				failed = true
+				failure = error
+			}
+		}
+	}
+	if (failed) {
+		throw failure
+	}
+}
+```
+
+In `libs/cmcd/src/emitEvent.ts`, change the parameter to `reporter: ReporterState | undefined`. Nothing else changes, because `assembleReport` and `emitReport` accept `undefined`.
+
+In `libs/cmcd/src/deriveStateEvents.ts`, import `emitBackgroundChange` and insert `emitBackgroundChange(session, ts)` between the `cid` block and the `br` block.
+
+- [ ] **Step 4: Wire the host and the listener**
+
+In `libs/cmcd/src/createSessionReporter.ts`, import `CMCD_EVENT_HOSTNAME` from `./CmcdEventType.ts` and add above `createSessionReporter`:
+
+```ts
+function hostOf(url: string): string | undefined {
+	try {
+		return new URL(url).hostname || undefined
+	}
+	catch {
+		return undefined
+	}
+}
+```
+
+In `decorate`, after `const origin: RequestOrigin = ...` insert:
+
+```ts
+			let hostChanged = false
+			if (!reporter.hSupplied) {
+				const host = hostOf(request.url)
+				if (host !== undefined && host !== reporter.host) {
+					reporter.host = host
+					hostChanged = true
+				}
+			}
+```
+
+and before `return finish(request, placed, record)` insert:
+
+```ts
+			if (hostChanged) {
+				emitEvent(state, reporter, CMCD_EVENT_HOSTNAME, undefined, undefined, origin.startedAt)
+			}
+```
+
+In `libs/cmcd/src/createCmcdSession.ts`, import `observeVisibility` and `emitBackgroundChange`, and insert before `armTimers(state)`:
+
+```ts
+	if (normalized.derive.bg) {
+		state.stopVisibility = observeVisibility((hidden) => {
+			if (state.disposed || state.bgSupplied) {
+				return
+			}
+			state.bg = hidden ? true : undefined
+			emitBackgroundChange(state, Date.now())
+		})
+		if (state.stopVisibility && document.visibilityState === 'hidden') {
+			state.bg = true
+			state.current.bgReported = true
+		}
+	}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.derived.test.ts libs/cmcd/test/CmcdSessionReporter.events.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): derive h from the request host and bg from document visibility in the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Responses and request origins
+
+**Files:**
+- Create: `libs/cmcd/src/readHeader.ts`, `libs/cmcd/src/toResponseKeys.ts`, `libs/cmcd/src/emitResponse.ts`
+- Modify: `libs/cmcd/src/RequestOrigin.ts`, `libs/cmcd/src/assembleReport.ts`, `libs/cmcd/src/createSessionReporter.ts`
+- Test: `libs/cmcd/test/CmcdSessionReporter.responses.test.ts`
+
+**Interfaces:**
+- Produces: `toResponseKeys(request, info, origin)`, `emitResponse(session, origin, request, info, data)`, `readHeader(headers, name)`. `assembleReport()` gains an optional last parameter `store?: Record<string, unknown>` that replaces the reporter's store. `RequestOrigin.startedAt` becomes `number | undefined`.
+
+`recordResponse()` looks the request's `cmcd` record up in the origin map. With an origin, the `rr` report uses the issuing `sid` state and the origin reporter's store, or its snapshot when that state has ended. It then merges the `cid` at decoration, the copied per-request data, the derived response keys, and the call's data. Without an origin, it uses the calling reporter and the current `sid`. An ended `sid` state sends at once.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSessionReporter.responses.test.ts
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal } from 'node:assert'
+import { describe, it } from 'node:test'
+import { EX_8_2_3 } from './data/CTA_5004_B_EXAMPLES.ts'
+import { createMockRequester, flushPromises } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const CDN = 'https://cdn.example.com'
+const CMSD_STATIC = atob('c2lkPSI5YTNiLTIxY2QiO2JyPTQ1MDA7ZD00MDAwO290PXY7c3Q9dg==')
+const CMSD_DYNAMIC = atob('ZXRwPTEyNTAwO3J0dD0zNTttYj02MDAwO3JkPTIwMA==')
+
+function harness(sid: string, cid: string, keys: string[]) {
+	const mock = createMockRequester()
+	const session = createCmcdSession({ sid, requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['rr'], keys: keys as never, interval: 0 }] })
+	return { mock, session, reporter: session.createReporter({ cid }) }
+}
+
+describe('CmcdSessionReporter responses', () => {
+	it('reproduces 8.2.3 from the decorated request, the headers, and the timing', async () => {
+		const { mock, reporter } = harness('session1', 'bbb', ['cid', 'cmsdd', 'cmsds', 'nor', 'ot', 'rc', 'sid', 'ttfb', 'ttlb', 'url'])
+		const req = reporter.decorate({ url: `${CDN}/index.mpd` }, { ot: 'v', nor: `${CDN}/video/segment-6.m4v` })
+		reporter.recordResponse(req, {
+			status: 200,
+			headers: { 'CMSD-Static': CMSD_STATIC, 'cmsd-dynamic': CMSD_DYNAMIC },
+			timing: { startTime: 1000, responseStart: 1180, responseEnd: 1200 },
+		}, { ts: 1763657019723, url: 'video/segment-5.m4v' })
+		await flushPromises()
+		deepEqual(mock.bodies(), [EX_8_2_3])
+	})
+
+	it('derives url, rc, ts, and ttlb without timing, and reads a Headers object', async (context) => {
+		context.mock.timers.enable({ apis: ['Date'], now: 1000 })
+		const { mock, reporter } = harness('s', 'c', ['cmsds', 'rc', 'sid', 'ttlb', 'url'])
+		const req = reporter.decorate({ url: `${CDN}/seg.m4s?a=1` })
+		context.mock.timers.setTime(1250)
+		const body = await new Response('', { headers: { 'CMSD-Static': 'ot=v' } }).arrayBuffer()
+		equal(body.byteLength, 0)
+		reporter.recordResponse(req, { status: 206, headers: new Headers({ 'CMSD-Static': 'ot=v' }) })
+		await flushPromises()
+		deepEqual(mock.bodies(), [`cmsds="${btoa('ot=v')}",e=rr,rc=206,sid="s",ts=1000,ttlb=250,url="${CDN}/seg.m4s?a=1",v=2`])
+	})
+
+	it('omits unavailable timing values', async () => {
+		const { mock, reporter } = harness('s', 'c', ['rc', 'sid', 'ttfb', 'ttlb', 'url'])
+		const req = reporter.decorate({ url: `${CDN}/seg.m4s` })
+		reporter.recordResponse(req, { status: 200, timing: { startTime: 5000, responseStart: 0, responseEnd: 5100 } }, { ts: 7 })
+		reporter.recordResponse(req, { status: 200, timing: { startTime: 5000, responseStart: 0, responseEnd: 4000, duration: 0 } }, { ts: 8 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [
+			`e=rr,rc=200,sid="s",ts=7,ttlb=100,url="${CDN}/seg.m4s",v=2`,
+			`e=rr,rc=200,sid="s",ts=8,url="${CDN}/seg.m4s",v=2`,
+		])
+	})
+
+	it('reports a URL-only response under the calling reporter, without the CMCD parameter', async (context) => {
+		context.mock.timers.enable({ apis: ['Date'], now: 1000 })
+		const { mock, reporter } = harness('s', 'c', ['cid', 'rc', 'sid', 'url'])
+		reporter.recordResponse({ url: `${CDN}/x?CMCD=abc&y=2` }, { status: 404 })
+		await flushPromises()
+		deepEqual(mock.bodies(), [`cid="c",e=rr,rc=404,sid="s",ts=1000,url="${CDN}/x?y=2",v=2`])
+	})
+
+	it('attributes a spread copy, uses the cid at decoration, and falls back after a JSON round trip', async () => {
+		const { mock, reporter } = harness('s', 'first', ['cid', 'rc', 'sid'])
+		const req = reporter.decorate({ url: `${CDN}/seg.m4s` })
+		reporter.update({ cid: 'second' })
+		reporter.recordResponse({ ...req }, { status: 200 }, { ts: 1 })
+		reporter.recordResponse(JSON.parse(JSON.stringify(req)), { status: 200 }, { ts: 2 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['cid="first",e=rr,rc=200,sid="s",ts=1,v=2', 'cid="second",e=rr,rc=200,sid="s",ts=2,v=2'])
+	})
+
+	it('accepts the response overrides and reports after the reporter is disposed', async () => {
+		const { mock, reporter } = harness('s', 'c', ['rc', 'sid', 'smrt', 'ttfb', 'ttfbb', 'ttlb'])
+		const req = reporter.decorate({ url: `${CDN}/seg.m4s` })
+		reporter.dispose()
+		reporter.recordResponse(req, { status: 200 }, { ts: 3, ttfb: 5, ttfbb: 12, ttlb: 40, smrt: 'abc' })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=rr,rc=200,sid="s",smrt="abc",ts=3,ttfb=5,ttfbb=12,ttlb=40,v=2'])
+	})
+
+	it('does not change a late report when the player mutates its per-request data object', async () => {
+		const { mock, reporter } = harness('s', 'c', ['br', 'ot', 'rc', 'sid'])
+		const data = { ot: 'v' as const, br: { v: 3000 } }
+		const req = reporter.decorate({ url: `${CDN}/seg.m4s` }, data)
+		data.br.v = 1
+		reporter.recordResponse(req, { status: 200 }, { ts: 1 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['br=(3000;v),e=rr,ot=v,rc=200,sid="s",ts=1,v=2'])
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.responses.test.ts`
+Expected: FAIL, no `rr` body.
+
+- [ ] **Step 3: Write the response derivations**
+
+In `libs/cmcd/src/RequestOrigin.ts`, change `startedAt` to `readonly startedAt: number | undefined`.
+
+```ts
+// libs/cmcd/src/readHeader.ts
+/** One response header by name, case-insensitively, from a `Headers` object or a record. */
+export function readHeader(headers: Headers | Readonly<Record<string, string>> | undefined, name: string): string | undefined {
+	if (!headers) {
+		return undefined
+	}
+	if (typeof (headers as Headers).get === 'function') {
+		return (headers as Headers).get(name) ?? undefined
+	}
+	const wanted = name.toLowerCase()
+	for (const [key, value] of Object.entries(headers as Record<string, string>)) {
+		if (key.toLowerCase() === wanted) {
+			return value
+		}
+	}
+	return undefined
+}
+```
+
+```ts
+// libs/cmcd/src/toResponseKeys.ts
+import { encodeBase64 } from '@svta/cml-utils'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import type { CmcdResponseInfo } from './CmcdResponseInfo.ts'
+import { removeCmcdQuery } from './placeRequestReport.ts'
+import { readHeader } from './readHeader.ts'
+import type { RequestOrigin } from './RequestOrigin.ts'
+
+function toBase64(text: string): string {
+	return encodeBase64(new TextEncoder().encode(text))
+}
+
+/**
+ * The derived `rr` keys: `url` without the CMCD parameter, `rc`, and when known `ts`, `ttfb`, `ttlb`, `cmsds`, and `cmsdd`.
+ * Resource Timing reports zero for `responseStart` of a cross-origin resource without `Timing-Allow-Origin`, so `ttfb` is
+ * omitted when `responseStart` is absent, zero, or earlier than `startTime`. Without timing, `ttlb` measures the call.
+ */
+export function toResponseKeys(request: CmcdRequestLike, info: CmcdResponseInfo, origin: RequestOrigin | undefined): Record<string, unknown> {
+	const keys: Record<string, unknown> = { url: removeCmcdQuery(request.url), rc: info.status ?? 0 }
+	const timing = info.timing
+	if (timing && typeof timing.startTime === 'number') {
+		keys['ts'] = Math.round(performance.timeOrigin + timing.startTime)
+		if (typeof timing.responseStart === 'number' && timing.responseStart > 0 && timing.responseStart >= timing.startTime) {
+			keys['ttfb'] = Math.round(timing.responseStart - timing.startTime)
+		}
+		if (typeof timing.duration === 'number' && timing.duration > 0) {
+			keys['ttlb'] = Math.round(timing.duration)
+		}
+		else if (typeof timing.responseEnd === 'number' && timing.responseEnd > timing.startTime) {
+			keys['ttlb'] = Math.round(timing.responseEnd - timing.startTime)
+		}
+	}
+	else if (origin?.startedAt !== undefined) {
+		keys['ts'] = origin.startedAt
+		keys['ttlb'] = Math.max(0, Date.now() - origin.startedAt)
+	}
+	const cmsds = readHeader(info.headers, 'CMSD-Static')
+	if (cmsds) {
+		keys['cmsds'] = toBase64(cmsds)
+	}
+	const cmsdd = readHeader(info.headers, 'CMSD-Dynamic')
+	if (cmsdd) {
+		keys['cmsdd'] = toBase64(cmsdd)
+	}
+	return keys
+}
+```
+
+```ts
+// libs/cmcd/src/emitResponse.ts
+import { CMCD_EVENT_RESPONSE_RECEIVED } from './CmcdEventType.ts'
+import type { CmcdRequestLike } from './CmcdRequestLike.ts'
+import type { CmcdResponseData } from './CmcdResponseData.ts'
+import type { CmcdResponseInfo } from './CmcdResponseInfo.ts'
+import { assembleReport } from './assembleReport.ts'
+import { emitReport } from './emitReport.ts'
+import { processQueue } from './processQueue.ts'
+import type { RequestOrigin } from './RequestOrigin.ts'
+import type { SessionState } from './SessionState.ts'
+import type { TargetState } from './TargetState.ts'
+import { toResponseKeys } from './toResponseKeys.ts'
+
+/**
+ * Emits `rr` to every event target of the origin `sid` state that lists it. The report merges the origin reporter's store,
+ * or the copy the ended `sid` state keeps, the `cid` at decoration, the copied per-request data, the derived keys, then `data`.
+ */
+export function emitResponse(session: SessionState, origin: RequestOrigin, request: CmcdRequestLike, info: CmcdResponseInfo, data: CmcdResponseData | undefined): void {
+	const { sidState, reporter } = origin
+	const derived = toResponseKeys(request, info, origin)
+	const perCall: Record<string, unknown> = { ...(origin.data ?? {}), ...derived, ...(data ?? {}) }
+	if (origin.cid !== undefined && data?.cid === undefined) {
+		perCall['cid'] = origin.cid
+	}
+	const ts = typeof perCall['ts'] === 'number' ? perCall['ts'] : Date.now()
+	delete perCall['ts']
+	const store = sidState.ended ? sidState.stores.get(reporter) ?? reporter.store : reporter.store
+	const targets: TargetState[] = []
+	let failure: unknown
+	let failed = false
+	for (const target of sidState.eventTargets) {
+		if (target.gone || !session.config.eventTargets[target.index].events.has(CMCD_EVENT_RESPONSE_RECEIVED)) {
+			continue
+		}
+		try {
+			const assembled = assembleReport(session, sidState, target, reporter, CMCD_EVENT_RESPONSE_RECEIVED, perCall, ts, store)
+			emitReport(session, sidState, target, reporter, assembled, CMCD_EVENT_RESPONSE_RECEIVED, request)
+			targets.push(target)
+		}
+		catch (error) {
+			if (!failed) {
+				failed = true
+				failure = error
+			}
+		}
+	}
+	for (const target of targets) {
+		processQueue(session, sidState, target, sidState.ended)
+	}
+	if (failed) {
+		throw failure
+	}
+}
+```
+
+In `libs/cmcd/src/assembleReport.ts`, add the optional last parameter and use it for the first line of the body:
+
+```ts
+export function assembleReport(session: SessionState, sidState: SidState, target: TargetState, reporter: ReporterState | undefined, event: string | undefined, data: Record<string, unknown> | undefined, ts: number, store?: Record<string, unknown>): AssembledReport {
+	const config = session.config
+	const report: Record<string, unknown> = { ...(store ?? reporter?.store ?? {}) }
+```
+
+The `data` parameter type widens to `Record<string, unknown> | undefined`, because the response path merges derived keys into it. The `CmcdPlaybackData` callers still compile.
+
+In `libs/cmcd/src/createSessionReporter.ts`, import `CMCD_REQUEST_ORIGINS` (already imported), `emitResponse`, and the `CmcdResponseData` and `CmcdResponseInfo` types. Replace `recordResponse`:
+
+```ts
+		recordResponse(request: CmcdRequestLike, info: CmcdResponseInfo, data?: CmcdResponseData) {
+			const record = (request as { cmcd?: unknown }).cmcd
+			const origin = record !== null && typeof record === 'object' ? CMCD_REQUEST_ORIGINS.get(record) : undefined
+			if (!origin && (reporter.disposed || state.disposed)) {
+				return
+			}
+			emitResponse(state, origin ?? { reporter, sidState: state.current, cid: reporter.store['cid'] as string | undefined, data: undefined, startedAt: undefined }, request, info, data)
+		},
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSessionReporter.responses.test.ts && npm run typecheck`
+Expected: PASS. If 8.2.3 differs in `nor`, the base URL of the `rr` report is the request URL, so `video/segment-6.m4v` is relative to `https://cdn.example.com/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): record responses through request origins in the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Rotation and late responses
+
+**Files:**
+- Create: `libs/cmcd/src/rotateSession.ts`
+- Modify: `libs/cmcd/src/createCmcdSession.ts`
+- Test: `libs/cmcd/test/CmcdSession.rotation.test.ts`
+
+**Interfaces:**
+- Consumes: `checkSid()`, `createSidState()`, `processQueue()`, `getTargetEntry()`, `copyPlaybackData()`.
+- Produces: `rotateSession(state, sid)`.
+
+`rotate()` follows the design record's rotate algorithm. It drains and ends the old `sid` state and copies each reporter's store onto it. It creates the new state, carries a startup measurement in progress, and resets the dedup baselines. For a reporter in `r`, it sets `bs` on the new targets and measures the stall from the rotation time. Nothing is emitted.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSession.rotation.test.ts
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal, throws } from 'node:assert'
+import { describe, it } from 'node:test'
+import { createMockRequester, flushPromises, queryValue } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const CDN = 'https://cdn.example.com'
+
+describe('CmcdSession rotation', () => {
+	it('restarts sn per target, re-arms the msd gate, resets the baselines, and emits nothing', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'a', requester: mock.requester, keys: ['msd', 'sid', 'sn'], eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['msd', 'sid', 'sn', 'sta'], interval: 0 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 's', ts: 1000 })
+		reporter.update({ sta: 'p', ts: 1200 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'msd=200,sid="a",sn=0,v=2')
+		session.rotate('b')
+		equal(session.sid, 'b')
+		await flushPromises()
+		equal(mock.requests.length, 2)
+		equal(queryValue(reporter.decorate({ url: `${CDN}/b` }).url), 'sid="b",sn=0,v=2')
+		reporter.update({ sta: 'p', ts: 1300 })
+		await flushPromises()
+		equal(mock.bodies()[2], 'e=ps,sid="b",sn=0,sta=p,ts=1300,v=2')
+		session.rotate('b')
+		equal(mock.requests.length, 3)
+		throws(() => session.rotate('x'.repeat(65)), { message: /^CmcdSession: sid must be/ })
+		session.dispose()
+	})
+
+	it('carries a startup measurement in progress', () => {
+		const session = createCmcdSession({ sid: 'a', keys: ['msd', 'sid'] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 's', ts: 1000 })
+		session.rotate('manifest-sid')
+		reporter.update({ sta: 's', ts: 1100 })
+		reporter.update({ sta: 'p', ts: 1500 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'msd=500,sid="manifest-sid",v=2')
+	})
+
+	it('drains the old queue at once and re-activates a target that a 410 silenced', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'a', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid', 'sta'], interval: 0, batchSize: 5 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1 })
+		reporter.update({ sta: 'a', ts: 2 })
+		await flushPromises()
+		equal(mock.requests.length, 0)
+		session.rotate('b')
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=ps,sid="a",sta=p,ts=1,v=2\ne=ps,sid="a",sta=a,ts=2,v=2'])
+		mock.status = 410
+		session.flush()
+		reporter.update({ sta: 'p', ts: 3 })
+		session.flush()
+		await flushPromises()
+		equal(mock.requests.length, 2)
+		mock.status = 200
+		reporter.update({ sta: 'a', ts: 4 })
+		session.flush()
+		await flushPromises()
+		equal(mock.requests.length, 2)
+		session.rotate('c')
+		reporter.update({ sta: 'p', ts: 5 })
+		session.flush()
+		await flushPromises()
+		equal(mock.bodies()[2], 'e=ps,sid="c",sta=p,ts=5,v=2')
+		session.dispose()
+	})
+
+	it('reports a late response under the old sid with the store copied at rotation', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 'a', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['rr'], keys: ['bl', 'rc', 'sid', 'sn'], interval: 0, batchSize: 5 }] })
+		const reporter = session.createReporter()
+		reporter.update({ bl: 1000 })
+		const req = reporter.decorate({ url: `${CDN}/a` })
+		session.rotate('b')
+		reporter.update({ bl: 9000 })
+		reporter.recordResponse(req, { status: 200 }, { ts: 7 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['bl=(1000),e=rr,rc=200,sid="a",sn=0,ts=7,v=2'])
+		reporter.recordResponse(reporter.decorate({ url: `${CDN}/b` }), { status: 200 }, { ts: 8 })
+		session.flush()
+		await flushPromises()
+		equal(mock.bodies()[1], 'bl=(9000),e=rr,rc=200,sid="b",sn=0,ts=8,v=2')
+		session.dispose()
+	})
+
+	it('measures a stall open at rotation from the rotation time and keeps bs set', async (context) => {
+		context.mock.timers.enable({ apis: ['Date'], now: 5000 })
+		const session = createCmcdSession({ sid: 'a', keys: ['bs', 'bsd', 'bsda', 'sid'] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1000 })
+		reporter.update({ sta: 'r', ts: 4000 })
+		session.rotate('b')
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'bs,sid="b",v=2')
+		reporter.update({ sta: 'p', ts: 5300 })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'bs,bsd=(300),bsda=(300),sid="b",v=2')
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'bsda=(300),sid="b",v=2')
+	})
+
+	it('lets an ended sid state be collected once its requests are released', async () => {
+		const v8 = await import('node:v8')
+		const vm = await import('node:vm')
+		v8.setFlagsFromString('--expose-gc')
+		const gc = vm.runInNewContext('gc') as () => void
+		const session = createCmcdSession({ sid: 'a' })
+		const reporter = session.createReporter()
+		let req: { cmcd: object } | undefined = reporter.decorate({ url: `${CDN}/a` })
+		const ref = new WeakRef(req.cmcd)
+		session.rotate('b')
+		req = undefined
+		for (let i = 0; i < 10 && ref.deref() !== undefined; i++) {
+			gc()
+			await new Promise(resolve => setTimeout(resolve, 0))
+		}
+		equal(ref.deref(), undefined)
+		session.dispose()
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.rotation.test.ts`
+Expected: FAIL on the drain, the carried `msd`, the snapshot, and the stall.
+
+- [ ] **Step 3: Write the rotation**
+
+```ts
+// libs/cmcd/src/rotateSession.ts
+import { uuid } from '@svta/cml-utils'
+import type { CmcdPlaybackData } from './CmcdPlaybackData.ts'
+import { checkSid } from './checkRequestSettings.ts'
+import { copyPlaybackData } from './copyPlaybackData.ts'
+import { createSidState } from './createSidState.ts'
+import { getTargetEntry } from './getTargetEntry.ts'
+import { processQueue } from './processQueue.ts'
+import type { SessionState } from './SessionState.ts'
+
+/**
+ * Starts the next `sid`. The old state is drained and ended, each reporter's store is copied onto it for late responses,
+ * and every counter, gate, buffer, and baseline restarts. A startup measurement in progress carries over.
+ * A reporter that is rebuffering keeps `bs` and measures the stall from now. Emits nothing.
+ */
+export function rotateSession(state: SessionState, sid: string | undefined): void {
+	if (state.disposed) {
+		return
+	}
+	const next = sid ?? uuid()
+	checkSid(next)
+	const old = state.current
+	if (next === old.sid) {
+		return
+	}
+	old.ended = true
+	for (const target of old.eventTargets) {
+		processQueue(state, old, target, true)
+	}
+	for (const reporter of state.reporters) {
+		old.stores.set(reporter, copyPlaybackData(reporter.store as CmcdPlaybackData) as Record<string, unknown>)
+	}
+	const fresh = createSidState(next, state.config)
+	if (old.msd === undefined && !old.msdSupplied && old.msdStart !== undefined) {
+		fresh.msdStart = old.msdStart
+	}
+	const now = Date.now()
+	for (const reporter of state.reporters) {
+		reporter.reported.sta = undefined
+		reporter.reported.pr = undefined
+		reporter.reported.cid = undefined
+		reporter.reported.br = undefined
+		if (reporter.store['sta'] === 'r') {
+			reporter.spanOpenedAt = now
+			for (const target of [fresh.requestTarget, ...fresh.eventTargets]) {
+				getTargetEntry(target, reporter).bs = true
+			}
+		}
+		else {
+			reporter.spanOpenedAt = undefined
+		}
+	}
+	state.current = fresh
+}
+```
+
+In `libs/cmcd/src/createCmcdSession.ts`, import `rotateSession` and replace the inline `rotate` member with `rotate: sid => rotateSession(state, sid),`. Remove the `uuid` import only if nothing else in the file uses it. The initial `sid` still uses `uuid()`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.rotation.test.ts libs/cmcd/test/CmcdSessionReporter.responses.test.ts && npm run typecheck`
+Expected: PASS. If the collectability test times out, run it alone with `node --no-warnings --expose-gc --test libs/cmcd/test/CmcdSession.rotation.test.ts` to separate a flag problem from a retained reference. A retained reference means something other than the origin map points at the record: check `finish()` in `createSessionReporter.ts` and the test's own variables.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): rotate the sid with snapshots and carried startup state in the session API" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Transforms
+
+**Files:**
+- Test: `libs/cmcd/test/CmcdSession.transforms.test.ts`
+
+**Interfaces:**
+- Consumes: `emitReport()` from Task 2, which already runs the transform, restores required keys, and re-stamps `sid`, `e`, and `ts`. `decorate()` pins the origin before the transform, and `emitEvent()` captures the `sid` state once.
+
+This task has no new source file. It verifies the transform contract of the RFC and the two pinning rules, and fixes whatever the tests find in `emitReport.ts`, `emitEvent.ts`, or `createSessionReporter.ts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSession.transforms.test.ts
+import type { Cmcd, CmcdSession } from '@svta/cml-cmcd'
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { deepEqual, equal, throws } from 'node:assert'
+import { describe, it } from 'node:test'
+import { createMockRequester, flushPromises, queryValue } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const CDN = 'https://cdn.example.com'
+
+describe('CmcdSession transforms', () => {
+	it('runs the request transform on the normalized report with the request, and cancels with null', () => {
+		const seen: Cmcd[] = []
+		const session = createCmcdSession({
+			sid: 's',
+			keys: ['br', 'sid', 'com.example-x'],
+			transform: (data, request) => {
+				seen.push(data)
+				return request.url.endsWith('skip') ? null : { ...data, 'com.example-x': 'y' }
+			},
+		})
+		const reporter = session.createReporter()
+		const req = reporter.decorate({ url: `${CDN}/a` }, { br: { v: 3000 } })
+		equal(queryValue(req.url), 'br=(3000;v),com.example-x="y",sid="s",v=2')
+		equal(Array.isArray(seen[0].br), true)
+		const skipped = reporter.decorate({ url: `${CDN}/skip` })
+		equal(skipped.url, `${CDN}/skip`)
+		deepEqual(skipped.cmcd, { sid: 's', data: {} })
+		equal(queryValue(reporter.decorate({ url: `${CDN}/b` }).url), 'com.example-x="y",sid="s",v=2')
+	})
+
+	it('cancels one event target only, restores required keys, and re-stamps sid, e, and ts', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [
+			{ url: `${COLLECTOR}/1`, events: ['ps'], keys: ['sid', 'sta'], interval: 0, transform: () => null },
+			{ url: `${COLLECTOR}/2`, events: ['ps'], keys: ['sid', 'sta'], interval: 0, transform: (data) => {
+				const copy = { ...data, sid: 'forged', e: 't', ts: 1 } as Cmcd
+				delete copy.sta
+				return copy
+			} },
+			{ url: `${COLLECTOR}/3`, events: ['ps'], keys: ['sid', 'sta'], interval: 0 },
+		] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 5 })
+		await flushPromises()
+		deepEqual(mock.requests.map(request => request.url), [`${COLLECTOR}/2`, `${COLLECTOR}/3`])
+		deepEqual(mock.bodies(), ['e=ps,sid="s",sta=p,ts=5,v=2', 'e=ps,sid="s",sta=p,ts=5,v=2'])
+	})
+
+	it('gives an rr transform the decorated request and other events undefined', async () => {
+		const mock = createMockRequester()
+		const urls: (string | undefined)[] = []
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['rr', 'ps'], keys: ['sid'], interval: 0, transform: (data, request) => {
+			urls.push(request?.url)
+			return data
+		} }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p' })
+		const req = reporter.decorate({ url: `${CDN}/a` })
+		reporter.recordResponse(req, { status: 200 })
+		await flushPromises()
+		deepEqual(urls, [undefined, req.url])
+	})
+
+	it('opts in to bg=?0 on the exit b report through a transform', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['b'], keys: ['bg', 'sid'], interval: 0, transform: (data) => data.e === 'b' && !('bg' in data) ? { ...data, bg: false } : data }] })
+		const reporter = session.createReporter()
+		reporter.update({ bg: true, ts: 1 })
+		reporter.update({ bg: false, ts: 2 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['bg,e=b,sid="s",ts=1,v=2', 'bg=?0,e=b,sid="s",ts=2,v=2'])
+	})
+
+	it('keeps the request and the remaining targets on the old sid when a transform rotates', async () => {
+		const mock = createMockRequester()
+		let session: CmcdSession | undefined
+		session = createCmcdSession({ sid: 'a', requester: mock.requester, keys: ['sid'], transform: (data) => {
+			session?.rotate('b')
+			return data
+		}, eventTargets: [
+			{ url: `${COLLECTOR}/1`, events: ['ps', 'rr'], keys: ['sid'], interval: 0, transform: (data) => {
+				session?.rotate('c')
+				return data
+			} },
+			{ url: `${COLLECTOR}/2`, events: ['ps', 'rr'], keys: ['sid'], interval: 0 },
+		] })
+		const reporter = session.createReporter()
+		const req = reporter.decorate({ url: `${CDN}/a` })
+		equal(req.cmcd.sid, 'a')
+		equal(queryValue(req.url), 'sid="a",v=2')
+		equal(session.sid, 'b')
+		reporter.update({ sta: 'p', ts: 1 })
+		reporter.recordResponse(req, { status: 200 }, { ts: 2 })
+		await flushPromises()
+		deepEqual(mock.bodies(), ['e=ps,sid="b",ts=1,v=2', 'e=ps,sid="b",ts=1,v=2', 'e=rr,rc=200,sid="a",ts=2,v=2'.replace('rc=200,', ''), 'e=rr,sid="a",ts=2,v=2'])
+		equal(session.sid, 'c')
+		session.dispose()
+	})
+
+	it('rethrows a throwing transform after the other targets ran', async () => {
+		const mock = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: mock.requester, eventTargets: [
+			{ url: `${COLLECTOR}/1`, events: ['ps'], keys: ['sid'], interval: 0, transform: () => {
+				throw new Error('boom')
+			} },
+			{ url: `${COLLECTOR}/2`, events: ['ps'], keys: ['sid'], interval: 0 },
+		] })
+		const reporter = session.createReporter()
+		throws(() => reporter.update({ sta: 'p', ts: 1 }), { message: /boom/ })
+		await flushPromises()
+		deepEqual(mock.requests.map(request => request.url), [`${COLLECTOR}/2`])
+	})
+})
+```
+
+In the rotation test above, the `rr` bodies have no `rc` because the target keys are `['sid']`. Write the expected array plainly as `['e=ps,sid="b",ts=1,v=2', 'e=ps,sid="b",ts=1,v=2', 'e=rr,sid="a",ts=2,v=2', 'e=rr,sid="a",ts=2,v=2']`.
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.transforms.test.ts`
+Expected: most tests PASS already. Fix any failure in the file the assertion points at, with this guidance:
+
+- A forged `sid`, `e`, or `ts` that survives means the re-stamp in `emitReport` runs before `normalizeReport(result)` instead of after. Keep the order: normalize the result, restore required keys, then re-stamp.
+- A missing `bg=?0` means `normalizeValue` dropped `false` for a boolean. It must return the boolean as is and leave the omission to `filterReport`.
+- A request that lands on `sid` b after the transform rotated means `decorate()` read `state.current` after `emitReport`. It must use the `sidState` captured in the origin for the target, the record, and the origin map.
+- Only one `ps` body under `sid` b would mean `emitEvent()` read `session.current` per target instead of once.
+
+- [ ] **Step 3: Run the whole suite and commit**
+
+Run: `npm run build -w libs/cmcd && npm test -w libs/cmcd && npm run typecheck`
+Expected: PASS.
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "test(cmcd): cover the session API transform contract and origin pinning" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: The delivery state machine
+
+**Files:**
+- Test: `libs/cmcd/test/CmcdSession.delivery.test.ts` (new `describe` block)
+
+**Interfaces:**
+- Consumes: `processQueue()` from Task 4. Fix that file when a test fails.
+
+The rules under test: a 410 silences the target for the rest of the `sid`. A 429, a 5xx, or a rejection puts the batch back. The retry waits 1, 2, 4, 8, 16, 32, then 60 seconds, and it drains everything queued since. Another 4xx drops the batch. The queue keeps the newest `maxQueueSize` lines. A drain requested while a send is in flight is honored when the send settles. After the `sid` state has ended, the failure after the 60 second wait stops the retries and goes to `onError`. The default requester posts through `fetch` with `keepalive`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/cmcd/test/CmcdSession.delivery.test.ts`. Add `mock` and the type `TestContext` to the `node:test` import, and `HttpRequest` as a type import from `@svta/cml-utils`.
+
+```ts
+describe('CmcdSession delivery state machine', () => {
+	async function twoLines(status: number, context: TestContext) {
+		context.mock.timers.enable({ apis: ['Date', 'setTimeout', 'setInterval'], now: 1000 })
+		const requester = createMockRequester(status)
+		const session = createCmcdSession({ sid: 's', requester: requester.requester, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid', 'sta'], interval: 0 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1 })
+		await flushPromises()
+		reporter.update({ sta: 'a', ts: 2 })
+		await flushPromises()
+		return { requester, session, reporter }
+	}
+
+	it('silences a target for the rest of the sid after a 410', async (context) => {
+		const { requester, session } = await twoLines(410, context)
+		equal(requester.requests.length, 1)
+		requester.status = 200
+		session.flush()
+		await flushPromises()
+		equal(requester.requests.length, 1)
+		session.dispose()
+	})
+
+	it('backs off after a 429 and aggregates the lines queued during the wait', async (context) => {
+		const { requester, session } = await twoLines(429, context)
+		deepEqual(requester.bodies(), ['e=ps,sid="s",sta=p,ts=1,v=2'])
+		context.mock.timers.tick(999)
+		await flushPromises()
+		equal(requester.requests.length, 1)
+		context.mock.timers.tick(1)
+		await flushPromises()
+		equal(requester.bodies()[1], 'e=ps,sid="s",sta=p,ts=1,v=2\ne=ps,sid="s",sta=a,ts=2,v=2')
+		requester.status = 200
+		context.mock.timers.tick(1999)
+		await flushPromises()
+		equal(requester.requests.length, 2)
+		context.mock.timers.tick(1)
+		await flushPromises()
+		equal(requester.requests.length, 3)
+		equal(requester.bodies()[2], requester.bodies()[1])
+		session.dispose()
+	})
+
+	it('retries a 5xx and a rejection, and drops the batch on another 4xx', async (context) => {
+		const { requester, session } = await twoLines(503, context)
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(requester.requests.length, 2)
+		session.dispose()
+
+		let attempts = 0
+		const rejecting = createCmcdSession({ sid: 'r', requester: () => {
+			attempts += 1
+			return Promise.reject(new Error('offline'))
+		}, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid'], interval: 0 }] })
+		rejecting.createReporter().update({ sta: 'p', ts: 1 })
+		await flushPromises()
+		equal(attempts, 1)
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(attempts, 2)
+		rejecting.dispose()
+
+		const dropping = createMockRequester(400)
+		const other = createCmcdSession({ sid: 'd', requester: dropping.requester, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid', 'sta'], interval: 0 }] })
+		const reporter = other.createReporter()
+		reporter.update({ sta: 'p', ts: 1 })
+		await flushPromises()
+		dropping.status = 200
+		reporter.update({ sta: 'a', ts: 2 })
+		await flushPromises()
+		deepEqual(dropping.bodies(), ['e=ps,sid="d",sta=p,ts=1,v=2', 'e=ps,sid="d",sta=a,ts=2,v=2'])
+		other.dispose()
+	})
+
+	it('keeps the newest maxQueueSize lines', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setTimeout', 'setInterval'], now: 1000 })
+		const requester = createMockRequester(429)
+		const session = createCmcdSession({ sid: 's', requester: requester.requester, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid', 'sta'], interval: 0, batchSize: 2, maxQueueSize: 2 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1 })
+		reporter.update({ sta: 'a', ts: 2 })
+		await flushPromises()
+		reporter.update({ sta: 'p', ts: 3 })
+		requester.status = 200
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(requester.bodies()[1], 'e=ps,sid="s",sta=a,ts=2,v=2\ne=ps,sid="s",sta=p,ts=3,v=2')
+		session.dispose()
+	})
+
+	it('honors a drain requested while a send is in flight', async () => {
+		let release: ((value: { status: number }) => void) | undefined
+		const bodies: string[] = []
+		const requester = (request: HttpRequest) => {
+			bodies.push(request.body as string)
+			return new Promise<{ status: number }>((resolve) => {
+				release = resolve
+			})
+		}
+		const session = createCmcdSession({ sid: 's', requester, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid', 'sta'], interval: 0, batchSize: 10 }] })
+		const reporter = session.createReporter()
+		reporter.update({ sta: 'p', ts: 1 })
+		session.flush()
+		reporter.update({ sta: 'a', ts: 2 })
+		reporter.update({ sta: 'p', ts: 3 })
+		session.dispose()
+		equal(bodies.length, 1)
+		release?.({ status: 200 })
+		await flushPromises()
+		deepEqual(bodies, ['e=ps,sid="s",sta=p,ts=1,v=2', 'e=ps,sid="s",sta=a,ts=2,v=2\ne=ps,sid="s",sta=p,ts=3,v=2'])
+	})
+
+	it('flush() fires an armed retry at once', async (context) => {
+		const { requester, session } = await twoLines(429, context)
+		requester.status = 200
+		session.flush()
+		await flushPromises()
+		equal(requester.requests.length, 2)
+		context.mock.timers.tick(60000)
+		await flushPromises()
+		equal(requester.requests.length, 2)
+		session.dispose()
+	})
+
+	it('stops retrying an ended sid state after the 60 second step and reports it', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setTimeout', 'setInterval'], now: 1000 })
+		const onError = mock.fn()
+		const requester = createMockRequester(503)
+		const session = createCmcdSession({ sid: 'a', requester: requester.requester, onError, eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid'], interval: 0 }] })
+		session.createReporter().update({ sta: 'p', ts: 1 })
+		await flushPromises()
+		session.rotate('b')
+		for (const wait of [1000, 2000, 4000, 8000, 16000, 32000, 60000]) {
+			context.mock.timers.tick(wait)
+			await flushPromises()
+		}
+		equal(requester.requests.length, 8)
+		equal(onError.mock.callCount(), 1)
+		const error = onError.mock.calls[0].arguments[0] as Error
+		equal(error.message, `CmcdSession: send failed for target ${COLLECTOR} after the back-off cap, status 503`)
+		context.mock.timers.tick(120000)
+		await flushPromises()
+		equal(requester.requests.length, 8)
+		session.dispose()
+	})
+
+	it('posts through fetch with keepalive by default', async (context) => {
+		const calls: { url: string; init: RequestInit }[] = []
+		context.mock.method(globalThis, 'fetch', async (url: string, init: RequestInit) => {
+			calls.push({ url, init })
+			return new Response(null, { status: 204 })
+		})
+		const session = createCmcdSession({ sid: 's', eventTargets: [{ url: COLLECTOR, events: ['ps'], keys: ['sid'], interval: 0 }] })
+		session.createReporter().update({ sta: 'p', ts: 1 })
+		await flushPromises()
+		equal(calls.length, 1)
+		equal(calls[0].url, COLLECTOR)
+		equal(calls[0].init.method, 'POST')
+		equal(calls[0].init.body, 'e=ps,sid="s",ts=1,v=2')
+		equal(calls[0].init.keepalive, true)
+		session.dispose()
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.delivery.test.ts`
+Expected: PASS for most. Fix a failure in `processQueue.ts`:
+
+- Eight requests but no `onError` call: the cap check must run after `attempt += 1` and compare with `> 7`.
+- The aggregated retry body missing the second line: the retry callback must call `processQueue(..., true)`.
+- A second POST during the in-flight test before `release`: the `sending` flag must be set before the requester is called.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "test(cmcd): cover the session API delivery state machine" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Errors and disposal
+
+**Files:**
+- Modify: `libs/cmcd/src/emitReport.ts`
+- Test: `libs/cmcd/test/CmcdSession.errors.test.ts`
+
+**Interfaces:**
+- Produces: errors from the report path are `Error` objects. The message names the stage, `transform` or `encode`, and the target. The original error is the `cause`. The send stage message was written in Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// libs/cmcd/test/CmcdSession.errors.test.ts
+import { createCmcdSession } from '@svta/cml-cmcd'
+import { SfToken } from '@svta/cml-structured-field-values'
+import { deepEqual, equal, ok, throws } from 'node:assert'
+import { describe, it, mock } from 'node:test'
+import { createMockRequester, flushPromises, queryValue } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const CDN = 'https://cdn.example.com'
+
+describe('CmcdSession errors', () => {
+	it('gives a tick error to onError with the stage and the target in the message', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setTimeout', 'setInterval'], now: 1000 })
+		const onError = mock.fn()
+		const requester = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: requester.requester, onError, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['sid'], interval: 1, transform: () => {
+			throw new Error('boom')
+		} }] })
+		session.createReporter()
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(onError.mock.callCount(), 1)
+		const error = onError.mock.calls[0].arguments[0] as Error
+		equal(error.message, `CmcdSession: transform failed for target ${COLLECTOR}: boom`)
+		equal((error.cause as Error).message, 'boom')
+		equal(requester.requests.length, 0)
+		session.dispose()
+	})
+
+	it('throws an encoder failure to the caller and commits nothing', () => {
+		const session = createCmcdSession({ sid: 's', keys: ['sid', 'sn', 'com.example-x'] })
+		const reporter = session.createReporter()
+		throws(() => reporter.decorate({ url: `${CDN}/a` }, { 'com.example-x': new SfToken('not a token') }), (error: Error) => {
+			ok(error.message.startsWith('CmcdSession: encode failed for target request:'))
+			return error.cause !== undefined
+		})
+		equal(queryValue(reporter.decorate({ url: `${CDN}/a` }).url), 'sid="s",sn=0,v=2')
+	})
+
+	it('makes every call a no-op after dispose, except createReporter which throws', async () => {
+		const requester = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: requester.requester, eventTargets: [{ url: COLLECTOR, events: ['ps', 'e', 'sk'], keys: ['sid'], interval: 0 }] })
+		const reporter = session.createReporter()
+		session.dispose()
+		reporter.update({ sta: 'p' })
+		reporter.recordEvent('sk')
+		reporter.recordError('X')
+		const req = reporter.decorate({ url: `${CDN}/a` })
+		equal(req.url, `${CDN}/a`)
+		deepEqual(req.cmcd, { sid: 's', data: {} })
+		session.rotate('b')
+		equal(session.sid, 's')
+		session.configure({ version: 1 })
+		session.flush()
+		await flushPromises()
+		equal(requester.requests.length, 0)
+		throws(() => session.createReporter(), { message: 'CmcdSession: createReporter must be a live session, received a disposed session' })
+	})
+
+	it('removes a disposed reporter from interval reports and target state', async (context) => {
+		context.mock.timers.enable({ apis: ['Date', 'setTimeout', 'setInterval'], now: 1000 })
+		const requester = createMockRequester()
+		const session = createCmcdSession({ sid: 's', requester: requester.requester, eventTargets: [{ url: COLLECTOR, events: ['t'], keys: ['cid', 'ec', 'sid'], interval: 1 }] })
+		const primary = session.createReporter({ cid: 'movie' })
+		const ad = session.createReporter({ cid: 'ad' })
+		ad.recordError('AD_ERR')
+		ad.dispose()
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		deepEqual(requester.bodies(), ['cid="movie",e=t,sid="s",ts=2000,v=2'])
+		primary.dispose()
+		context.mock.timers.tick(1000)
+		await flushPromises()
+		equal(requester.bodies()[1], 'e=t,sid="s",ts=3000,v=2')
+		session.dispose()
+	})
+})
+```
+
+If `encodeSfDict` accepts `not a token` as a token, use a string with a control character as the custom value instead. Structured field strings reject control characters.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.errors.test.ts`
+Expected: FAIL on the error messages.
+
+- [ ] **Step 3: Name the stage and the target in report errors**
+
+In `libs/cmcd/src/emitReport.ts`, add above `emitReport`:
+
+```ts
+function fail(stage: 'transform' | 'encode', targetName: string, error: unknown): Error {
+	const detail = error instanceof Error ? error.message : String(error)
+	return new Error(`CmcdSession: ${stage} failed for target ${targetName}: ${detail}`, { cause: error })
+}
+```
+
+Inside `emitReport`, define `const targetName = targetConfig ? targetConfig.url : 'request'` after `targetConfig`. Wrap the transform call:
+
+```ts
+		let result: Cmcd | null
+		try {
+			result = (transform as CmcdEventTransform)(before as Cmcd, request)
+		}
+		catch (error) {
+			throw fail('transform', targetName, error)
+		}
+```
+
+Wrap the encoder call:
+
+```ts
+	let line: string
+	try {
+		line = encodePreparedCmcd(prepared as Cmcd)
+	}
+	catch (error) {
+		throw fail('encode', targetName, error)
+	}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm run build -w libs/cmcd && npm test -w libs/cmcd && npm run typecheck`
+Expected: PASS, including the Task 10 transform test, whose `/boom/` pattern still matches the wrapped message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/cmcd/src libs/cmcd/test
+git commit -s -m "feat(cmcd): name the stage and the target in session API report errors" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Validation sweep and bundle probes
+
+**Files:**
+- Test: `libs/cmcd/test/CmcdSession.validation.test.ts`
+- Modify: `plans/cmcd-session-api/comparison.md` (the measured sizes)
+
+**Interfaces:**
+- Consumes: `validateCmcdEvents(body)` and `validateCmcdRequest(request)` from the package.
+
+Every line the session API emits must pass the package's own validators. The bundle probes check three things. Importing `createCmcdSession` alone does not pull in `CmcdReporter`. The package has no module-scope side effect. The size is compared with the baseline in `comparison.md`.
+
+- [ ] **Step 1: Write the sweep**
+
+```ts
+// libs/cmcd/test/CmcdSession.validation.test.ts
+import { CmcdTransmissionMode, createCmcdSession, validateCmcdEvents, validateCmcdRequest } from '@svta/cml-cmcd'
+import { deepEqual, equal, ok } from 'node:assert'
+import { describe, it } from 'node:test'
+import { createMockRequester, flushPromises } from './helpers/cmcdSessionHarness.ts'
+
+const COLLECTOR = 'https://collector.example.com/cmcd'
+const CDN = 'https://cdn.example.com'
+
+describe('CmcdSession validation sweep', () => {
+	for (const transmissionMode of [CmcdTransmissionMode.QUERY, CmcdTransmissionMode.HEADERS]) {
+		it(`emits only valid reports in ${transmissionMode} mode`, async (context) => {
+			context.mock.timers.enable({ apis: ['Date', 'setTimeout', 'setInterval'], now: 1764752370000 })
+			const mock = createMockRequester()
+			const session = createCmcdSession({ sid: 'session-id-123', transmissionMode, requester: mock.requester, eventTargets: [{ url: COLLECTOR, events: ['ps', 'pr', 'c', 'b', 'bc', 't', 'rr', 'e', 'h', 'ce', 'sk', 'as', 'ae', 'abs', 'abe'], interval: 1 }] })
+			const primary = session.createReporter({ cid: 'movie-42' })
+			const requests: { url: string; headers?: Readonly<Record<string, string>> }[] = []
+			primary.update({ sf: 'd', st: 'v', sta: 's', bl: 0, mtp: 15000, ts: 1764752370000 })
+			requests.push(primary.decorate({ url: `${CDN}/manifest.mpd` }, { ot: 'm' }))
+			const init = primary.decorate({ url: `${CDN}/init.m4v` }, { ot: 'i', br: { v: 3000, a: 128 }, nor: [`${CDN}/seg-1.m4v`] })
+			requests.push(init)
+			primary.recordResponse(init, { status: 200, headers: { 'CMSD-Static': 'ot=i' }, timing: { startTime: 10, responseStart: 40, responseEnd: 90 } })
+			primary.update({ sta: 'p', bl: 4000, pr: 1, ts: 1764752370500 })
+			primary.update({ pr: 1.5, br: { v: 4200, a: 256 }, tb: { v: 6000, a: 350 }, pt: 1000 })
+			primary.recordError('MEDIA_ERR_NETWORK')
+			primary.update({ sta: 'r', ts: 1764752371000 })
+			context.mock.timers.tick(1000)
+			primary.update({ sta: 'p', ts: 1764752371800 })
+			const ad = session.createReporter({ cid: 'ad-7' })
+			ad.update({ nr: true, sta: 'p' })
+			primary.recordEvent('abs')
+			ad.recordEvent('as')
+			requests.push(ad.decorate({ url: `${CDN}/ad-1.m4v` }, { ot: 'v', d: 4000 }))
+			ad.recordEvent('ce', { cen: 'ad-quartile' })
+			ad.recordEvent('sk')
+			ad.recordEvent('ae')
+			ad.dispose()
+			primary.recordEvent('abe')
+			primary.update({ bg: true })
+			primary.update({ bg: false })
+			primary.update({ cid: 'movie-43', sta: 'e' })
+			context.mock.timers.tick(1000)
+			session.rotate('session-id-456')
+			primary.update({ sta: 's', ts: 1764752373000 })
+			requests.push(primary.decorate({ url: `${CDN}/seg-9.m4v` }, { ot: 'v', d: 4000, 'com.example-tag': 'x' }))
+			session.dispose()
+			await flushPromises()
+
+			ok(mock.bodies().length >= 15, `expected many reports, got ${mock.bodies().length}`)
+			for (const body of mock.bodies()) {
+				const result = validateCmcdEvents(body)
+				deepEqual(result.issues.filter(issue => issue.severity === 'error'), [], `invalid body: ${body}`)
+			}
+			for (const request of requests) {
+				const result = validateCmcdRequest({ url: request.url, headers: request.headers ? { ...request.headers } : undefined })
+				deepEqual(result.issues.filter(issue => issue.severity === 'error'), [], `invalid request: ${request.url}`)
+			}
+			equal(session.sid, 'session-id-456')
+		})
+	}
+})
+```
+
+Check the shape of the validator results in `libs/cmcd/src/CmcdValidationResult.ts` and `CmcdValidationIssue.ts` before running. Adjust the `issues` and `severity` member names to the real ones.
+
+The exit `b` line is `e=b` without `bg`. The validator on `main` rejected it until the fix on branch `fix/cmcd-validator-b-event-without-bg` merged. If that fix is not on the branch yet, merge `main` into `feat/cmcd-session-api` first. Do not weaken the sweep.
+
+- [ ] **Step 2: Run the sweep**
+
+Run: `npm run build -w libs/cmcd && node --no-warnings --test libs/cmcd/test/CmcdSession.validation.test.ts`
+Expected: PASS. A failing body names the line. Fix the emitter, not the test. If the validator itself is wrong, open an issue and reference it in a comment next to the affected line.
+
+- [ ] **Step 3: Run the bundle probes**
+
+The folder `libs/cmcd/temp/` is git-ignored. From the repository root:
+
+```bash
+mkdir -p libs/cmcd/temp/probe
+printf "import { createCmcdSession } from '../../dist/index.js'\nexport { createCmcdSession }\n" > libs/cmcd/temp/probe/session-entry.ts
+printf "import { CmcdReporter } from '../../dist/index.js'\nexport { CmcdReporter }\n" > libs/cmcd/temp/probe/reporter-entry.ts
+printf "import '../../dist/index.js'\n" > libs/cmcd/temp/probe/bare-entry.ts
+npx tsdown libs/cmcd/temp/probe/session-entry.ts libs/cmcd/temp/probe/reporter-entry.ts libs/cmcd/temp/probe/bare-entry.ts --format esm --minify --out-dir libs/cmcd/temp/probe/out --no-clean
+for f in session-entry reporter-entry bare-entry; do printf "%s min=%s gz=%s\n" "$f" "$(wc -c < libs/cmcd/temp/probe/out/$f.js)" "$(gzip -c libs/cmcd/temp/probe/out/$f.js | wc -c)"; done
+grep -c "CmcdReporter" libs/cmcd/temp/probe/out/session-entry.js
+grep -v "^import" libs/cmcd/temp/probe/out/bare-entry.js | grep -c "[a-zA-Z]"
+```
+
+Expected: the `CmcdReporter` count in the session entry is `0`. The bare entry has no line with letters besides `import` lines, so the last count is `0`. If tsdown externalizes `@svta/cml-utils` or `@svta/cml-structured-field-values`, both entries externalize them the same way, and the comparison stays fair. If the `CmcdReporter` count is not zero, a session module imports something from the `CmcdReporter` module graph. Move that import to a shared file.
+
+- [ ] **Step 4: Record the sizes**
+
+In `plans/cmcd-session-api/comparison.md`, replace the three estimate rows of the Size table with the measured numbers:
+
+```markdown
+| Minified bundle, reporter entry | 18.8 KB | not measured | <session-entry min> KB |
+| Minified with gzip | 7.1 KB | not measured | <session-entry gz> KB |
+```
+
+If the `reporter-entry` measurement differs from 18.8 KB and 7.1 KB, replace the baseline numbers too. The probe method must be the same for both. Delete the sentence after the table that calls the numbers estimates. Write instead that both entries were measured with the probe of Task 13 in `plans/cmcd-session-api/steps.md`, on the same day.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/cmcd/test/CmcdSession.validation.test.ts plans/cmcd-session-api/comparison.md
+git commit -s -m "test(cmcd): validate every session API report and record the bundle sizes" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Documentation and the API report
+
+**Files:**
+- Modify: `libs/cmcd/docs/user-guide.md`, `libs/cmcd/README.md`, `libs/cmcd/CHANGELOG.md`, `plans/cmcd-session-api/architecture.md`, `rfc/cmcd-session-api.md`
+- Review: `libs/cmcd/config/cml-cmcd.api.md`
+
+- [ ] **Step 1: Add the session API to the user guide**
+
+Insert the section of [`user-guide-section.md`](./user-guide-section.md) into `libs/cmcd/docs/user-guide.md`, after `## Installation` and before `## Basic Usage`. Copy it from its first heading to its last paragraph. Then run `bash plans/writing-style-compliance/check.sh HEAD libs/cmcd/docs/user-guide.md` and fix any `length` failure.
+
+- [ ] **Step 2: Add the quick start to the README**
+
+In `libs/cmcd/README.md`, insert a `## Reporting with a session` section after the `## Usage` block and before the `CmcdReportRecorder` section. Its body is the code block below, followed by one sentence: "The [user guide](docs/user-guide.md#reporting-with-a-session) describes the session API."
+
+```typescript
+import { createCmcdSession } from "@svta/cml-cmcd";
+
+const session = createCmcdSession({
+	eventTargets: [{ url: "https://collector.example.com/cmcd" }],
+});
+const reporter = session.createReporter({ cid: "movie-42" });
+
+reporter.update({ sta: "p", bl: 3200, mtp: 15000 });
+const req = reporter.decorate({ url: "https://cdn.example.com/seg-1.m4s" }, { ot: "v", d: 4000 });
+const res = await fetch(req.url, { headers: req.headers });
+await res.arrayBuffer();
+reporter.recordResponse(req, { status: res.status, headers: res.headers });
+```
+
+Check that the example runs. Pipe the block into `node --input-type=module` from the repository root, with the import changed to `./libs/cmcd/dist/index.js`. The `fetch` call fails offline, which is fine, but the lines before it must not throw.
+
+- [ ] **Step 3: Write the changelog entries**
+
+Under `## [Unreleased]` in `libs/cmcd/CHANGELOG.md`, add an `### Added` section above `### Changed` with:
+
+```markdown
+### Added
+
+- `createCmcdSession()`, the CMCD version 2 session API. One `CmcdSession` per playback and one `CmcdSessionReporter` per media player. The reporter derives `msd`, `bs`, `bsa`, `bsda`, `bsd`, `su`, `sn`, `h`, `bg`, and the response timing keys, keeps one `sid` and one sequence per target across players, and handles the event-mode delivery rules for 410, 429, and 5xx. `session.rotate()` changes the `sid`, and `session.configure()` changes the request-mode settings. `CmcdReporter` is unchanged. The design is in `rfc/cmcd-session-api.md`
+- `CmcdEventType.HOSTNAME` and `CMCD_EVENT_HOSTNAME`, the `h` event of CTA-5004-B. The validators accept `e=h`
+```
+
+- [ ] **Step 4: Record the two deviations in the design record and the RFC**
+
+In `plans/cmcd-session-api/architecture.md`:
+
+- In the `emitReport` algorithm, replace step 1 with: `1. Normalize the report to structured-field values. When the target has a transform: run it on the normalized report, return on null, normalize the result, restore a removed required key, re-stamp sid, e, and ts.` The transform then receives an exact `Cmcd`, and the normalization produces the copies that protected the store.
+- In the key table, change the `h` row to `| h | string | | event | | | | | h | | 128 | absent |`, so the `h` key is required on the `h` event like the other state-change keys.
+- Add a row to the Testing table: `| Bundle probe | Task 13 of steps.md: no CmcdReporter code in the createCmcdSession entry, no module-scope code in a bare import, sizes recorded in comparison.md |`
+
+In the Transforms section of `rfc/cmcd-session-api.md`, replace "The reporter copies nested values before a configured transform runs". The new text is "The reporter normalizes the report to structured-field values before a configured transform runs". In the Reports and targets section, add `h` on `h` to the list of required keys. The bullet becomes "- `sta` on `ps`, `pr` on `pr`, `cid` on `c`, `bg` on `b`, `br` on `bc`, and `h` on `h`".
+
+Run `bash plans/writing-style-compliance/check.sh HEAD rfc/cmcd-session-api.md plans/cmcd-session-api/architecture.md libs/cmcd/CHANGELOG.md libs/cmcd/README.md` and fix any `chars`, `length`, or `abbrev` failure.
+
+- [ ] **Step 5: Review the API report**
+
+Run: `npm run build -w libs/cmcd && git diff --stat libs/cmcd/config/cml-cmcd.api.md && git diff libs/cmcd/config/cml-cmcd.api.md | grep "^+export" `
+
+Expected: exactly the exports of the RFC's New exports table, `createCmcdSession`, the 18 types, `CMCD_EVENT_HOSTNAME`, and the `HOSTNAME` member. Anything else means an internal module leaked into `index.ts`.
+
+- [ ] **Step 6: Run the full validation and commit**
+
+Run: `npm test` from the repository root. It runs lint, the full build, the typecheck, and every package's tests.
+Expected: PASS.
+
+```bash
+git add libs/cmcd plans/cmcd-session-api rfc/cmcd-session-api.md
+git commit -s -m "docs(cmcd): document the session API and record the implementation deviations" -m "Co-Authored-By: Claude claude-fable-5-1 <noreply@anthropic.com>"
+```
+
+Push the branch and hand the pull request to Casey. The PR description names the RFC, lists the fourteen tasks, and reports the measured sizes.
+
+---
+
+## Execution notes
+
+- Tasks 1 to 9 are sequential. Task 10, 11, and 12 are independent of each other once Task 9 is done. Task 13 needs 12. Task 14 needs 13.
+- When a fixture fails, print the produced line next to the expected one before changing code. Most differences are a key the allowlist should have excluded, a rounding step, or an `sn` offset.
+- Never change a fixture string to make a test pass. The fixtures are spec text, with the three documented adaptations: `sn` numbered from zero, the `bs` on the first line of 8.2.5, and the `ts` of the second line of 8.2.5.

--- a/plans/cmcd-session-api/user-guide-section.md
+++ b/plans/cmcd-session-api/user-guide-section.md
@@ -1,0 +1,63 @@
+# User guide section for the session API
+
+Task 14 of [`steps.md`](./steps.md) inserts the text below into `libs/cmcd/docs/user-guide.md`, after `## Installation` and before `## Basic Usage`. Copy it as is, from the first heading to the last paragraph.
+
+---
+
+## Reporting with a session
+
+The session API is the CMCD version 2 reporter. One `CmcdSession` per playback owns the report targets, the requester, the interval timers, and `bg`. One `CmcdSessionReporter` per media player pushes state, records events, decorates requests, and records responses. The reporter derives `msd`, `bs`, `bsa`, `bsda`, `bsd`, `su`, `sn`, `h`, and the response timing keys. `CmcdReporter` remains available and unchanged.
+
+```typescript
+import { createCmcdSession, CmcdEventType } from '@svta/cml-cmcd'
+
+const session = createCmcdSession({
+	keys: ['br', 'bl', 'd', 'ot', 'sid', 'cid', 'mtp', 'sf', 'st', 'su', 'nor'],
+	eventTargets: [{ url: 'https://collector.example.com/cmcd' }],
+})
+
+const reporter = session.createReporter({ cid: 'movie-42' })
+
+reporter.update({ sf: 'h', st: 'v' })
+reporter.update({ sta: 'p', bl: 3200, mtp: 15000, pt: 12000 }) // emits e=ps with this snapshot
+
+const req = reporter.decorate({ url: 'https://cdn.example.com/seg-1.m4s' }, { ot: 'v', d: 4000, br: 3000 })
+const res = await fetch(req.url, { headers: req.headers })
+const bytes = await res.arrayBuffer() // read the body first, so ttlb measures the last byte
+reporter.recordResponse(req, { status: res.status, headers: res.headers }) // emits e=rr
+
+reporter.recordError('MEDIA_ERR_NETWORK')
+reporter.recordEvent(CmcdEventType.AD_BREAK_START)
+
+session.dispose()
+```
+
+### Pushing state
+
+`update()` merges plain values into the reporter's store. Numbers are in the spec's units, and the reporter rounds them. A metric that the spec allows per object type takes a number or a record such as `{ v: 3000, a: 128 }`. A member set to `undefined` removes the key. `ts` is the time of the transition for a push that arrives late, and it is not stored.
+
+A change of `sta`, `pr`, `cid`, `bg`, or `br` emits the matching state-change event, `ps`, `pr`, `c`, `b`, or `bc`, once per changed value. Push the state and let the reporter emit. Do not call `recordEvent()` for these five.
+
+### Events and errors
+
+`recordEvent()` takes the discrete events: `as`, `ae`, `abs`, `abe`, `sk`, `m`, `um`, `pe`, `pc`, and `ce`. A `ce` event needs `cen` in its data. `recordError()` takes one code or a list. The codes are buffered per destination and go out with the next report to that destination. Destinations that list `e` receive an `e` event at once.
+
+### Requests and responses
+
+`decorate()` returns a copy of the request with the report placed on it. Query mode adds the `CMCD` query parameter, and header mode adds the `CMCD-` headers. The copy carries a `cmcd` record. Pass that returned request to `recordResponse()` with the status, the headers, and a Resource Timing entry when you have one. Without timing, `ttlb` measures the moment of the call, so record the response after the body is read. A request you did not keep can be recorded with `{ url }` and reports under the current `sid`.
+
+### Interstitials
+
+Create one reporter per media player with `session.createReporter({ cid })`. Every reporter reports under the same `sid`, and each destination sees one sequence of `sn`. Set `nr: true` on the player that is not rendered.
+
+### Changing the sid
+
+`session.rotate(sid)` starts the next `sid` for every reporter with no new objects. Counters, gates, and buffers restart, a startup measurement in progress carries over, and nothing is emitted. `session.configure()` replaces the request-mode settings `version`, `transmissionMode`, `keys`, and `headerMap` without a reset. A manifest that supplies CMCD parameters is handled with `configure()`, then `rotate(sid)`, then `update({ cid })`.
+
+### Lifecycle
+
+`createCmcdSession()` starts the interval timers and the visibility listener. `session.flush()` sends every queued line now. `session.dispose()` stops the timers, drains the queues, and turns every later call into a no-op. A response that arrives after `dispose()` or `rotate()` still reports under the `sid` that issued its request.
+
+### Derived defaults
+
+`derive` names three observations the reporter turns into defaults: `bg` from document visibility, `dl` from `bl` and `pr`, and `su` from the play state. Each is on by default. `derive: { bg: false }` turns one off, and a pushed value always wins.

--- a/rfc/cmcd-session-api.md
+++ b/rfc/cmcd-session-api.md
@@ -103,6 +103,33 @@ const ad = session.createPlayer({ cid: 'ad-7' })
 
 Every player reports under the session's `sid` and takes the next sequence number of each target. Dispose a player when its media player is destroyed.
 
+The ownership in one picture. Targets belong to the session, and every player reports to every target.
+
+```mermaid
+flowchart TB
+    subgraph session["CmcdSession, one sid"]
+        direction TB
+        sdata["sid, version, transport, timers<br>msd, bg, bsa, bsda, completed spans"]
+        subgraph players["Players, one per media player"]
+            direction LR
+            primary["CmcdPlayer, cid movie-42<br>store, reported values, host, su, open span"]
+            ad["CmcdPlayer, cid ad-7<br>store, reported values, host, su, open span"]
+        end
+        subgraph targets["Targets, one per destination"]
+            direction LR
+            req["request target<br>sn, msd gate, bsd cursor<br>bs and ec per player"]
+            ev1["event target A<br>sn, msd gate, bsd cursor<br>bs and ec per player<br>queue, back-off, gone"]
+            ev2["event target B<br>same state as A"]
+        end
+    end
+    primary --> req
+    primary --> ev1
+    primary --> ev2
+    ad --> req
+    ad --> ev1
+    ad --> ev2
+```
+
 ### Push state, get events
 
 `update()` stores playback state and derives the five state-change events from it: `sta` gives `ps`, `pr` gives `pr`, `cid` gives `c`, `bg` gives `b`, and `br` gives `bc`. The event fires when the value differs from the last value the reporter reported for that player. Metrics pushed in the same call ride the event.
@@ -160,6 +187,26 @@ primary.recordResponse(req, {
 
 A response can arrive after the player has disposed the session that issued the request. The record on the request points to that session, so the `rr` report has the old `sid` and the old session's next sequence number. The old session sends the report at once, because no batch will fill again.
 
+The sequence for a response that arrives after its session was disposed:
+
+```mermaid
+sequenceDiagram
+    participant Player as media player
+    participant A as CmcdSession A
+    participant B as CmcdSession B
+    participant C as collector
+    Player->>A: player.decorate(request, data)
+    A-->>Player: request with cmcd record, sid A, sn 41
+    Player->>Player: send the request to the CDN
+    Player->>A: session.dispose()
+    A->>C: POST the queued lines
+    Player->>B: createCmcdSession(), then createPlayer()
+    Note over Player,C: the response for the old request arrives
+    Player->>B: player.recordResponse(request, info)
+    B-->>A: the record resolves to session A
+    A->>C: POST e=rr with sid A and sn 42, at once
+```
+
 ### Interstitials
 
 The spec covers multi-player sessions with `cid`, `ps`, and `nr`. The session API needs no other concept. When an interstitial renders on its own player, the primary player sets `nr` while it fetches content that the user does not see.
@@ -174,6 +221,23 @@ primary.update({ nr: false })
 ```
 
 Each interval tick emits one `t` line per live player, with the same `ts` and consecutive sequence numbers. Overlay and side-by-side interstitials report both players, and a collector tells them apart by `cid` and `nr`.
+
+The wire during a sequential interstitial. Keys other than the ones shown are omitted.
+
+```text
+# The primary pauses and stops rendering while the ad player starts
+cid="movie-42",e=ps,nr,sid="s1",sn=7,sta=a,ts=1764752400000,v=2
+cid="ad-7",e=as,sid="s1",sn=8,ts=1764752400050,v=2
+cid="ad-7",e=ps,sid="s1",sn=9,sta=p,ts=1764752400120,v=2
+
+# One interval tick: one t line per live player, same ts, consecutive sn
+cid="movie-42",e=t,nr,sid="s1",sn=10,sta=a,ts=1764752430000,v=2
+cid="ad-7",e=t,sid="s1",sn=11,sta=p,ts=1764752430000,v=2
+
+# The ad ends and its player is disposed, the primary renders again
+cid="ad-7",e=ae,sid="s1",sn=12,ts=1764752445000,v=2
+cid="movie-42",e=ps,sid="s1",sn=13,sta=p,ts=1764752445200,v=2
+```
 
 ### Lifecycle
 
@@ -319,6 +383,30 @@ The `cid` given to `createPlayer()` counts as reported, so creating a player emi
 
 `bsa` counts the transitions into `r`. `bsda` and `bsd` count completed spans only. A span still open at `dispose()` is dropped. Automatic `bsa`, `bsd`, and `bsda` entries have no cause token. `url` is the request URL without its `CMCD` parameter. `rc` is `0` when `status` is absent. `ts` for a response is the request start.
 
+The `sta` transitions and what each one derives. Transitions with no effect on a derived key are left out.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    d : d preloading
+    s : s starting
+    p : p playing
+    k : k seeking
+    r : r rebuffering
+    a : a paused
+    [*] --> d
+    [*] --> s : records msdStart, su true
+    d --> s : records msdStart, su true
+    s --> p : msd from msdStart, su false
+    p --> k : su true
+    k --> p : su false
+    p --> r : bsa increments, span opens, bs set on every target, su true
+    r --> p : span closes into bsda and bsd, su false
+    r --> a : span closes into bsda and bsd
+    p --> a
+    a --> p
+```
+
 ### Reports and targets
 
 Every report is assembled in a fixed order, and a later source wins:
@@ -330,6 +418,25 @@ Every report is assembled in a fixed order, and a later source wins:
 5. the derived defaults
 
 The target's `transform` runs on a copy when one is configured, and `null` cancels the report for that target. The reporter then filters the keys, applies the spec rules, encodes, and only then commits: `sn` advances, the `msd` gate closes when the output kept `msd`, `bs` and the `ec` buffer clear, and the `bsd` cursor moves. A cancelled or failed report commits nothing.
+
+The report path for one target:
+
+```mermaid
+flowchart LR
+    subgraph assemble["Assemble, a later source wins"]
+        direction TB
+        s1["player store"] --> s2["session data"] --> s3["per-call data"] --> s4["target state for the player"] --> s5["derived defaults"]
+    end
+    assemble --> tq{"transform<br>configured?"}
+    tq -- no --> prep["filter keys<br>apply the spec rules"]
+    tq -- yes --> tr["copy nested values<br>run the transform"]
+    tr -- null --> cancel["cancelled<br>nothing committed"]
+    tr -- data --> restore["restore required keys<br>re-stamp sid, e, ts"] --> prep
+    prep --> enc["encode"]
+    enc -- throws --> fail["thrown to the caller<br>nothing committed"]
+    enc -- line --> commit["commit<br>sn advances<br>msd gate closes if kept<br>bs and ec clear<br>bsd cursor moves"]
+    commit --> out["event target: queue the line<br>request target: URL or headers"]
+```
 
 Filtering follows the target's `keys`. A key the current event requires is included whatever the list says:
 
@@ -408,8 +515,26 @@ Each event target queues encoded lines. It sends a batch when the queue reaches 
 | 2xx | done, back-off resets |
 | 410 | the target sends nothing else for this session |
 | 429, 5xx, or a rejected transport | the batch returns to the front of the queue, and the target retries after a back-off |
+| other 4xx | the batch is dropped, back-off resets |
 
 The back-off starts at one second and doubles to a cap of 60 seconds. New lines keep queueing during the back-off and go out with the retry, which is the aggregation the spec recommends for 429. After `dispose()`, a target stops retrying when a retry at the 60 second step fails. When a queue exceeds `maxQueueSize`, the oldest lines are dropped.
+
+The delivery states of one event target:
+
+```mermaid
+stateDiagram-v2
+    [*] --> queueing
+    queueing --> sending : batchSize reached, flush, dispose, or a late rr after dispose
+    sending --> queueing : 2xx, back-off resets
+    sending --> queueing : other 4xx, batch dropped
+    sending --> gone : 410
+    sending --> backingOff : 429, 5xx, or a rejected transport, batch back to the front
+    backingOff --> sending : timer fires, 1 s doubling to 60 s, or flush
+    backingOff --> gone : after dispose, the 60 s retry fails
+    gone --> [*]
+    note right of queueing : lines past maxQueueSize drop from the front
+    note right of backingOff : new lines keep queueing and join the retry
+```
 
 ### Errors
 

--- a/rfc/cmcd-session-api.md
+++ b/rfc/cmcd-session-api.md
@@ -1,0 +1,521 @@
+---
+status: draft
+---
+
+# RFC: Session API for CMCD version 2
+
+| | |
+|---|---|
+| **Author** | Casey Occhialini |
+| **Date** | 2026-09-09 |
+| **Package** | `@svta/cml-cmcd` |
+| **Breaking change** | No |
+
+## Summary
+
+Add a second reporting API to `@svta/cml-cmcd`, next to `CmcdReporter`. The new API has three objects that match the three scopes of CTA-5004-B.
+
+- A `CmcdSession` is one `sid`. It owns the report targets, the transport, the interval timers, and the session totals.
+- A `CmcdPlayer` is one media player inside the session. A player pushes its state, records events, decorates its requests, and records their responses.
+- A target is one report destination. Targets are internal. Each target owns the state the spec scopes to a destination. That state is the sequence number, the `msd` gate, the `bs` flag, the `ec` buffer, and the delivery queue.
+
+The reporter derives every key the spec defines in terms of state the reporter can observe. A player never computes `msd`, `bs`, `su`, `sn`, the starvation counters, or the response timing keys. State-change events come only from `update()`. A session can hold several players, and the wire shows one `sid` and one sequence per target.
+
+```ts
+import { createCmcdSession, CmcdEventType } from '@svta/cml-cmcd'
+
+const session = createCmcdSession({
+	keys: ['br', 'bl', 'd', 'ot', 'sid', 'cid', 'mtp', 'sf', 'st', 'su', 'nor'],
+	eventTargets: [{ url: 'https://collector.example.com/cmcd' }],
+})
+
+const player = session.createPlayer({ cid: 'movie-42' })
+
+player.update({ sf: 'h', st: 'v' })
+player.update({ sta: 'p', bl: 3200, mtp: 15000, pt: 12000 }) // emits e=ps with this snapshot
+
+const req = player.decorate({ url: 'https://cdn.example.com/seg-1.m4s' }, { ot: 'v', d: 4000, br: 3000 })
+const res = await fetch(req.url, { headers: req.headers })
+player.recordResponse(req, { status: res.status, headers: res.headers }) // emits e=rr
+
+player.recordError('MEDIA_ERR_NETWORK')
+player.recordEvent(CmcdEventType.AD_BREAK_START)
+
+session.dispose()
+```
+
+`CmcdReporter` does not change. It remains until players have migrated, and a later release marks it deprecated.
+
+## Motivation
+
+CMCD version 2 is much larger than version 1. It adds a second reporting mode, several targets with their own filters, 19 event types, and 32 new keys. It also adds rules that scope state to a session or to a destination. `CmcdReporter` encodes and sequences reports, but it leaves much of the spec to the player. The two largest adopters show the result. The table lists spec behavior that hls.js and dash.js implement by hand, read from their development branches on 2026-09-09.
+
+| Spec behavior | hls.js | dash.js |
+|---|---|---|
+| `msd` from the `sta` starting to playing delta | not sent | `calculateMsd()` in `CmcdModel` |
+| `bs` per destination since the last report | `starved` flag, cleared on the next video request | `wasPlaying()` and `onRebufferingStarted()` |
+| `su` until the buffer is stable | `buffering` flag | set per request in `CmcdModel` |
+| `dl` from buffer length and playback rate | computed per request | computed per request |
+| `bsd` from rebuffering spans | not sent | `_rebufferingDuration` in `CmcdModel` |
+| `ec` buffered per destination | fatal errors only, one event | `update({ ec })`, so the code stays on every later report |
+| `cmsds` and `cmsdd` from response headers | not sent | base64 encoding in `CmcdController` |
+
+The current API also has three traps that the two integrations fall into.
+
+1. `update({ sta })` fires a `ps` event, and a following `recordEvent(PLAY_STATE, data)` is deduplicated. dash.js makes exactly that pair of calls. On `@svta/cml-cmcd` 2.4 or later its play-state events lose the `data` payload.
+2. `recordResponseReceived()` attributes a response only through the provenance record on the decorated request. The hls.js loader passes `{ url }` from its loader context. The dash.js interceptor copies only the `cmcd` object from the decorated request. On 2.6 or later both players drop every `rr` event. Both pin older versions today.
+3. Configuration is fixed at construction. Both players rebuild the reporter to apply a manifest setting, and the rebuild resets `sid` and every `sn`. dash.js has a comment about that reset.
+
+Multi-player sessions are the case the current design fits worst. The spec expects one `sid` to span a movie and its interstitials, and the `bg` key is defined over "all players in a session". A second `CmcdReporter` with the same `sid` restarts every sequence number and sends `msd` again. The child-reporters proposal ([PR #398](https://github.com/streaming-video-technology-alliance/common-media-library/pull/398)) adds a root and child split to the current class. That proposal calls a session-first API "the right long-term shape" and set it aside for surface area.
+
+Inside the package, `CmcdReporter` is one class with five jobs: session bookkeeping, report assembly, transform policy, delivery, and the public facade. Each feature since version 2.4 added pairwise interactions between those jobs. A refactor ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)) splits the class along those jobs while keeping every current semantic. This RFC asks a different question: which of those semantics would a design built for the version 2 spec keep at all? The answer removes session rotation, the retention window, eviction, the provenance record, and the `customData` generics, and adds derived keys and a player object. The design record in [`plans/cmcd-session-api/`](../plans/cmcd-session-api/) has the comparison.
+
+## Guide-level explanation
+
+### One session, one or more players
+
+Create one session per playback session. The session generates a `sid` when the configuration has none. A session never changes its `sid`. When the player needs a new `sid`, it disposes the session and creates a new one. Requests that are still in flight keep reporting under the session that issued them (see [Requests and responses](#requests-and-responses)).
+
+```ts
+const session = createCmcdSession({
+	sid: 'session-abc-123',
+	version: 1,             // wire version for request mode. Event mode is always version 2
+	transmissionMode: 'headers',
+	eventTargets: [
+		{
+			url: 'https://collector.example.com/cmcd',
+			events: ['ps', 'e', 't', 'rr', 'bc'],
+			keys: ['sid', 'cid', 'sta', 'br', 'bl', 'url', 'rc', 'ttfb', 'ttlb'],
+			interval: 10,
+			batchSize: 5,
+			headers: { Authorization: 'Bearer token' },
+		},
+	],
+})
+```
+
+Create one player per media player. The primary player and an interstitial player are the same type and use the same code.
+
+```ts
+const primary = session.createPlayer({ cid: 'movie-42' })
+const ad = session.createPlayer({ cid: 'ad-7' })
+```
+
+Every player reports under the session's `sid` and takes the next sequence number of each target. Dispose a player when its media player is destroyed.
+
+### Push state, get events
+
+`update()` stores playback state and derives the five state-change events from it: `sta` gives `ps`, `pr` gives `pr`, `cid` gives `c`, `bg` gives `b`, and `br` gives `bc`. The event fires when the value differs from the last value the reporter reported for that player. Metrics pushed in the same call ride the event.
+
+```ts
+primary.update({ sta: 'r', bl: 0 })        // emits e=ps,sta=r,bl=(0)
+primary.update({ sta: 'r', bl: 0 })        // emits nothing, no change
+primary.update({ br: { v: 3000, a: 128 } }) // emits e=bc with br=(3000;v 128;a)
+```
+
+Interval reports and request reports read the same stored state, so push a metric when it changes. There is no second method for state-change events. The `recordEvent()` type accepts only the events that state cannot derive, so the compiler rejects `recordEvent(CmcdEventType.PLAY_STATE)`.
+
+Values are plain. A key that the spec defines as an inner list with object-type parameters accepts a number, or one number per object type. `nor` accepts a string, an object with a `range`, or an array of them. The reporter builds the structured-field syntax.
+
+### Discrete events and errors
+
+`recordEvent()` covers the ad events, `sk`, `m`, `um`, `pe`, `pc`, and `ce`. A custom event requires `cen`. The `data` argument applies to that one report.
+
+```ts
+ad.recordEvent(CmcdEventType.AD_START)
+ad.recordEvent(CmcdEventType.CUSTOM_EVENT, { cen: 'ad-quartile', 'com.example-quartile': 'q3' })
+```
+
+`recordError()` follows the spec's error rule. A target that lists `e` in its events receives an `e=e` report at once, with `ec`. Every other target, the request target included, buffers the code and attaches `ec` to the player's next report to that destination.
+
+```ts
+primary.recordError('MEDIA_ERR_NETWORK')
+primary.recordError(['DRM_NOT_SUPPORTED', 'PLAYBACK_FAILED'])
+```
+
+### Requests and responses
+
+`decorate()` returns a copy of the request with the CMCD query parameter or the CMCD headers applied, plus a `cmcd` record. The second argument is the data for this one request. An existing `CMCD` query parameter in the URL is replaced. A `nor` given as an absolute URL becomes a path relative to the request URL.
+
+```ts
+const req = primary.decorate(
+	{ url: frag.url, headers: {} },
+	{ ot: 'v', d: 4000, br: 3000, nor: next.url },
+)
+// req.url has the CMCD query parameter, or req.headers has the four CMCD headers
+// req.cmcd.data is the report as sent, for logging or a player event
+```
+
+Hand the returned request back with the response. The reporter derives `url`, `rc`, `ts`, `ttfb`, and `ttlb`, and reads `cmsds` and `cmsdd` from the `CMSD-Static` and `CMSD-Dynamic` response headers.
+
+```ts
+primary.recordResponse(req, {
+	status: res.status,
+	headers: res.headers,
+	timing: performance.getEntriesByName(req.url)[0],
+})
+```
+
+`timing` is optional. Without it, the reporter computes `ts` and `ttlb` from the clock reading it recorded in `decorate()`. A request the player did not keep can still be recorded with `{ url }`. That response reports under the calling player's session.
+
+A response can arrive after the player has disposed the session that issued the request. The record on the request points to that session, so the `rr` report has the old `sid` and the old session's next sequence number. The old session sends the report at once, because no batch will fill again.
+
+### Interstitials
+
+The spec covers multi-player sessions with `cid`, `ps`, and `nr`. The session API needs no other concept. When an interstitial renders on its own player, the primary player sets `nr` while it fetches content that the user does not see.
+
+```ts
+const ad = session.createPlayer({ cid: hash(asset.uri) })
+primary.update({ nr: true })
+ad.update({ sta: 'p' })
+// ...
+ad.dispose()
+primary.update({ nr: false })
+```
+
+Each interval tick emits one `t` line per live player, with the same `ts` and consecutive sequence numbers. Overlay and side-by-side interstitials report both players, and a collector tells them apart by `cid` and `nr`.
+
+### Lifecycle
+
+Creating a session arms its interval timers. `flush()` sends every queued batch now. `dispose()` flushes, stops the timers, and closes the session. Calls on a disposed player or session do nothing.
+
+```ts
+window.addEventListener('pagehide', () => session.flush())
+// on player destroy
+session.dispose()
+```
+
+## Reference-level explanation
+
+### New exports
+
+| Export | Kind |
+|---|---|
+| `createCmcdSession` | function |
+| `CmcdSession`, `CmcdSessionConfig` | types |
+| `CmcdPlayer`, `CmcdPlayerConfig`, `CmcdPlayerData`, `CmcdMetric`, `CmcdNextObject` | types |
+| `CmcdEventTargetConfig`, `CmcdTransport` | types |
+| `CmcdRequestLike`, `CmcdDecoratedRequest`, `CmcdRequestRecord`, `CmcdResponseInfo`, `CmcdResourceTiming` | types |
+| `CmcdRequestTransform`, `CmcdEventTransform` | types |
+| `CmcdDiscreteEventType` | type |
+| `CMCD_EVENT_HOSTNAME`, `CmcdEventType.HOSTNAME` | constant, the missing `h` event |
+
+### Configuration
+
+```ts
+type CmcdSessionConfig = {
+	sid?: string                                // default: a new UUID
+	version?: CmcdVersion                       // request mode only. default CMCD_V2
+	transmissionMode?: CmcdTransmissionMode     // default CMCD_QUERY
+	keys?: readonly CmcdKey[]                   // request mode allowlist. default: every key of the version
+	headerMap?: Partial<CmcdHeaderMap>          // header shard per custom key
+	transform?: CmcdRequestTransform
+	eventTargets?: readonly CmcdEventTargetConfig[]
+	transport?: CmcdTransport                   // default: fetch, POST, keepalive
+	visibility?: boolean                        // derive bg from document.visibilityState. default true when document exists
+	onError?: (error: unknown) => void
+}
+
+type CmcdEventTargetConfig = {
+	url: string
+	events?: readonly CmcdEventType[]           // default ['ps', 'e', 't', 'rr']
+	keys?: readonly CmcdKey[]                   // default: every event key
+	interval?: number                           // seconds. default 30. 0 disables t
+	batchSize?: number                          // default 1
+	maxQueueSize?: number                       // lines. default 500
+	headers?: Readonly<Record<string, string>>  // sent with every POST
+	transform?: CmcdEventTransform
+}
+
+type CmcdPlayerConfig = {
+	cid?: string
+}
+```
+
+The defaults make `{ url }` a complete event target and `createCmcdSession()` a complete request-mode configuration. The spec's minimum recommended event set is `ps`, `e`, `t`, and `rr`. A configuration error throws at `createCmcdSession()` or `createPlayer()`. The message names the parameter, the expected value, and the received value. The checks:
+
+- a `sid` over 64 characters
+- a `cid` over 128 characters
+- an unknown key or a malformed custom key in a `keys` list
+- an unknown event type
+- a target without `url`
+- a negative `interval`
+- a `batchSize` under 1
+- an event target with `version`
+
+### Objects
+
+```ts
+type CmcdSession = {
+	readonly sid: string
+	createPlayer(config?: CmcdPlayerConfig): CmcdPlayer
+	flush(): void
+	dispose(): void
+}
+
+type CmcdPlayer = {
+	readonly session: CmcdSession
+	update(data: CmcdPlayerData): void
+	recordEvent(type: Exclude<CmcdDiscreteEventType, 'ce'>, data?: CmcdPlayerData): void
+	recordEvent(type: 'ce', data: CmcdPlayerData & { cen: string }): void
+	recordError(code: string | readonly string[], data?: CmcdPlayerData): void
+	decorate<R extends CmcdRequestLike>(request: R, data?: CmcdPlayerData): CmcdDecoratedRequest<R>
+	recordResponse(request: CmcdRequestLike, response: CmcdResponseInfo, data?: CmcdPlayerData): void
+	dispose(): void
+}
+
+type CmcdDiscreteEventType = 'as' | 'ae' | 'abs' | 'abe' | 'sk' | 'm' | 'um' | 'pe' | 'pc' | 'ce'
+```
+
+`CmcdDiscreteEventType` is `CmcdEventType` without the derived types `ps`, `pr`, `c`, `b`, `bc`, `t`, `rr`, `e`, and `h`.
+
+### Data
+
+`CmcdPlayerData` is the one input type for `update()`, per-event data, per-request data, and per-response data. Every member is optional.
+
+| Members | Type |
+|---|---|
+| `sta`, `sf`, `st`, `ot` | the existing token unions |
+| `cid`, `cs`, `h` | `string` |
+| `bg`, `bs`, `nr`, `su` | `boolean` |
+| `d`, `dfa`, `dl`, `ltc`, `msd`, `pr`, `pt`, `rtp` | `number` |
+| `ab`, `bl`, `br`, `bsa`, `bsd`, `bsda`, `lab`, `lb`, `mtp`, `pb`, `tab`, `tb`, `tbl`, `tpb` | `CmcdMetric` |
+| `nor` | `CmcdNextObject \| readonly CmcdNextObject[]` |
+| `ts` | `number`, the time of the transition, not stored |
+| custom keys | `CmcdCustomValue` |
+
+```ts
+type CmcdMetric = number | Readonly<Partial<Record<CmcdObjectType, number>>>
+type CmcdNextObject = string | { readonly url: string; readonly range?: string }
+```
+
+`ec` is not a member. Errors go through `recordError()`. `sid`, `sn`, `v`, `e`, and the response keys are reporter-owned and not members. The reporter rounds values per the spec: integer keys to the nearest integer, and `bl`, `dl`, `mtp`, `rtp`, and `tbl` to the nearest 100. Pass raw values.
+
+`update()` merges `data` into the player's store. A member set to `undefined` removes the key. `bg`, `msd`, `bsa`, `bsda`, and `bsd` are session facts. A player that pushes one of them writes it on the session, and automatic tracking of that key stops for the rest of the session.
+
+### State-change events
+
+After the merge, the reporter compares the five tracked fields with the last value it reported for that player. The order is `sta`, `pr`, `cid`, `bg`, `br`. Each changed field emits its event to every target that lists it, with the merged store as the report. Two spec clauses shape the rule.
+
+- `pr` fires only while `sta` is `p`. A rate change while paused fires once on resume, if the rate still differs from the last reported rate.
+- `bg` is compared on the session, and `b` follows the one-line-per-player rule of interval reports.
+
+The `cid` given to `createPlayer()` counts as reported, so creating a player emits no `c`. The first `sta` and the first `br` emit, because nothing was reported before. `b` on exit is sent as `bg=?0`, as today.
+
+### Derived keys
+
+| Key | Derived from | Scope | Player value |
+|---|---|---|---|
+| `sn`, `ts`, `v`, `e` | counters and clocks | target and report | ignored |
+| `msd` | the first `sta` s to the next `sta` p | session, sent once per target | wins, stops tracking |
+| `bs` | `sta` entering r | target and player, cleared by the next report | wins for that report |
+| `bsa`, `bsda`, `bsd` | spans between `sta` transitions | session totals, `bsd` cursor per target | wins, stops tracking |
+| `su` | in s, k, or r, or no p since one | player | wins |
+| `dl` | `bl` divided by `pr`, nearest 100 ms, only when `pr` is over 0 | player | wins |
+| `h`, event `h` | the host of decorated request URLs | player | wins, stops tracking |
+| `bg`, event `b` | `document.visibilityState`, when `visibility` is on | session | wins, stops tracking |
+| `url`, `rc`, `ts`, `ttfb`, `ttlb` | request URL, status, timing | response | wins |
+| `cmsds`, `cmsdd` | `CMSD-Static` and `CMSD-Dynamic` response headers | response | wins |
+
+`bsa` counts the transitions into `r`. `bsda` and `bsd` count completed spans only. A span still open at `dispose()` is dropped. Automatic `bsa`, `bsd`, and `bsda` entries have no cause token. `url` is the request URL without its `CMCD` parameter. `rc` is `0` when `status` is absent. `ts` for a response is the request start.
+
+### Reports and targets
+
+Every report is assembled in a fixed order, and a later source wins:
+
+1. the player's store
+2. the session data
+3. the per-call data
+4. the target's per-player state
+5. the derived defaults
+
+The target's `transform` runs on a copy when one is configured, and `null` cancels the report for that target. The reporter then filters the keys, applies the spec rules, encodes, and only then commits: `sn` advances, the `msd` gate closes when the output kept `msd`, `bs` and the `ec` buffer clear, and the `bsd` cursor moves. A cancelled or failed report commits nothing.
+
+Filtering follows the target's `keys`. A key the current event requires is included whatever the list says:
+
+- `e` and `ts` on every event report, and `v` in version 2
+- `sta` on `ps`, `pr` on `pr`, `cid` on `c`, `bg` on `b`, and `br` on `bc`
+- `ec` on `e`, `cen` on `ce`, and `url` on `rr`
+
+The response keys appear only on `rr`. `cen` appears only on `ce`. `d` and `tpb` follow the object-type rule, and `ab`, `lab`, and `tab` yield to `br`, `lb`, and `tb`, as the encoder does today.
+
+Each interval tick emits one `t` line per live player, in creation order, or one session-only line when the session has no player. Session-triggered events, `t` and `b`, follow that rule. Player-triggered events emit one line for that player. The first `t` report of a target comes one interval after creation. Today's `start()` sends one at once. The `ps` event for `sta` s already marks the start of a session.
+
+### Requests
+
+`decorate()` returns a new object. `url` has the `CMCD` query parameter in query mode. `headers` has the four `CMCD-` headers in header mode, and an empty shard is omitted. `cmcd` is the request record.
+
+```ts
+type CmcdRequestLike = {
+	readonly url: string
+	readonly headers?: Readonly<Record<string, string>>
+}
+
+type CmcdDecoratedRequest<R extends CmcdRequestLike> = R & {
+	readonly cmcd: CmcdRequestRecord
+}
+
+type CmcdRequestRecord = {
+	readonly sid: string
+	readonly data: Readonly<Cmcd>   // the report as sent, after keys and transform
+}
+```
+
+The record is a plain object. Spread and `Object.assign` keep it. JSON does not keep the link to the origin. A response for a request that crossed a JSON boundary reports under the calling player's session. A request that the transform cancelled still receives a record, so its response is attributed.
+
+### Responses
+
+```ts
+type CmcdResponseInfo = {
+	status?: number                              // rc. 0 when absent
+	headers?: Headers | Readonly<Record<string, string>>
+	timing?: CmcdResourceTiming
+}
+
+type CmcdResourceTiming = {
+	startTime: number                            // DOMHighResTimeStamp
+	responseStart?: number
+	responseEnd?: number
+	duration?: number
+}
+```
+
+A `PerformanceResourceTiming` entry satisfies `CmcdResourceTiming`. The `rr` report is assembled in this order, and a later source wins:
+
+1. the origin player's store
+2. the session data
+3. the per-request data given to `decorate()`
+4. the derived response keys
+5. the `data` argument
+
+It goes to every event target of the origin session that lists `rr`.
+
+### Transforms
+
+```ts
+type CmcdRequestTransform = (data: Cmcd, request: Readonly<CmcdRequestLike>) => Cmcd | null
+type CmcdEventTransform = (data: Cmcd, request: Readonly<CmcdRequestLike> | undefined) => Cmcd | null
+```
+
+The contract is the one the transforms RFC defined. The reporter copies nested values before a configured transform runs, re-stamps the reporter-owned keys after it returns, and restores a required key the transform removed. A transform that throws cancels that target's report. The error is thrown to the caller after every other target has been processed. The `request` argument is the request the player passed to `decorate()`. Read player fields through a cast or bracket access.
+
+### Delivery
+
+Each event target queues encoded lines. It sends a batch when the queue reaches `batchSize`, on `flush()`, on `dispose()`, or at once for a late `rr` report after dispose. A batch is one POST with content type `application/cmcd`, the lines joined by a line feed, no trailing line feed, and the target's `headers`. The default transport is `fetch` with `keepalive` set when the body is under 64 KB, so a `flush()` on `pagehide` completes.
+
+| Response | Action |
+|---|---|
+| 2xx | done, back-off resets |
+| 410 | the target sends nothing else for this session |
+| 429, 5xx, or a rejected transport | the batch returns to the front of the queue, and the target retries after a back-off |
+
+The back-off starts at one second and doubles to a cap of 60 seconds. New lines keep queueing during the back-off and go out with the retry, which is the aggregation the spec recommends for 429. After `dispose()`, a target stops retrying when a retry at the 60 second step fails. When a queue exceeds `maxQueueSize`, the oldest lines are dropped.
+
+### Errors
+
+Runtime data never throws. An unknown or empty value is omitted, as the spec requires. A value the structured-field encoder cannot serialize throws at the call that produced it, and nothing is committed. `createPlayer()` on a disposed session throws. Every other call on a disposed player or session is a no-op.
+
+`onError` receives the errors that have no caller. Those are a transform or encoding failure on an interval tick, and a transport that still fails after the back-off cap. Without `onError`, those errors are thrown from the timer callback, as today.
+
+### Bundle and performance
+
+The estimates below are for the design record to verify with a prototype.
+
+| Measure | `CmcdReporter` today | This API, estimate |
+|---|---|---|
+| Minified, request mode only | 18.8 KB | at or below 18.8 KB |
+| Minified with gzip | 7.1 KB | at or below 7.1 KB |
+| Objects per report | 1, plus copies when a transform runs | 1, plus copies when a transform runs |
+
+The retention ledger, the eviction pass, the dirty set, and the provenance encoding go away. The derivation code and the key table arrive. A player that imports only `createCmcdSession` does not bundle `CmcdReporter`. Event-mode delivery is bundled whenever the session API is, because the configuration is data.
+
+### Migration from `CmcdReporter`
+
+| `CmcdReporter` | Session API |
+|---|---|
+| `new CmcdReporter(config, requester)` | `createCmcdSession({ ...config, transport })` and `session.createPlayer({ cid })` |
+| `enabledKeys` | `keys` |
+| `customHeaderMap` | `headerMap` |
+| `sessionRetention`, `CMCD_REQUEST_PROVENANCE`, the `C` type parameter | removed |
+| `update(data)` | `player.update(data)` with plain values |
+| `update({ sid })` | dispose the session and create a new one |
+| `recordEvent(PLAY_STATE, data)` and the other state events | `player.update(data)` |
+| `recordEvent(ERROR, { ec })` | `player.recordError(codes)` |
+| `createRequestReport(request, data)` | `player.decorate(request, data)` |
+| `recordResponseReceived(response, data)` | `player.recordResponse(req, info, data)` |
+| `start()` | creation |
+| `stop(true)` | `session.dispose()` |
+| `flush()` | `session.flush()` |
+| `createChildReporter()` (proposed) | `session.createPlayer()` |
+
+A sketch of the hls.js change in `CMCDController`:
+
+- create the session and one player on `MANIFEST_LOADING`
+- delete the `starved` and `buffering` flags and the `dl` arithmetic
+- keep the decorated request on the loader wrapper, so `onSuccess` can pass it to `recordResponse()`
+- create one player per interstitial asset, and set `nr` on the primary at asset start and clear it at primary resume
+
+The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` persistence, and the rebuild logic. It passes the decorated request through its interceptors.
+
+## Drawbacks
+
+- **Two reporting APIs in one package.** Until `CmcdReporter` is removed, both need documentation and tests. Adopters must choose.
+- **Two objects in the simplest integration.** A request-only player still creates a session and a player.
+- **One `t` line per player changes the wire during interstitials.** A collector that expected one interval line per `sid` sees two while an interstitial player exists.
+- **A DOM side effect.** The session listens to `visibilitychange` when a document exists. The `visibility` option turns that off.
+- **Derived defaults are assumptions.** `dl` from `bl` and `pr`, and `su` from the play state, match what hls.js and dash.js compute today. The spec words `dl` as a possible equivalence only.
+- **Exact attribution needs the returned request.** A player that keeps only the URL gets current-session attribution for late responses.
+- **In-flight requests keep their session reachable.** There is no retention knob. Memory is bounded by the requests the player keeps.
+- **Event-mode code is always bundled** with the session API, because targets are configuration objects.
+- **Wire differences from `CmcdReporter`.** The first `t` report comes after one interval. `ec` no longer persists across reports. `bs` is per destination.
+
+## Rationale and alternatives
+
+- **Refactor in place ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)).** Keeps the public API and every 2.6 semantic. It organizes session rotation, retention, eviction, dirty tracking, and provenance into units, and it keeps them. This RFC removes them. The design record compares the two.
+- **One object that is both the session and the primary player.** One fewer line in the common case. It recreates the root and child asymmetry of the child-reporters proposal, where a child cannot do what the root does.
+- **An explicit `activate()` for interval reports.** The child-reporters proposal's answer. It needs two calls in the interstitials controller and gives wrong data when a teardown skips the return call. One line per live player needs no call and loses no player.
+- **A presenting-player rule for one interval line.** The first draft of this design used the most recently updated player without `nr`. Overlay and side-by-side interstitials render both players, so the rule flips on every metric push.
+- **The provenance record and the retention ledger (2.6.0).** Exact attribution for every request, including undecorated ones, and it survives JSON with a bridge. Its cost is the ledger, the eviction pass, a symbol on `customData`, and a contract that neither adopter meets today.
+- **Attribution from the wire.** Parse the `sid` back out of the `CMCD` query parameter or the `CMCD-Session` header. It works with a URL alone and survives every boundary. It costs a decode per response, it fails in header mode without the headers, and it cannot attribute a cancelled or undecorated request. It remains possible as a later fallback.
+- **A pull model.** A `getState()` callback read at report time gives fresh interval data. A pull cannot see a `sta` transition when it happens, so transitions still need a push, and the player has two data paths.
+- **Targets as factory functions.** `requestTarget()` and `eventTarget()` would let a request-only player tree-shake event mode. It adds a concept and an import for every integration. The configuration shape here matches `CmcdReporterConfig`, which both adopters already map.
+- **`formatters` on the session API.** Custom formatters remain on `encodeCmcd`. The transform is the per-report hook of this API, and the built-in rounding is a spec `MUST` for `dl`, `mtp`, and `rtp`.
+- **`ts` as a second `update()` argument.** It would keep the payload type to stored keys. Kept in the payload for now, because every other reporting call takes `ts` in its payload too.
+- **`start()` and `stop()`.** Both adopters call them only as a constructor and destructor pair. Creation and `dispose()` cover that with two calls.
+
+## Prior art
+
+- **hls.js** `CMCDController` and **dash.js** `CmcdController` drive `CmcdReporter` today, and both compute the spec behavior listed in Motivation by hand.
+- **Shaka Player** `CmcdManager` is an independent implementation with the same per-player fields and no session sharing.
+- **The report transforms RFC** ([`rfc/cmcd-reporter-middleware.md`](./cmcd-reporter-middleware.md)) defined the transform contract this API reuses.
+- **The session retention RFC** ([`rfc/cmcd-session-retention.md`](./cmcd-session-retention.md)) defined the late-response goal this API meets by object lifetime.
+- **The child-reporters RFC** ([PR #398](https://github.com/streaming-video-technology-alliance/common-media-library/pull/398)) defined the state partition between a session and a player that this API makes the primary model.
+- **The starvation counters design** ([`plans/cmcd-session-counters/design.md`](../plans/cmcd-session-counters/design.md)) settled the supplied-value precedence this API uses for every derived key.
+
+## Unresolved questions
+
+1. **Configuration shape.** Top-level request settings plus `eventTargets`, as proposed, or a `targets` list of factory functions that tree-shakes event mode.
+2. **`bg` from document visibility by default.** On by default with an opt-out, or off by default.
+3. **`dl` as a derived default.** Keep it, or make `dl` player-supplied only.
+4. **One `t` line per live player.** Collector feedback on two lines per interval during interstitials.
+5. **`b` on exit.** `bg=?0`, as today, or a bare `e=b` as the token description implies.
+6. **`ts` in the `update()` payload**, or a second argument.
+7. **A URL-only `recordResponse()`** with attribution parsed from the wire, or the current-session fallback alone.
+8. **`onError` signature.** A single callback, or a context argument that names the target and the stage.
+9. **Names.** `CmcdPlayer` and `CmcdPlayerData` next to the existing `CmcdPlayerState` token union.
+
+## Future possibilities
+
+- `encodeCmcd` accepts the plain values of `CmcdPlayerData`, once the shared preparation step normalizes them.
+- Automatic response recording through a `PerformanceObserver`, so a browser player never calls `recordResponse()`.
+- `Retry-After` from a 429 response, when the transport returns headers.
+- A per-target URL filter for the `url` key, per spec item 19. A transform covers it today.
+- `CmcdReporter` marked deprecated after hls.js and dash.js migrate, and removed in the next major version.
+
+## Final Decision
+
+*(Completed after review)*
+
+**Decision:**
+**Rationale:**
+**Date:**

--- a/rfc/cmcd-session-api.md
+++ b/rfc/cmcd-session-api.md
@@ -15,7 +15,7 @@ status: draft
 
 Add a second reporting API to `@svta/cml-cmcd`, next to `CmcdReporter`. The new API has three objects that match the three scopes of CTA-5004-B.
 
-- A `CmcdSession` is one `sid`. It owns the report targets, the transport, the interval timers, and the session totals.
+- A `CmcdSession` reports under one `sid` at a time. It owns the report targets, the transport, the interval timers, and the session totals. `rotate()` starts the next `sid` for every reporter in the session.
 - A `CmcdSessionReporter` reports for one media player inside the session. Through it the player pushes its state, records events, decorates its requests, and records their responses.
 - A target is one report destination. Targets are internal. Each target owns the state the spec scopes to a destination. That state is the sequence number, the `msd` gate, the `bs` flag, the `ec` buffer, and the delivery queue.
 
@@ -68,13 +68,13 @@ The current API also has three traps that the two integrations fall into.
 
 Multi-player sessions are the case the current design fits worst. The spec expects one `sid` to span a movie and its interstitials, and the `bg` key is defined over "all players in a session". A second `CmcdReporter` with the same `sid` restarts every sequence number and sends `msd` again. The child-reporters proposal ([PR #398](https://github.com/streaming-video-technology-alliance/common-media-library/pull/398)) adds a root and child split to the current class. That proposal calls a session-first API "the right long-term shape" and set it aside for surface area.
 
-Inside the package, `CmcdReporter` is one class with five jobs: session bookkeeping, report assembly, transform policy, delivery, and the public facade. Each feature since version 2.4 added pairwise interactions between those jobs. A refactor ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)) splits the class along those jobs while keeping every current semantic. This RFC asks a different question: which of those semantics would a design built for the version 2 spec keep at all? The answer removes session rotation, the retention window, eviction, the provenance record, and the `customData` generics. It adds derived keys and a reporter per media player. The design record in [`plans/cmcd-session-api/`](../plans/cmcd-session-api/) has the comparison.
+Inside the package, `CmcdReporter` is one class with five jobs: session bookkeeping, report assembly, transform policy, delivery, and the public facade. Each feature since version 2.4 added pairwise interactions between those jobs. A refactor ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)) splits the class along those jobs while keeping every current semantic. This RFC asks a different question: which of those semantics would a design built for the version 2 spec keep at all? The answer keeps `sid` rotation as one call and removes the retention window, eviction, the provenance record, and the `customData` generics. It adds derived keys and a reporter per media player. The design record in [`plans/cmcd-session-api/`](../plans/cmcd-session-api/) has the comparison.
 
 ## Guide-level explanation
 
 ### One session, one reporter per media player
 
-Create one session per playback session. The session generates a `sid` when the configuration has none. A session never changes its `sid`. When the player needs a new `sid`, it disposes the session and creates a new one. Requests that are still in flight keep reporting under the session that issued them (see [Requests and responses](#requests-and-responses)).
+Create one session per playback session. The session generates a `sid` when the configuration has none. When the same playback needs a new `sid`, for example one supplied by the manifest, call `rotate(sid)`. Every reporter moves to the new `sid` and keeps its state (see [Changing the `sid`](#changing-the-sid)). When a new playback starts, create a new session. Requests that are still in flight keep reporting under the `sid` that issued them (see [Requests and responses](#requests-and-responses)).
 
 ```ts
 const session = createCmcdSession({
@@ -107,9 +107,9 @@ The ownership in one picture. Targets belong to the session, and every reporter 
 
 ```mermaid
 flowchart TB
-    subgraph session["CmcdSession, one sid"]
+    subgraph session["CmcdSession, one sid at a time"]
         direction TB
-        sdata["sid, version, transport, timers<br>msd, bg, bsa, bsda, completed spans"]
+        sdata["current sid, version, transport, timers, bg<br>per sid: msd, bsa, bsda, completed spans"]
         subgraph reporters["Reporters, one per media player"]
             direction LR
             primary["CmcdSessionReporter, cid movie-42<br>store, reported values, host, su, open span"]
@@ -185,25 +185,27 @@ primary.recordResponse(req, {
 
 `timing` is optional. Without it, the reporter computes `ts` and `ttlb` from the clock reading it recorded in `decorate()`. A request the player did not keep can still be recorded with `{ url }`. That response reports under the calling reporter's session.
 
-A response can arrive after the player has disposed the session that issued the request. The record on the request points to that session, so the `rr` report has the old `sid` and the old session's next sequence number. The old session sends the report at once, because no batch will fill again.
+A response can arrive after the session rotated to a new `sid`, or after the player disposed the session. The record on the request points to the `sid` state that issued it. The `rr` report has the old `sid` and that state's next sequence number. An ended `sid` state sends the report at once, because no batch will fill again.
 
-The sequence for a response that arrives after its session was disposed:
+The sequence for a response that arrives after the session rotated to a new `sid`:
 
 ```mermaid
 sequenceDiagram
     participant Player as media player
-    participant A as CmcdSession A
-    participant B as CmcdSession B
+    participant S as CmcdSession
+    participant A as sid A state
+    participant B as sid B state
     participant C as collector
-    Player->>A: reporter.decorate(request, data)
-    A-->>Player: request with cmcd record, sid A, sn 41
+    Player->>S: reporter.decorate(request, data)
+    S->>A: sn 41
+    S-->>Player: request with cmcd record, sid A
     Player->>Player: send the request to the CDN
-    Player->>A: session.dispose()
+    Player->>S: session.rotate(sid B)
     A->>C: POST the queued lines
-    Player->>B: createCmcdSession(), then createReporter()
+    S->>B: fresh counters, gates, and queues
     Note over Player,C: the response for the old request arrives
-    Player->>B: reporter.recordResponse(request, info)
-    B-->>A: the record's origin is session A
+    Player->>S: reporter.recordResponse(request, info)
+    S-->>A: the record's origin is the sid A state
     A->>C: POST e=rr with sid A and sn 42, at once
 ```
 
@@ -238,6 +240,16 @@ cid="ad-7",e=t,sid="s1",sn=11,sta=p,ts=1764752430000,v=2
 cid="ad-7",e=ae,sid="s1",sn=12,ts=1764752445000,v=2
 cid="movie-42",e=ps,sid="s1",sn=13,sta=p,ts=1764752445200,v=2
 ```
+
+### Changing the `sid`
+
+`rotate()` starts the next `sid` for the whole session. Every reporter keeps its store and its `cid`. Every target restarts its sequence at zero, the `msd` gate re-arms, and the session totals reset. The dedup baselines reset, so the first state each reporter pushes after the rotation emits under the new `sid`. Rotation itself emits nothing. The queued lines of the old `sid` are sent at once. A response to a request issued before the rotation still reports under the old `sid`.
+
+```ts
+session.rotate(manifestSid)   // omit the argument for a new UUID
+```
+
+Use `rotate()` for a new `sid` on the same playback. Use a new session for a new playback.
 
 ### Lifecycle
 
@@ -319,8 +331,9 @@ The defaults make `{ url }` a complete event target and `createCmcdSession()` a 
 
 ```ts
 type CmcdSession = {
-	readonly sid: string
+	readonly sid: string                        // the current sid
 	createReporter(config?: CmcdSessionReporterConfig): CmcdSessionReporter
+	rotate(sid?: string): void
 	flush(): void
 	dispose(): void
 }
@@ -340,6 +353,17 @@ type CmcdDiscreteEventType = 'as' | 'ae' | 'abs' | 'abe' | 'sk' | 'm' | 'um' | '
 ```
 
 `CmcdDiscreteEventType` is `CmcdEventType` without the derived types `ps`, `pr`, `c`, `b`, `bc`, `t`, `rr`, `e`, and `h`.
+
+### Rotation
+
+`rotate(sid?)` starts a new `sid`, a new UUID when the argument is omitted. A `sid` equal to the current one is a no-op, and a `sid` over 64 characters throws.
+
+- Resets: every target's `sn`, `msd` gate, `bs` flags, `ec` buffers, and `bsd` cursor. The session totals `msd`, `bsa`, `bsda`, and the spans reset too, with their supplied-value overrides.
+- Kept: every reporter with its store, `cid`, host, and `su` state, and the session `bg`.
+- Baselines: the dedup baselines of every reporter and of `bg` reset. The next push of a tracked field emits under the new `sid`, even when the value did not change. Rotation itself emits nothing.
+- Spans: an open starvation span is dropped, as at `dispose()`.
+- Delivery: the queued lines of the old `sid` are sent at once. A target that a 410 silenced is active again, because the spec scopes the 410 to the current session.
+- Late responses: a request issued before the rotation still reports under the old `sid`, with that `sid`'s next sequence number.
 
 ### Data
 
@@ -478,9 +502,9 @@ type CmcdRequestRecord = {
 }
 ```
 
-The record is a plain object. Spread and `Object.assign` keep it. JSON does not keep the link to the origin. A response for a request that crossed a JSON boundary reports under the calling reporter's session. A request that the transform cancelled still receives a record, so its response is attributed.
+The record is a plain object. Spread and `Object.assign` keep it. JSON does not keep the link to the origin. A response for a request that crossed a JSON boundary reports under the calling reporter's session and its current `sid`. A request that the transform cancelled still receives a record, so its response is attributed.
 
-There is no registry of sessions. The record is the key in a reporter-internal `WeakMap`. The value is the origin: the session and the reporter that issued the request, the per-request data, and the start time. `recordResponse()` on any reporter looks the record up and reports through that origin. The entry lives as long as the request object, and the origin keeps its session reachable, so nothing else tracks past sessions.
+There is no registry of sessions or of past `sid` values. The record is the key in a reporter-internal `WeakMap`. The value is the origin. It holds the `sid` state and the reporter that issued the request, the `cid` at that time, the per-request data, and the start time. `recordResponse()` on any reporter looks the record up and reports through that origin. The entry lives as long as the request object, and the origin keeps its `sid` state reachable, so nothing else tracks past `sid` values.
 
 ### Responses
 
@@ -502,12 +526,13 @@ type CmcdResourceTiming = {
 A `PerformanceResourceTiming` entry satisfies `CmcdResourceTiming`. The `rr` report is assembled in this order, and a later source wins:
 
 1. the origin reporter's store
-2. the session data
-3. the per-request data given to `decorate()`
-4. the derived response keys
-5. the `data` argument
+2. the session data of the origin `sid`
+3. the `cid` at the time of `decorate()`
+4. the per-request data given to `decorate()`
+5. the derived response keys
+6. the `data` argument
 
-It goes to every event target of the origin session that lists `rr`.
+It goes to every event target that lists `rr`, with the counters of the origin `sid`.
 
 ### Transforms
 
@@ -575,7 +600,7 @@ The retention ledger, the eviction pass, the dirty set, and the provenance encod
 | `customHeaderMap` | `headerMap` |
 | `sessionRetention`, `CMCD_REQUEST_PROVENANCE`, the `C` type parameter | removed |
 | `update(data)` | `reporter.update(data)` with plain values |
-| `update({ sid })` | dispose the session and create a new one |
+| `update({ sid })` | `session.rotate(sid)` |
 | `recordEvent(PLAY_STATE, data)` and the other state events | `reporter.update(data)` |
 | `recordEvent(ERROR, { ec })` | `reporter.recordError(codes)` |
 | `createRequestReport(request, data)` | `reporter.decorate(request, data)` |
@@ -602,13 +627,14 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 - **A DOM side effect.** The session listens to `visibilitychange` when a document exists. `derive: { bg: false }` turns that off.
 - **Derived defaults are assumptions.** `dl` from `bl` and `pr`, and `su` from the play state, match what hls.js and dash.js compute today. The spec words `dl` as a possible equivalence only.
 - **Exact attribution needs the returned request.** A player that keeps only the URL gets current-session attribution for late responses.
-- **In-flight requests keep their session reachable.** There is no retention knob. Memory is bounded by the requests the player keeps.
+- **In-flight requests keep their `sid` state reachable.** There is no retention knob. Memory is bounded by the requests the player keeps.
 - **Event-mode code is always bundled** with the session API, because targets are configuration objects. `CmcdReporter` has the same property today. The factory-function alternative in Rationale would improve on both.
 - **Wire differences from `CmcdReporter`.** The first `t` report comes after one interval. `ec` no longer persists across reports. `bs` is per destination.
 
 ## Rationale and alternatives
 
-- **Refactor in place ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)).** Keeps the public API and every 2.6 semantic. It organizes session rotation, retention, eviction, dirty tracking, and provenance into units, and it keeps them. This RFC removes them. The design record compares the two.
+- **Refactor in place ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)).** Keeps the public API and every 2.6 semantic. It organizes the retention ledger, eviction, dirty tracking, and provenance into units, and it keeps them. This RFC removes them and keeps rotation as one call on the session. The design record compares the two.
+- **A new session object for every `sid`.** The first draft's rule. It made a manifest-supplied `sid` expensive. The player had to dispose the session, create a new one with new reporters, swap every reference, and push the whole store again. `rotate()` keeps every object and moves the `sid`-scoped state to a fresh internal object. The change is one call, and late responses still find their `sid`.
 - **One object that is both the session and the primary reporter.** One fewer line in the common case. It recreates the root and child asymmetry of the child-reporters proposal, where a child cannot do what the root does.
 - **An explicit `activate()` for interval reports.** The child-reporters proposal's answer. It needs two calls in the interstitials controller and gives wrong data when a teardown skips the return call. One line per live reporter needs no call and loses no reporter.
 - **A presenting-reporter rule for one interval line.** The first draft of this design used the most recently updated reporter without `nr`. Overlay and side-by-side interstitials render both players, so the rule flips on every metric push.

--- a/rfc/cmcd-session-api.md
+++ b/rfc/cmcd-session-api.md
@@ -36,6 +36,7 @@ reporter.update({ sta: 'p', bl: 3200, mtp: 15000, pt: 12000 }) // emits e=ps wit
 
 const req = reporter.decorate({ url: 'https://cdn.example.com/seg-1.m4s' }, { ot: 'v', d: 4000, br: 3000 })
 const res = await fetch(req.url, { headers: req.headers })
+const bytes = await res.arrayBuffer() // read the body first, so ttlb measures the last byte
 reporter.recordResponse(req, { status: res.status, headers: res.headers }) // emits e=rr
 
 reporter.recordError('MEDIA_ERR_NETWORK')
@@ -183,7 +184,7 @@ primary.recordResponse(req, {
 })
 ```
 
-`timing` is optional. Without it, the reporter computes `ts` and `ttlb` from the clock reading it recorded in `decorate()`. A request the player did not keep can still be recorded with `{ url }`. That response reports under the calling reporter's session.
+`timing` is optional. Without it, the reporter computes `ts` and `ttlb` from the clock reading it recorded in `decorate()`. Call `recordResponse()` after the body is read, so `ttlb` measures the last byte. A request the player did not keep can still be recorded with `{ url }`. That response reports under the calling reporter's session.
 
 A response can arrive after the session rotated to a new `sid`, or after the player disposed the session. The record on the request points to the `sid` state that issued it. The `rr` report has the old `sid` and that state's next sequence number. An ended `sid` state sends the report at once, because no batch will fill again.
 
@@ -271,7 +272,7 @@ session.dispose()
 | `CmcdSession`, `CmcdSessionConfig` | types |
 | `CmcdSessionReporter`, `CmcdSessionReporterConfig`, `CmcdPlaybackData`, `CmcdMetric`, `CmcdNextObject` | types |
 | `CmcdEventTargetConfig`, `CmcdRequester` | types |
-| `CmcdRequestLike`, `CmcdDecoratedRequest`, `CmcdRequestRecord`, `CmcdResponseInfo`, `CmcdResourceTiming` | types |
+| `CmcdRequestLike`, `CmcdDecoratedRequest`, `CmcdRequestRecord`, `CmcdResponseInfo`, `CmcdResourceTiming`, `CmcdResponseData` | types |
 | `CmcdRequestTransform`, `CmcdEventTransform` | types |
 | `CmcdDiscreteEventType` | type |
 | `CMCD_EVENT_HOSTNAME`, `CmcdEventType.HOSTNAME` | constant, the missing `h` event |
@@ -323,9 +324,11 @@ The defaults make `{ url }` a complete event target and `createCmcdSession()` a 
 - an unknown key or a malformed custom key in a `keys` list
 - an unknown event type
 - a target without `url`
-- a negative `interval`
-- a `batchSize` under 1
+- an `interval` that is negative or not finite
+- a `batchSize` or `maxQueueSize` that is not a finite positive integer, or a `batchSize` over `maxQueueSize`
 - an event target with `version`
+
+`configure()` replaces the request-mode settings `version`, `transmissionMode`, `keys`, and `headerMap` for the current and later `sid` states. It runs the same checks as creation, emits nothing, and resets no counter or gate. Event targets are fixed at creation. A manifest that supplies CMCD parameters is handled with `configure()`, then `rotate(sid)`, then `update({ cid })`.
 
 ### Objects
 
@@ -334,6 +337,7 @@ type CmcdSession = {
 	readonly sid: string                        // the current sid
 	createReporter(config?: CmcdSessionReporterConfig): CmcdSessionReporter
 	rotate(sid?: string): void
+	configure(settings: Pick<CmcdSessionConfig, 'version' | 'transmissionMode' | 'keys' | 'headerMap'>): void
 	flush(): void
 	dispose(): void
 }
@@ -345,7 +349,7 @@ type CmcdSessionReporter = {
 	recordEvent(type: 'ce', data: CmcdPlaybackData & { cen: string }): void
 	recordError(code: string | readonly string[], data?: CmcdPlaybackData): void
 	decorate<R extends CmcdRequestLike>(request: R, data?: CmcdPlaybackData): CmcdDecoratedRequest<R>
-	recordResponse(request: CmcdRequestLike, response: CmcdResponseInfo, data?: CmcdPlaybackData): void
+	recordResponse(request: CmcdRequestLike, response: CmcdResponseInfo, data?: CmcdResponseData): void
 	dispose(): void
 }
 
@@ -358,12 +362,12 @@ type CmcdDiscreteEventType = 'as' | 'ae' | 'abs' | 'abe' | 'sk' | 'm' | 'um' | '
 
 `rotate(sid?)` starts a new `sid`, a new UUID when the argument is omitted. A `sid` equal to the current one is a no-op, and a `sid` over 64 characters throws.
 
-- Resets: every target's `sn`, `msd` gate, `bs` flags, `ec` buffers, and `bsd` cursor. The session totals `msd`, `bsa`, `bsda`, and the spans reset too, with their supplied-value overrides.
-- Kept: every reporter with its store, `cid`, host, and `su` state, and the session `bg`.
+- Resets: every target's `sn`, `msd` gate, `bs` flags, `ec` buffers, and `bsd` cursors. The session totals `bsa` and `bsda`, the pending `bsd` samples, and the supplied-value overrides reset too.
+- Kept: every reporter with its store, `cid`, host, and `su` state, and the session `bg`. A startup measurement in progress carries over. When `msd` is not yet derived or supplied, the new `sid` keeps the start time, so the manifest-supplied `sid` flow still reports `msd`.
 - Baselines: the dedup baselines of every reporter and of `bg` reset. The next push of a tracked field emits under the new `sid`, even when the value did not change. Rotation itself emits nothing.
-- Spans: an open starvation span is dropped, as at `dispose()`.
+- Stalls: a stall open at rotation is measured by the new `sid` from the rotation time, and the old `sid` drops its part. The new targets start with `bs` set, because the player is still rebuffering.
 - Delivery: the queued lines of the old `sid` are sent at once. A target that a 410 silenced is active again, because the spec scopes the 410 to the current session.
-- Late responses: a request issued before the rotation still reports under the old `sid`, with that `sid`'s next sequence number.
+- Late responses: a request issued before the rotation still reports under the old `sid`, with that `sid`'s next sequence number. The ended `sid` state keeps a copy of each reporter's store, so a late response reads the values at rotation and not the live store.
 
 ### Data
 
@@ -385,9 +389,9 @@ type CmcdMetric = number | Readonly<Partial<Record<CmcdObjectType, number>>>
 type CmcdNextObject = string | { readonly url: string; readonly range?: string }
 ```
 
-`ec` is not a member. Errors go through `recordError()`. `sid`, `sn`, `v`, `e`, and the response keys are reporter-owned and not members. The reporter rounds values per the spec: integer keys to the nearest integer, and `bl`, `dl`, `mtp`, `rtp`, and `tbl` to the nearest 100. Pass raw values. `CmcdPlayerState` remains the token union for `sta`, not the payload type.
+`ec` is not a member. Errors go through `recordError()`. `sid`, `sn`, `v`, and `e` are reporter-owned and not members. The response keys are members of `CmcdResponseData` alone, the data type of `recordResponse()`. The reporter rounds values per the spec: integer keys to the nearest integer, and `bl`, `dl`, `mtp`, `rtp`, and `tbl` to the nearest 100. Pass raw values. `CmcdPlayerState` remains the token union for `sta`, not the payload type.
 
-`update()` merges `data` into the reporter's store. A member set to `undefined` removes the key. `bg`, `msd`, `bsa`, `bsda`, and `bsd` are session facts. Pushing one of them through any reporter writes it on the session, and automatic tracking of that key stops for the rest of the session.
+`update()` merges `data` into the reporter's store. A member set to `undefined` removes the key. `bg`, `msd`, `bsa`, `bsda`, and `bsd` are session facts. Pushing one of them through any reporter writes it on the session, and automatic tracking of that key stops for the rest of the session. A pushed `bsd` is not stored. It is appended as one pending sample per cause, and each destination receives it once.
 
 ### State-change events
 
@@ -406,9 +410,10 @@ A derived key is a key the reporter computes from state it observes. A derived d
 |---|---|---|---|
 | `sn`, `v`, `e` | the target's counter, the version, and the event type | target and report | ignored |
 | `ts` | the clock at emission | report | wins for that report |
-| `msd` | the first `sta` s to the next `sta` p | session, sent once per target | wins, stops tracking |
-| `bs` | `sta` entering r | target and reporter, cleared by the next report | wins for that report |
-| `bsa`, `bsda`, `bsd` | spans between `sta` transitions | session totals, `bsd` cursor per target | wins, stops tracking |
+| `msd` | the first `sta` s to the next `sta` p, carried across `rotate()` while in progress | session, sent once per target | wins, stops tracking |
+| `bs` | `sta` entering or remaining in r since the target's last report | target and reporter, cleared by the first report after the stall | wins for that report |
+| `bsa`, `bsda` | completed stalls between `sta` transitions | session totals per cause | wins, stops tracking |
+| `bsd` | one completed stall per entry, one entry per cause per report | pending samples per cause, one cursor per cause per target | appended as a sample, stops tracking |
 | `su` | in s, k, or r, or no p since one | reporter | wins |
 | `dl` | `bl` divided by `pr`, nearest 100 ms, only when `pr` is over 0 | reporter | wins |
 | `h`, event `h` | the host of decorated request URLs | reporter | wins, stops tracking |
@@ -416,7 +421,9 @@ A derived key is a key the reporter computes from state it observes. A derived d
 | `url`, `rc`, `ts`, `ttfb`, `ttlb` | request URL, status, timing | response | wins |
 | `cmsds`, `cmsdd` | `CMSD-Static` and `CMSD-Dynamic` response headers | response | wins |
 
-`bsa` counts the transitions into `r`. `bsda` and `bsd` count completed spans only. A span still open at `dispose()` is dropped. Automatic `bsa`, `bsd`, and `bsda` entries have no cause token. `url` is the request URL without its `CMCD` parameter. `rc` is `0` when `status` is absent. `ts` for a response is the request start.
+`bsa` counts the transitions into `r`. `bsda` and `bsd` count completed stalls only. A stall still open at `dispose()` is dropped. Automatic `bsa`, `bsd`, and `bsda` entries have no cause token. Each completed stall is reported to each destination once, on the next report to that destination, in order. A report carries at most one `bsd` value per cause, per spec item 14. A second stall of the same cause waits for the next report to that destination. The pending samples are capped at 100 per cause, and the oldest is dropped past the cap. When no destination can report `bsd`, no samples are kept.
+
+`url` is the request URL without its `CMCD` parameter. `rc` is `0` when `status` is absent. `ts` for a response is the request start. `ttfb` is omitted when `responseStart` is absent, zero, or earlier than `startTime`. Resource Timing reports zero there for a cross-origin resource without `Timing-Allow-Origin`. `ttlb` is omitted when neither `duration` nor a usable `responseEnd` exists and no start time was recorded. `ttfbb` and `smrt` have no derivation and come only from `CmcdResponseData`.
 
 The `sta` transitions and what each one derives. Transitions with no effect on a derived key are left out.
 
@@ -452,7 +459,7 @@ Every report is assembled in a fixed order, and a later source wins:
 4. the target's per-reporter state
 5. the derived defaults
 
-The target's `transform` runs on a copy when one is configured, and `null` cancels the report for that target. The reporter then filters the keys, applies the spec rules, encodes, and only then commits: `sn` advances, the `msd` gate closes when the output kept `msd`, `bs` and the `ec` buffer clear, and the `bsd` cursor moves. A cancelled or failed report commits nothing.
+The target's `transform` runs on a copy when one is configured, and `null` cancels the report for that target. The reporter then filters the keys, applies the spec rules, encodes, and only then commits. At the commit, `sn` advances, and the `msd` gate closes when the output kept `msd`. The `ec` buffer clears, `bs` clears unless the reporter is still rebuffering, and the `bsd` cursors move. A cancelled or failed report commits nothing.
 
 The report path for one target:
 
@@ -469,7 +476,7 @@ flowchart LR
     tr -- data --> restore["restore required keys<br>re-stamp sid, e, ts"] --> prep
     prep --> enc["encode"]
     enc -- throws --> fail["thrown to the caller<br>nothing committed"]
-    enc -- line --> commit["commit<br>sn advances<br>msd gate closes if kept<br>bs and ec clear<br>bsd cursor moves"]
+    enc -- line --> commit["commit<br>sn advances<br>msd gate closes if kept<br>ec clears, bs clears unless still in r<br>bsd cursors move"]
     commit --> out["event target: queue the line<br>request target: URL or headers"]
 ```
 
@@ -485,7 +492,7 @@ Each interval tick emits one `t` line per live reporter, in creation order, or o
 
 ### Requests
 
-`decorate()` returns a new object. `url` has the `CMCD` query parameter in query mode. `headers` has the four `CMCD-` headers in header mode, and an empty shard is omitted. `cmcd` is the request record.
+`decorate()` returns a new object. `url` has the `CMCD` query parameter in query mode. `headers` has the four `CMCD-` headers in header mode, and an empty shard is omitted. `cmcd` is the request record. Before it writes, `decorate()` removes an existing `CMCD` parameter and every `CMCD-` header from its copy, compared case-insensitively. A re-decorated request carries only the current report.
 
 ```ts
 type CmcdRequestLike = {
@@ -493,7 +500,9 @@ type CmcdRequestLike = {
 	readonly headers?: Readonly<Record<string, string>>
 }
 
-type CmcdDecoratedRequest<R extends CmcdRequestLike> = R & {
+type CmcdDecoratedRequest<R extends CmcdRequestLike> = Omit<R, 'url' | 'headers' | 'cmcd'> & {
+	readonly url: string
+	readonly headers?: Readonly<Record<string, string>>
 	readonly cmcd: CmcdRequestRecord
 }
 
@@ -505,7 +514,7 @@ type CmcdRequestRecord = {
 
 The record is a plain object. Spread and `Object.assign` keep it. JSON does not keep the link to the origin. A response for a request that crossed a JSON boundary reports under the calling reporter's session and its current `sid`. A request that the transform cancelled still receives a record, so its response is attributed.
 
-There is no registry of sessions or of past `sid` values. The record is the key in a reporter-internal `WeakMap`. The value is the origin. It holds the `sid` state and the reporter that issued the request, the `cid` at that time, the per-request data, and the start time. `recordResponse()` on any reporter looks the record up and reports through that origin. The entry lives as long as the request object, and the origin keeps its `sid` state reachable, so nothing else tracks past `sid` values.
+There is no registry of sessions or of past `sid` values. The record is the key in a reporter-internal `WeakMap`. The value is the origin. It holds the `sid` state and the reporter that issued the request. It also holds the `cid` at that time, a copy of the per-request data, and the start time. `decorate()` captures the origin before the transform runs, so a transform that calls `rotate()` does not move the request to the new `sid`. `recordResponse()` on any reporter looks the record up and reports through that origin. The entry lives as long as the request object, and the origin keeps its `sid` state reachable, so nothing else tracks past `sid` values.
 
 ### Responses
 
@@ -522,14 +531,25 @@ type CmcdResourceTiming = {
 	responseEnd?: number
 	duration?: number
 }
+
+type CmcdResponseData = CmcdPlaybackData & {
+	ttfb?: number                                // milliseconds from the request start
+	ttlb?: number
+	ttfbb?: number
+	smrt?: string                                // base64, the request tracing header
+	cmsds?: string                               // base64
+	cmsdd?: string
+	rc?: number
+	url?: string
+}
 ```
 
 A `PerformanceResourceTiming` entry satisfies `CmcdResourceTiming`. The `rr` report is assembled in this order, and a later source wins:
 
-1. the origin reporter's store
+1. the origin reporter's store, or the copy the ended `sid` state keeps
 2. the session data of the origin `sid`
 3. the `cid` at the time of `decorate()`
-4. the per-request data given to `decorate()`
+4. the copy of the per-request data taken in `decorate()`
 5. the derived response keys
 6. the `data` argument
 
@@ -544,6 +564,8 @@ type CmcdEventTransform = (data: Cmcd, request: Readonly<CmcdRequestLike> | unde
 
 The contract is the one the transforms RFC defined. The reporter copies nested values before a configured transform runs, re-stamps the reporter-owned keys after it returns, and restores a required key the transform removed. A transform that throws cancels that target's report. The error is thrown to the caller after every other target has been processed. The `request` argument is the request the player passed to `decorate()`. Read player fields through a cast or bracket access.
 
+A transform may call `rotate()`. The report it runs in and the request origin stay with the `sid` state that was current when the call began. The remaining targets of that emission do too. The rotation applies to every later call.
+
 A transform is also the opt-in for a collector that expects `bg=?0` on the exit `b` report. A target that lists `b` always receives `bg` when it is true. An absent `bg` on `e=b` therefore means exit. The encoder writes an explicit `bg: false` on `e=b` as `?0`.
 
 ```ts
@@ -555,7 +577,7 @@ const legacyCollector: CmcdEventTargetConfig = {
 
 ### Delivery
 
-Each event target queues encoded lines. It sends a batch when the queue reaches `batchSize`, on `flush()`, on `dispose()`, or at once for a late `rr` report after dispose. A batch is one POST with content type `application/cmcd`, the lines joined by a line feed, no trailing line feed, and the target's `headers`. The default requester is `fetch` with `keepalive` set when the body is under 64 KB, so a `flush()` on `pagehide` completes.
+Each event target queues encoded lines. It sends a batch when the queue reaches `batchSize`, on `flush()`, on `dispose()`, or at once for a late `rr` report after dispose. A batch is one POST with content type `application/cmcd`, the lines joined by a line feed, no trailing line feed, and the target's `headers`. The default requester is `fetch` with `keepalive` set when the body is under 64 KB, so a `flush()` on `pagehide` completes. A drain requested by `flush()`, `rotate()`, `dispose()`, or a late `rr` while a send is in flight is kept. The target continues draining when the send settles, until the queue is empty.
 
 | Response | Action |
 |---|---|
@@ -611,6 +633,7 @@ The retention ledger, the eviction pass, the dirty set, and the provenance encod
 | `sessionRetention`, `CMCD_REQUEST_PROVENANCE`, the `C` type parameter | removed |
 | `update(data)` | `reporter.update(data)` with plain values |
 | `update({ sid })` | `session.rotate(sid)` |
+| the rebuild on manifest parameters | `session.configure(settings)`, then `session.rotate(sid)` and `reporter.update({ cid })` |
 | `recordEvent(PLAY_STATE, data)` and the other state events | `reporter.update(data)` |
 | `recordEvent(ERROR, { ec })` | `reporter.recordError(codes)` |
 | `createRequestReport(request, data)` | `reporter.decorate(request, data)` |
@@ -627,7 +650,7 @@ A sketch of the hls.js change in `CMCDController`:
 - keep the decorated request on the loader wrapper, so `onSuccess` can pass it to `recordResponse()`
 - create one reporter per interstitial asset, and set `nr` on the primary at asset start and clear it at primary resume
 
-The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` persistence, and the rebuild logic. It passes the decorated request through its interceptors.
+The dash.js change deletes `calculateMsd()`, the rebuffer tracking, and the `ec` persistence. The rebuild on manifest parameters becomes `configure()`, `rotate()`, and `update({ cid })`. It passes the decorated request through its interceptors.
 
 ## Drawbacks
 
@@ -637,7 +660,7 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 - **A DOM side effect.** The session listens to `visibilitychange` when a document exists. `derive: { bg: false }` turns that off.
 - **Derived defaults are assumptions.** `dl` from `bl` and `pr`, and `su` from the play state, match what hls.js and dash.js compute today. The spec words `dl` as a possible equivalence only.
 - **Exact attribution needs the returned request.** A player that keeps only the URL gets current-session attribution for late responses.
-- **In-flight requests keep their `sid` state reachable.** There is no retention knob. Memory is bounded by the requests the player keeps.
+- **In-flight requests keep their `sid` state reachable.** There is no retention knob. Memory is bounded by the requests the player keeps. An ended `sid` state also holds one copy of each reporter's store, taken at rotation.
 - **Event-mode code is always bundled** with the session API, because targets are configuration objects. `CmcdReporter` has the same property today. The factory-function alternative in Rationale would improve on both.
 - **Wire differences from `CmcdReporter`.** The first `t` report comes after one interval. `ec` no longer persists across reports. `bs` is per destination. The exit `b` report has no `bg` key, and `bg=?0` needs a transform.
 
@@ -652,6 +675,7 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 - **Attribution from the wire.** Parse the `sid` back out of the `CMCD` query parameter or the `CMCD-Session` header. It works with a URL alone and survives every boundary. It costs a decode per response, it fails in header mode without the headers, and it cannot attribute a cancelled or undecorated request. It remains possible as a later fallback.
 - **A pull model.** A `getState()` callback read at report time gives fresh interval data. A pull cannot see a `sta` transition when it happens, so transitions still need a push, and the player has two data paths.
 - **Targets as factory functions.** `requestTarget()` and `eventTarget()` would let a request-only player tree-shake event mode. It adds a concept and an import for every integration. A hybrid keeps the top-level request settings and wraps only the event targets in `eventTarget()`. It gets the same bundle result for one import. The configuration shape here matches `CmcdReporterConfig`, which both adopters already map.
+- **Request targets per destination.** The PR #398 review accepted a configured destination identity for request mode. Requests to different CDNs would then keep separate `sn`, `bs`, and `bsd` state. This RFC keeps one request target per `sid`. The spec defines targets as the configured event endpoints, in items 4, 5, 8, 12 to 14, and 16 of section 5. It names no request-mode target below the mode itself. The `sn` rule, one sequence per combination of mode and target, then gives request mode one sequence. An optional destination name on `decorate()` can be added later without a breaking change.
 - **`formatters` on the session API.** Custom formatters remain on `encodeCmcd`. The transform is the per-report hook of this API, and the built-in rounding is a spec `MUST` for `dl`, `mtp`, and `rtp`.
 - **`ts` as a second `update()` argument.** It would keep the payload type to stored keys. Kept in the payload for now, because every other reporting call takes `ts` in its payload too.
 - **`start()` and `stop()`.** Both adopters call them only as a constructor and destructor pair. Creation and `dispose()` cover that with two calls.
@@ -684,6 +708,7 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 - `Retry-After` from a 429 response, when the requester returns headers.
 - A per-target URL filter for the `url` key, per spec item 19. A transform covers it today.
 - A request-only entry point that leaves out event-mode delivery, if an adopter without a collector asks for it.
+- An optional destination name on `decorate()`, with request-mode state per name, if CTA WAVE defines request-mode targets below the mode.
 - `CmcdReporter` marked deprecated after hls.js and dash.js migrate, and removed in the next major version.
 
 ## Final Decision

--- a/rfc/cmcd-session-api.md
+++ b/rfc/cmcd-session-api.md
@@ -15,7 +15,7 @@ status: draft
 
 Add a second reporting API to `@svta/cml-cmcd`, next to `CmcdReporter`. The new API has three objects that match the three scopes of CTA-5004-B.
 
-- A `CmcdSession` reports under one `sid` at a time. It owns the report targets, the transport, the interval timers, and the session totals. `rotate()` starts the next `sid` for every reporter in the session.
+- A `CmcdSession` reports under one `sid` at a time. It owns the report targets, the requester, the interval timers, and the session totals. `rotate()` starts the next `sid` for every reporter in the session.
 - A `CmcdSessionReporter` reports for one media player inside the session. Through it the player pushes its state, records events, decorates its requests, and records their responses.
 - A target is one report destination. Targets are internal. Each target owns the state the spec scopes to a destination. That state is the sequence number, the `msd` gate, the `bs` flag, the `ec` buffer, and the delivery queue.
 
@@ -109,7 +109,7 @@ The ownership in one picture. Targets belong to the session, and every reporter 
 flowchart TB
     subgraph session["CmcdSession, one sid at a time"]
         direction TB
-        sdata["current sid, version, transport, timers, bg<br>per sid: msd, bsa, bsda, completed spans"]
+        sdata["current sid, version, requester, timers, bg<br>per sid: msd, bsa, bsda, completed spans"]
         subgraph reporters["Reporters, one per media player"]
             direction LR
             primary["CmcdSessionReporter, cid movie-42<br>store, reported values, host, su, open span"]
@@ -270,7 +270,7 @@ session.dispose()
 | `createCmcdSession` | function |
 | `CmcdSession`, `CmcdSessionConfig` | types |
 | `CmcdSessionReporter`, `CmcdSessionReporterConfig`, `CmcdPlaybackData`, `CmcdMetric`, `CmcdNextObject` | types |
-| `CmcdEventTargetConfig`, `CmcdTransport` | types |
+| `CmcdEventTargetConfig`, `CmcdRequester` | types |
 | `CmcdRequestLike`, `CmcdDecoratedRequest`, `CmcdRequestRecord`, `CmcdResponseInfo`, `CmcdResourceTiming` | types |
 | `CmcdRequestTransform`, `CmcdEventTransform` | types |
 | `CmcdDiscreteEventType` | type |
@@ -287,7 +287,7 @@ type CmcdSessionConfig = {
 	headerMap?: Partial<CmcdHeaderMap>          // header shard per custom key
 	transform?: CmcdRequestTransform
 	eventTargets?: readonly CmcdEventTargetConfig[]
-	transport?: CmcdTransport                   // default: fetch, POST, keepalive
+	requester?: CmcdRequester                   // default: fetch, POST, keepalive
 	derive?: Partial<Record<'bg' | 'dl' | 'su', boolean>>  // observations the reporter may turn into defaults. default: all true
 	onError?: (error: unknown) => void
 }
@@ -309,10 +309,10 @@ type CmcdSessionReporterConfig = {
 ```
 
 ```ts
-type CmcdTransport = (request: HttpRequest) => Promise<{ status: number }>
+type CmcdRequester = (request: HttpRequest) => Promise<{ status: number }>
 ```
 
-`transport` sends the event-mode POST requests. It receives an `HttpRequest` with `url`, `method`, `headers`, and `body`, and it resolves with the response status. The default is `fetch` with `keepalive`. It is the `requester` argument of `CmcdReporter` under a new name, so the loader adapters that hls.js and dash.js inject today move over unchanged.
+`requester` sends the event-mode POST requests. It receives an `HttpRequest` with `url`, `method`, `headers`, and `body`, and it resolves with the response status. The default is `fetch` with `keepalive`. It is the `requester` argument of `CmcdReporter`, with the same name and signature. The loader adapters that hls.js and dash.js inject today move over unchanged.
 
 `derive` names the three observations the reporter may turn into a default value when the player has not supplied the key: `bg` from document visibility, `dl` from `bl` and `pr`, and `su` from the play state. Each is on by default, and `false` turns it off. The other derived keys are spec definitions and have no switch. A supplied value wins for all of them.
 
@@ -385,7 +385,7 @@ type CmcdMetric = number | Readonly<Partial<Record<CmcdObjectType, number>>>
 type CmcdNextObject = string | { readonly url: string; readonly range?: string }
 ```
 
-`ec` is not a member. Errors go through `recordError()`. `sid`, `sn`, `v`, `e`, and the response keys are reporter-owned and not members. The reporter rounds values per the spec: integer keys to the nearest integer, and `bl`, `dl`, `mtp`, `rtp`, and `tbl` to the nearest 100. Pass raw values.
+`ec` is not a member. Errors go through `recordError()`. `sid`, `sn`, `v`, `e`, and the response keys are reporter-owned and not members. The reporter rounds values per the spec: integer keys to the nearest integer, and `bl`, `dl`, `mtp`, `rtp`, and `tbl` to the nearest 100. Pass raw values. `CmcdPlayerState` remains the token union for `sta`, not the payload type.
 
 `update()` merges `data` into the reporter's store. A member set to `undefined` removes the key. `bg`, `msd`, `bsa`, `bsda`, and `bsd` are session facts. Pushing one of them through any reporter writes it on the session, and automatic tracking of that key stops for the rest of the session.
 
@@ -396,7 +396,7 @@ After the merge, the reporter compares the five tracked fields with the values i
 - `pr` fires only while `sta` is `p`. A rate change while paused fires once on resume, if the rate still differs from the last reported rate.
 - `bg` is compared on the session, and `b` follows the one-line-per-reporter rule of interval reports.
 
-The `cid` given to `createReporter()` counts as reported, so creating a reporter emits no `c`. The first `sta` and the first `br` emit, because nothing was reported before. `b` on exit is sent as `bg=?0`, as today.
+The `cid` given to `createReporter()` counts as reported, so creating a reporter emits no `c`. The first `sta` and the first `br` emit, because nothing was reported before. `b` on exit is a bare `e=b` with no `bg` key, as the event definition describes. The exit also removes `bg` from the session, so later reports omit it. The Transforms section shows the opt-in for `bg=?0`.
 
 ### Derived keys
 
@@ -404,7 +404,8 @@ A derived key is a key the reporter computes from state it observes. A derived d
 
 | Key | Derived from | Scope | Supplied value |
 |---|---|---|---|
-| `sn`, `ts`, `v`, `e` | counters and clocks | target and report | ignored |
+| `sn`, `v`, `e` | the target's counter, the version, and the event type | target and report | ignored |
+| `ts` | the clock at emission | report | wins for that report |
 | `msd` | the first `sta` s to the next `sta` p | session, sent once per target | wins, stops tracking |
 | `bs` | `sta` entering r | target and reporter, cleared by the next report | wins for that report |
 | `bsa`, `bsda`, `bsd` | spans between `sta` transitions | session totals, `bsd` cursor per target | wins, stops tracking |
@@ -543,15 +544,24 @@ type CmcdEventTransform = (data: Cmcd, request: Readonly<CmcdRequestLike> | unde
 
 The contract is the one the transforms RFC defined. The reporter copies nested values before a configured transform runs, re-stamps the reporter-owned keys after it returns, and restores a required key the transform removed. A transform that throws cancels that target's report. The error is thrown to the caller after every other target has been processed. The `request` argument is the request the player passed to `decorate()`. Read player fields through a cast or bracket access.
 
+A transform is also the opt-in for a collector that expects `bg=?0` on the exit `b` report. A target that lists `b` always receives `bg` when it is true. An absent `bg` on `e=b` therefore means exit. The encoder writes an explicit `bg: false` on `e=b` as `?0`.
+
+```ts
+const legacyCollector: CmcdEventTargetConfig = {
+	url: 'https://legacy-collector.example.com/cmcd',
+	transform: (data) => data.e === 'b' && !('bg' in data) ? { ...data, bg: false } : data,
+}
+```
+
 ### Delivery
 
-Each event target queues encoded lines. It sends a batch when the queue reaches `batchSize`, on `flush()`, on `dispose()`, or at once for a late `rr` report after dispose. A batch is one POST with content type `application/cmcd`, the lines joined by a line feed, no trailing line feed, and the target's `headers`. The default transport is `fetch` with `keepalive` set when the body is under 64 KB, so a `flush()` on `pagehide` completes.
+Each event target queues encoded lines. It sends a batch when the queue reaches `batchSize`, on `flush()`, on `dispose()`, or at once for a late `rr` report after dispose. A batch is one POST with content type `application/cmcd`, the lines joined by a line feed, no trailing line feed, and the target's `headers`. The default requester is `fetch` with `keepalive` set when the body is under 64 KB, so a `flush()` on `pagehide` completes.
 
 | Response | Action |
 |---|---|
 | 2xx | done, back-off resets |
 | 410 | the target sends nothing else for this session |
-| 429, 5xx, or a rejected transport | the batch returns to the front of the queue, and the target retries after a back-off |
+| 429, 5xx, or a requester rejection | the batch returns to the front of the queue, and the target retries after a back-off |
 | other 4xx | the batch is dropped, back-off resets |
 
 The back-off starts at one second and doubles to a cap of 60 seconds. New lines keep queueing during the back-off and go out with the retry, which is the aggregation the spec recommends for 429. After `dispose()`, a target stops retrying when a retry at the 60 second step fails. When a queue exceeds `maxQueueSize`, the oldest lines are dropped.
@@ -565,7 +575,7 @@ stateDiagram-v2
     sending --> queueing : 2xx, back-off resets
     sending --> queueing : other 4xx, batch dropped
     sending --> gone : 410
-    sending --> backingOff : 429, 5xx, or a rejected transport, batch back to the front
+    sending --> backingOff : 429, 5xx, or a requester rejection, batch back to the front
     backingOff --> sending : timer fires, 1 s doubling to 60 s, or flush
     backingOff --> gone : after dispose, the 60 s retry fails
     gone --> [*]
@@ -577,7 +587,7 @@ stateDiagram-v2
 
 Runtime data never throws. An unknown or empty value is omitted, as the spec requires. A value the structured-field encoder cannot serialize throws at the call that produced it, and nothing is committed. `createReporter()` on a disposed session throws. Every other call on a disposed reporter or session is a no-op.
 
-`onError` receives the errors that have no caller. Those are a transform or encoding failure on an interval tick, and a transport that still fails after the back-off cap. Without `onError`, those errors are thrown from the timer callback, as today.
+`onError` receives the errors that have no caller. Those are a transform or encoding failure on an interval tick, and a requester that still fails after the back-off cap. Without `onError`, those errors are thrown from the timer callback, as today. In both paths the error is an `Error`. Its message names the target URL and the stage, one of transform, encode, or send. Its `cause` is the requester's error when one exists.
 
 ### Bundle and performance
 
@@ -595,7 +605,7 @@ The retention ledger, the eviction pass, the dirty set, and the provenance encod
 
 | `CmcdReporter` | Session API |
 |---|---|
-| `new CmcdReporter(config, requester)` | `createCmcdSession({ ...config, transport })` and `session.createReporter({ cid })` |
+| `new CmcdReporter(config, requester)` | `createCmcdSession({ ...config, requester })` and `session.createReporter({ cid })` |
 | `enabledKeys` | `keys` |
 | `customHeaderMap` | `headerMap` |
 | `sessionRetention`, `CMCD_REQUEST_PROVENANCE`, the `C` type parameter | removed |
@@ -629,7 +639,7 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 - **Exact attribution needs the returned request.** A player that keeps only the URL gets current-session attribution for late responses.
 - **In-flight requests keep their `sid` state reachable.** There is no retention knob. Memory is bounded by the requests the player keeps.
 - **Event-mode code is always bundled** with the session API, because targets are configuration objects. `CmcdReporter` has the same property today. The factory-function alternative in Rationale would improve on both.
-- **Wire differences from `CmcdReporter`.** The first `t` report comes after one interval. `ec` no longer persists across reports. `bs` is per destination.
+- **Wire differences from `CmcdReporter`.** The first `t` report comes after one interval. `ec` no longer persists across reports. `bs` is per destination. The exit `b` report has no `bg` key, and `bg=?0` needs a transform.
 
 ## Rationale and alternatives
 
@@ -641,7 +651,7 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 - **The provenance record and the retention ledger (2.6.0).** Exact attribution for every request, including undecorated ones, and it survives JSON with a bridge. Its cost is the ledger, the eviction pass, a symbol on `customData`, and a contract that neither adopter meets today.
 - **Attribution from the wire.** Parse the `sid` back out of the `CMCD` query parameter or the `CMCD-Session` header. It works with a URL alone and survives every boundary. It costs a decode per response, it fails in header mode without the headers, and it cannot attribute a cancelled or undecorated request. It remains possible as a later fallback.
 - **A pull model.** A `getState()` callback read at report time gives fresh interval data. A pull cannot see a `sta` transition when it happens, so transitions still need a push, and the player has two data paths.
-- **Targets as factory functions.** `requestTarget()` and `eventTarget()` would let a request-only player tree-shake event mode. It adds a concept and an import for every integration. The configuration shape here matches `CmcdReporterConfig`, which both adopters already map.
+- **Targets as factory functions.** `requestTarget()` and `eventTarget()` would let a request-only player tree-shake event mode. It adds a concept and an import for every integration. A hybrid keeps the top-level request settings and wraps only the event targets in `eventTarget()`. It gets the same bundle result for one import. The configuration shape here matches `CmcdReporterConfig`, which both adopters already map.
 - **`formatters` on the session API.** Custom formatters remain on `encodeCmcd`. The transform is the per-report hook of this API, and the built-in rounding is a spec `MUST` for `dl`, `mtp`, and `rtp`.
 - **`ts` as a second `update()` argument.** It would keep the payload type to stored keys. Kept in the payload for now, because every other reporting call takes `ts` in its payload too.
 - **`start()` and `stop()`.** Both adopters call them only as a constructor and destructor pair. Creation and `dispose()` cover that with two calls.
@@ -657,22 +667,23 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 
 ## Unresolved questions
 
-1. **Configuration shape.** Top-level request settings plus `eventTargets`, as proposed, or a `targets` list of factory functions that tree-shakes event mode.
+1. **Configuration shape.** Top-level request settings plus `eventTargets`, as proposed, or a `targets` list of factory functions that tree-shakes event mode. **Resolution (2026-09-10):** kept as proposed. The gain of the factory shape is unmeasured, and no known adopter has a request-only configuration path. A request-only entry point remains a future possibility.
 2. **`bg` from document visibility by default.** On by default with an opt-out, or off by default. **Resolution (2026-09-09):** on by default. `derive: { bg: false }` turns it off.
 3. **`dl` as a derived default.** Keep it, or make `dl` player-supplied only. **Resolution (2026-09-09):** kept as a derived default. A supplied `dl` wins, and `derive: { dl: false }` turns the default off.
-4. **One `t` line per live reporter.** Collector feedback on two lines per interval during interstitials.
-5. **`b` on exit.** `bg=?0`, as today, or a bare `e=b` as the token description implies.
-6. **`ts` in the `update()` payload**, or a second argument.
-7. **A URL-only `recordResponse()`** with attribution parsed from the wire, or the current-session fallback alone.
-8. **`onError` signature.** A single callback, or a context argument that names the target and the stage.
-9. **Names.** `CmcdSessionReporter` and `CmcdPlaybackData` next to the existing `CmcdPlayerState` token union.
+4. **One `t` line per live reporter.** Collector feedback on two lines per interval during interstitials. **Resolution (2026-09-10):** the design stands. Section 4 of the spec describes a multi-player session as per-player reports, told apart by `cid`, play state, and `nr`. Section 8.1.7 shows two players under one `sid`. No collector objection was raised. Reviewers can reopen the question on the pull request.
+5. **`b` on exit.** `bg=?0`, as today, or a bare `e=b` as the token description implies. **Resolution (2026-09-10):** a bare `e=b`. The `bg` key row says the key SHOULD only be sent when TRUE. The `b` event definition describes exit as the event without `bg`. A collector that checks for the presence of `bg` would read `bg=?0` as an enter. The Transforms section shows the per-target opt-in for `bg=?0`.
+6. **`ts` in the `update()` payload**, or a second argument. **Resolution (2026-09-10):** kept in the payload. `update()`, `recordEvent()`, `recordError()`, `decorate()`, and `recordResponse()` take one data shape. A second argument would give `recordEvent()` and `recordError()` a third parameter or a second convention.
+7. **A URL-only `recordResponse()`** with attribution parsed from the wire, or the current-session fallback alone. **Resolution (2026-09-10):** the fallback alone. Wire parsing needs a map from `sid` strings to past `sid` states, with an eviction rule, which is the retention ledger this design removes. The fallback is wrong only for a response that crosses a `rotate()` from a player that discarded the returned request. Wire parsing stays listed under Rationale as a possible later addition.
+8. **`onError` signature.** A single callback, or a context argument that names the target and the stage. **Resolution (2026-09-10):** a single callback. The target URL and the stage are in the error message, and `cause` holds the requester's error. Targets are fixed at `createCmcdSession()`, so a player cannot act on a target at runtime, and a context argument would only feed logging. A `CmcdReportError` class with fields stays a later option if a player needs to branch on the stage.
+9. **Names.** `CmcdSessionReporter` and `CmcdPlaybackData` next to the existing `CmcdPlayerState` token union. **Resolution (2026-09-10):** accepted. `CmcdPlayerState` remains the token union for `sta`, and the Data section says so. The send function is `requester` and `CmcdRequester`, not `CmcdTransport`. The package already uses "transport" for the interception adapters of `CmcdReportRecorder`, and `requester` is the existing `CmcdReporter` argument name.
 
 ## Future possibilities
 
 - `encodeCmcd` accepts the plain values of `CmcdPlaybackData`, once the shared preparation step normalizes them.
 - Automatic response recording through a `PerformanceObserver`, so a browser player never calls `recordResponse()`.
-- `Retry-After` from a 429 response, when the transport returns headers.
+- `Retry-After` from a 429 response, when the requester returns headers.
 - A per-target URL filter for the `url` key, per spec item 19. A transform covers it today.
+- A request-only entry point that leaves out event-mode delivery, if an adopter without a collector asks for it.
 - `CmcdReporter` marked deprecated after hls.js and dash.js migrate, and removed in the next major version.
 
 ## Final Decision

--- a/rfc/cmcd-session-api.md
+++ b/rfc/cmcd-session-api.md
@@ -16,10 +16,10 @@ status: draft
 Add a second reporting API to `@svta/cml-cmcd`, next to `CmcdReporter`. The new API has three objects that match the three scopes of CTA-5004-B.
 
 - A `CmcdSession` is one `sid`. It owns the report targets, the transport, the interval timers, and the session totals.
-- A `CmcdPlayer` is one media player inside the session. A player pushes its state, records events, decorates its requests, and records their responses.
+- A `CmcdSessionReporter` reports for one media player inside the session. Through it the player pushes its state, records events, decorates its requests, and records their responses.
 - A target is one report destination. Targets are internal. Each target owns the state the spec scopes to a destination. That state is the sequence number, the `msd` gate, the `bs` flag, the `ec` buffer, and the delivery queue.
 
-The reporter derives every key the spec defines in terms of state the reporter can observe. A player never computes `msd`, `bs`, `su`, `sn`, the starvation counters, or the response timing keys. State-change events come only from `update()`. A session can hold several players, and the wire shows one `sid` and one sequence per target.
+The reporter derives every key the spec defines in terms of state the reporter can observe. A player never computes `msd`, `bs`, `su`, `sn`, the starvation counters, or the response timing keys. State-change events come only from `update()`. A session can hold several reporters, one per media player, and the wire shows one `sid` and one sequence per target.
 
 ```ts
 import { createCmcdSession, CmcdEventType } from '@svta/cml-cmcd'
@@ -29,17 +29,17 @@ const session = createCmcdSession({
 	eventTargets: [{ url: 'https://collector.example.com/cmcd' }],
 })
 
-const player = session.createPlayer({ cid: 'movie-42' })
+const reporter = session.createReporter({ cid: 'movie-42' })
 
-player.update({ sf: 'h', st: 'v' })
-player.update({ sta: 'p', bl: 3200, mtp: 15000, pt: 12000 }) // emits e=ps with this snapshot
+reporter.update({ sf: 'h', st: 'v' })
+reporter.update({ sta: 'p', bl: 3200, mtp: 15000, pt: 12000 }) // emits e=ps with this snapshot
 
-const req = player.decorate({ url: 'https://cdn.example.com/seg-1.m4s' }, { ot: 'v', d: 4000, br: 3000 })
+const req = reporter.decorate({ url: 'https://cdn.example.com/seg-1.m4s' }, { ot: 'v', d: 4000, br: 3000 })
 const res = await fetch(req.url, { headers: req.headers })
-player.recordResponse(req, { status: res.status, headers: res.headers }) // emits e=rr
+reporter.recordResponse(req, { status: res.status, headers: res.headers }) // emits e=rr
 
-player.recordError('MEDIA_ERR_NETWORK')
-player.recordEvent(CmcdEventType.AD_BREAK_START)
+reporter.recordError('MEDIA_ERR_NETWORK')
+reporter.recordEvent(CmcdEventType.AD_BREAK_START)
 
 session.dispose()
 ```
@@ -68,11 +68,11 @@ The current API also has three traps that the two integrations fall into.
 
 Multi-player sessions are the case the current design fits worst. The spec expects one `sid` to span a movie and its interstitials, and the `bg` key is defined over "all players in a session". A second `CmcdReporter` with the same `sid` restarts every sequence number and sends `msd` again. The child-reporters proposal ([PR #398](https://github.com/streaming-video-technology-alliance/common-media-library/pull/398)) adds a root and child split to the current class. That proposal calls a session-first API "the right long-term shape" and set it aside for surface area.
 
-Inside the package, `CmcdReporter` is one class with five jobs: session bookkeeping, report assembly, transform policy, delivery, and the public facade. Each feature since version 2.4 added pairwise interactions between those jobs. A refactor ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)) splits the class along those jobs while keeping every current semantic. This RFC asks a different question: which of those semantics would a design built for the version 2 spec keep at all? The answer removes session rotation, the retention window, eviction, the provenance record, and the `customData` generics, and adds derived keys and a player object. The design record in [`plans/cmcd-session-api/`](../plans/cmcd-session-api/) has the comparison.
+Inside the package, `CmcdReporter` is one class with five jobs: session bookkeeping, report assembly, transform policy, delivery, and the public facade. Each feature since version 2.4 added pairwise interactions between those jobs. A refactor ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)) splits the class along those jobs while keeping every current semantic. This RFC asks a different question: which of those semantics would a design built for the version 2 spec keep at all? The answer removes session rotation, the retention window, eviction, the provenance record, and the `customData` generics. It adds derived keys and a reporter per media player. The design record in [`plans/cmcd-session-api/`](../plans/cmcd-session-api/) has the comparison.
 
 ## Guide-level explanation
 
-### One session, one or more players
+### One session, one reporter per media player
 
 Create one session per playback session. The session generates a `sid` when the configuration has none. A session never changes its `sid`. When the player needs a new `sid`, it disposes the session and creates a new one. Requests that are still in flight keep reporting under the session that issued them (see [Requests and responses](#requests-and-responses)).
 
@@ -94,31 +94,31 @@ const session = createCmcdSession({
 })
 ```
 
-Create one player per media player. The primary player and an interstitial player are the same type and use the same code.
+Create one reporter per media player. The reporter for the primary player and the reporter for an interstitial player are the same type and use the same code.
 
 ```ts
-const primary = session.createPlayer({ cid: 'movie-42' })
-const ad = session.createPlayer({ cid: 'ad-7' })
+const primary = session.createReporter({ cid: 'movie-42' })
+const ad = session.createReporter({ cid: 'ad-7' })
 ```
 
-Every player reports under the session's `sid` and takes the next sequence number of each target. Dispose a player when its media player is destroyed.
+Every reporter uses the session's `sid` and takes the next sequence number of each target. Dispose a reporter when its media player is destroyed.
 
-The ownership in one picture. Targets belong to the session, and every player reports to every target.
+The ownership in one picture. Targets belong to the session, and every reporter reports to every target.
 
 ```mermaid
 flowchart TB
     subgraph session["CmcdSession, one sid"]
         direction TB
         sdata["sid, version, transport, timers<br>msd, bg, bsa, bsda, completed spans"]
-        subgraph players["Players, one per media player"]
+        subgraph reporters["Reporters, one per media player"]
             direction LR
-            primary["CmcdPlayer, cid movie-42<br>store, reported values, host, su, open span"]
-            ad["CmcdPlayer, cid ad-7<br>store, reported values, host, su, open span"]
+            primary["CmcdSessionReporter, cid movie-42<br>store, reported values, host, su, open span"]
+            ad["CmcdSessionReporter, cid ad-7<br>store, reported values, host, su, open span"]
         end
         subgraph targets["Targets, one per destination"]
             direction LR
-            req["request target<br>sn, msd gate, bsd cursor<br>bs and ec per player"]
-            ev1["event target A<br>sn, msd gate, bsd cursor<br>bs and ec per player<br>queue, back-off, gone"]
+            req["request target<br>sn, msd gate, bsd cursor<br>bs and ec per reporter"]
+            ev1["event target A<br>sn, msd gate, bsd cursor<br>bs and ec per reporter<br>queue, back-off, gone"]
             ev2["event target B<br>same state as A"]
         end
     end
@@ -132,7 +132,7 @@ flowchart TB
 
 ### Push state, get events
 
-`update()` stores playback state and derives the five state-change events from it: `sta` gives `ps`, `pr` gives `pr`, `cid` gives `c`, `bg` gives `b`, and `br` gives `bc`. The event fires when the value differs from the last value the reporter reported for that player. Metrics pushed in the same call ride the event.
+`update()` stores playback state and derives the five state-change events from it: `sta` gives `ps`, `pr` gives `pr`, `cid` gives `c`, `bg` gives `b`, and `br` gives `bc`. The event fires when the value differs from the last value that reporter reported. Metrics pushed in the same call ride the event.
 
 ```ts
 primary.update({ sta: 'r', bl: 0 })        // emits e=ps,sta=r,bl=(0)
@@ -153,7 +153,7 @@ ad.recordEvent(CmcdEventType.AD_START)
 ad.recordEvent(CmcdEventType.CUSTOM_EVENT, { cen: 'ad-quartile', 'com.example-quartile': 'q3' })
 ```
 
-`recordError()` follows the spec's error rule. A target that lists `e` in its events receives an `e=e` report at once, with `ec`. Every other target, the request target included, buffers the code and attaches `ec` to the player's next report to that destination.
+`recordError()` follows the spec's error rule. A target that lists `e` in its events receives an `e=e` report at once, with `ec`. Every other target, the request target included, buffers the code and attaches `ec` to the reporter's next report to that destination.
 
 ```ts
 primary.recordError('MEDIA_ERR_NETWORK')
@@ -183,7 +183,7 @@ primary.recordResponse(req, {
 })
 ```
 
-`timing` is optional. Without it, the reporter computes `ts` and `ttlb` from the clock reading it recorded in `decorate()`. A request the player did not keep can still be recorded with `{ url }`. That response reports under the calling player's session.
+`timing` is optional. Without it, the reporter computes `ts` and `ttlb` from the clock reading it recorded in `decorate()`. A request the player did not keep can still be recorded with `{ url }`. That response reports under the calling reporter's session.
 
 A response can arrive after the player has disposed the session that issued the request. The record on the request points to that session, so the `rr` report has the old `sid` and the old session's next sequence number. The old session sends the report at once, because no batch will fill again.
 
@@ -195,15 +195,15 @@ sequenceDiagram
     participant A as CmcdSession A
     participant B as CmcdSession B
     participant C as collector
-    Player->>A: player.decorate(request, data)
+    Player->>A: reporter.decorate(request, data)
     A-->>Player: request with cmcd record, sid A, sn 41
     Player->>Player: send the request to the CDN
     Player->>A: session.dispose()
     A->>C: POST the queued lines
-    Player->>B: createCmcdSession(), then createPlayer()
+    Player->>B: createCmcdSession(), then createReporter()
     Note over Player,C: the response for the old request arrives
-    Player->>B: player.recordResponse(request, info)
-    B-->>A: the record resolves to session A
+    Player->>B: reporter.recordResponse(request, info)
+    B-->>A: the record's origin is session A
     A->>C: POST e=rr with sid A and sn 42, at once
 ```
 
@@ -212,7 +212,7 @@ sequenceDiagram
 The spec covers multi-player sessions with `cid`, `ps`, and `nr`. The session API needs no other concept. When an interstitial renders on its own player, the primary player sets `nr` while it fetches content that the user does not see.
 
 ```ts
-const ad = session.createPlayer({ cid: hash(asset.uri) })
+const ad = session.createReporter({ cid: hash(asset.uri) })
 primary.update({ nr: true })
 ad.update({ sta: 'p' })
 // ...
@@ -220,7 +220,7 @@ ad.dispose()
 primary.update({ nr: false })
 ```
 
-Each interval tick emits one `t` line per live player, with the same `ts` and consecutive sequence numbers. Overlay and side-by-side interstitials report both players, and a collector tells them apart by `cid` and `nr`.
+Each interval tick emits one `t` line per live reporter, with the same `ts` and consecutive sequence numbers. Overlay and side-by-side interstitials report both players, and a collector tells them apart by `cid` and `nr`.
 
 The wire during a sequential interstitial. Keys other than the ones shown are omitted.
 
@@ -230,18 +230,18 @@ cid="movie-42",e=ps,nr,sid="s1",sn=7,sta=a,ts=1764752400000,v=2
 cid="ad-7",e=as,sid="s1",sn=8,ts=1764752400050,v=2
 cid="ad-7",e=ps,sid="s1",sn=9,sta=p,ts=1764752400120,v=2
 
-# One interval tick: one t line per live player, same ts, consecutive sn
+# One interval tick: one t line per live reporter, same ts, consecutive sn
 cid="movie-42",e=t,nr,sid="s1",sn=10,sta=a,ts=1764752430000,v=2
 cid="ad-7",e=t,sid="s1",sn=11,sta=p,ts=1764752430000,v=2
 
-# The ad ends and its player is disposed, the primary renders again
+# The ad ends and its reporter is disposed, the primary renders again
 cid="ad-7",e=ae,sid="s1",sn=12,ts=1764752445000,v=2
 cid="movie-42",e=ps,sid="s1",sn=13,sta=p,ts=1764752445200,v=2
 ```
 
 ### Lifecycle
 
-Creating a session arms its interval timers. `flush()` sends every queued batch now. `dispose()` flushes, stops the timers, and closes the session. Calls on a disposed player or session do nothing.
+Creating a session arms its interval timers. `flush()` sends every queued batch now. `dispose()` flushes, stops the timers, and closes the session. Calls on a disposed reporter or session do nothing.
 
 ```ts
 window.addEventListener('pagehide', () => session.flush())
@@ -257,7 +257,7 @@ session.dispose()
 |---|---|
 | `createCmcdSession` | function |
 | `CmcdSession`, `CmcdSessionConfig` | types |
-| `CmcdPlayer`, `CmcdPlayerConfig`, `CmcdPlayerData`, `CmcdMetric`, `CmcdNextObject` | types |
+| `CmcdSessionReporter`, `CmcdSessionReporterConfig`, `CmcdPlaybackData`, `CmcdMetric`, `CmcdNextObject` | types |
 | `CmcdEventTargetConfig`, `CmcdTransport` | types |
 | `CmcdRequestLike`, `CmcdDecoratedRequest`, `CmcdRequestRecord`, `CmcdResponseInfo`, `CmcdResourceTiming` | types |
 | `CmcdRequestTransform`, `CmcdEventTransform` | types |
@@ -276,7 +276,7 @@ type CmcdSessionConfig = {
 	transform?: CmcdRequestTransform
 	eventTargets?: readonly CmcdEventTargetConfig[]
 	transport?: CmcdTransport                   // default: fetch, POST, keepalive
-	visibility?: boolean                        // derive bg from document.visibilityState. default true when document exists
+	derive?: Partial<Record<'bg' | 'dl' | 'su', boolean>>  // observations the reporter may turn into defaults. default: all true
 	onError?: (error: unknown) => void
 }
 
@@ -291,12 +291,20 @@ type CmcdEventTargetConfig = {
 	transform?: CmcdEventTransform
 }
 
-type CmcdPlayerConfig = {
+type CmcdSessionReporterConfig = {
 	cid?: string
 }
 ```
 
-The defaults make `{ url }` a complete event target and `createCmcdSession()` a complete request-mode configuration. The spec's minimum recommended event set is `ps`, `e`, `t`, and `rr`. A configuration error throws at `createCmcdSession()` or `createPlayer()`. The message names the parameter, the expected value, and the received value. The checks:
+```ts
+type CmcdTransport = (request: HttpRequest) => Promise<{ status: number }>
+```
+
+`transport` sends the event-mode POST requests. It receives an `HttpRequest` with `url`, `method`, `headers`, and `body`, and it resolves with the response status. The default is `fetch` with `keepalive`. It is the `requester` argument of `CmcdReporter` under a new name, so the loader adapters that hls.js and dash.js inject today move over unchanged.
+
+`derive` names the three observations the reporter may turn into a default value when the player has not supplied the key: `bg` from document visibility, `dl` from `bl` and `pr`, and `su` from the play state. Each is on by default, and `false` turns it off. The other derived keys are spec definitions and have no switch. A supplied value wins for all of them.
+
+The defaults make `{ url }` a complete event target and `createCmcdSession()` a complete request-mode configuration. The spec's minimum recommended event set is `ps`, `e`, `t`, and `rr`. A configuration error throws at `createCmcdSession()` or `createReporter()`. The message names the parameter, the expected value, and the received value. The checks:
 
 - a `sid` over 64 characters
 - a `cid` over 128 characters
@@ -312,19 +320,19 @@ The defaults make `{ url }` a complete event target and `createCmcdSession()` a 
 ```ts
 type CmcdSession = {
 	readonly sid: string
-	createPlayer(config?: CmcdPlayerConfig): CmcdPlayer
+	createReporter(config?: CmcdSessionReporterConfig): CmcdSessionReporter
 	flush(): void
 	dispose(): void
 }
 
-type CmcdPlayer = {
+type CmcdSessionReporter = {
 	readonly session: CmcdSession
-	update(data: CmcdPlayerData): void
-	recordEvent(type: Exclude<CmcdDiscreteEventType, 'ce'>, data?: CmcdPlayerData): void
-	recordEvent(type: 'ce', data: CmcdPlayerData & { cen: string }): void
-	recordError(code: string | readonly string[], data?: CmcdPlayerData): void
-	decorate<R extends CmcdRequestLike>(request: R, data?: CmcdPlayerData): CmcdDecoratedRequest<R>
-	recordResponse(request: CmcdRequestLike, response: CmcdResponseInfo, data?: CmcdPlayerData): void
+	update(data: CmcdPlaybackData): void
+	recordEvent(type: Exclude<CmcdDiscreteEventType, 'ce'>, data?: CmcdPlaybackData): void
+	recordEvent(type: 'ce', data: CmcdPlaybackData & { cen: string }): void
+	recordError(code: string | readonly string[], data?: CmcdPlaybackData): void
+	decorate<R extends CmcdRequestLike>(request: R, data?: CmcdPlaybackData): CmcdDecoratedRequest<R>
+	recordResponse(request: CmcdRequestLike, response: CmcdResponseInfo, data?: CmcdPlaybackData): void
 	dispose(): void
 }
 
@@ -335,7 +343,7 @@ type CmcdDiscreteEventType = 'as' | 'ae' | 'abs' | 'abe' | 'sk' | 'm' | 'um' | '
 
 ### Data
 
-`CmcdPlayerData` is the one input type for `update()`, per-event data, per-request data, and per-response data. Every member is optional.
+`CmcdPlaybackData` is the one input type for `update()`, per-event data, per-request data, and per-response data. Every member is optional.
 
 | Members | Type |
 |---|---|
@@ -355,29 +363,31 @@ type CmcdNextObject = string | { readonly url: string; readonly range?: string }
 
 `ec` is not a member. Errors go through `recordError()`. `sid`, `sn`, `v`, `e`, and the response keys are reporter-owned and not members. The reporter rounds values per the spec: integer keys to the nearest integer, and `bl`, `dl`, `mtp`, `rtp`, and `tbl` to the nearest 100. Pass raw values.
 
-`update()` merges `data` into the player's store. A member set to `undefined` removes the key. `bg`, `msd`, `bsa`, `bsda`, and `bsd` are session facts. A player that pushes one of them writes it on the session, and automatic tracking of that key stops for the rest of the session.
+`update()` merges `data` into the reporter's store. A member set to `undefined` removes the key. `bg`, `msd`, `bsa`, `bsda`, and `bsd` are session facts. Pushing one of them through any reporter writes it on the session, and automatic tracking of that key stops for the rest of the session.
 
 ### State-change events
 
-After the merge, the reporter compares the five tracked fields with the last value it reported for that player. The order is `sta`, `pr`, `cid`, `bg`, `br`. Each changed field emits its event to every target that lists it, with the merged store as the report. Two spec clauses shape the rule.
+After the merge, the reporter compares the five tracked fields with the values it last reported for that reporter. The order is `sta`, `pr`, `cid`, `bg`, `br`. Each changed field emits its event to every target that lists it, with the merged store as the report. Two spec clauses shape the rule.
 
 - `pr` fires only while `sta` is `p`. A rate change while paused fires once on resume, if the rate still differs from the last reported rate.
-- `bg` is compared on the session, and `b` follows the one-line-per-player rule of interval reports.
+- `bg` is compared on the session, and `b` follows the one-line-per-reporter rule of interval reports.
 
-The `cid` given to `createPlayer()` counts as reported, so creating a player emits no `c`. The first `sta` and the first `br` emit, because nothing was reported before. `b` on exit is sent as `bg=?0`, as today.
+The `cid` given to `createReporter()` counts as reported, so creating a reporter emits no `c`. The first `sta` and the first `br` emit, because nothing was reported before. `b` on exit is sent as `bg=?0`, as today.
 
 ### Derived keys
 
-| Key | Derived from | Scope | Player value |
+A derived key is a key the reporter computes from state it observes. A derived default is a derived key the reporter fills only when the player has not supplied it. A value from `update()` wins for the rest of the session, and a value in per-call data wins for that report. The last column says how a supplied value interacts with each key.
+
+| Key | Derived from | Scope | Supplied value |
 |---|---|---|---|
 | `sn`, `ts`, `v`, `e` | counters and clocks | target and report | ignored |
 | `msd` | the first `sta` s to the next `sta` p | session, sent once per target | wins, stops tracking |
-| `bs` | `sta` entering r | target and player, cleared by the next report | wins for that report |
+| `bs` | `sta` entering r | target and reporter, cleared by the next report | wins for that report |
 | `bsa`, `bsda`, `bsd` | spans between `sta` transitions | session totals, `bsd` cursor per target | wins, stops tracking |
-| `su` | in s, k, or r, or no p since one | player | wins |
-| `dl` | `bl` divided by `pr`, nearest 100 ms, only when `pr` is over 0 | player | wins |
-| `h`, event `h` | the host of decorated request URLs | player | wins, stops tracking |
-| `bg`, event `b` | `document.visibilityState`, when `visibility` is on | session | wins, stops tracking |
+| `su` | in s, k, or r, or no p since one | reporter | wins |
+| `dl` | `bl` divided by `pr`, nearest 100 ms, only when `pr` is over 0 | reporter | wins |
+| `h`, event `h` | the host of decorated request URLs | reporter | wins, stops tracking |
+| `bg`, event `b` | `document.visibilityState`, when `derive.bg` is on | session | wins, stops tracking |
 | `url`, `rc`, `ts`, `ttfb`, `ttlb` | request URL, status, timing | response | wins |
 | `cmsds`, `cmsdd` | `CMSD-Static` and `CMSD-Dynamic` response headers | response | wins |
 
@@ -411,10 +421,10 @@ stateDiagram-v2
 
 Every report is assembled in a fixed order, and a later source wins:
 
-1. the player's store
+1. the reporter's store
 2. the session data
 3. the per-call data
-4. the target's per-player state
+4. the target's per-reporter state
 5. the derived defaults
 
 The target's `transform` runs on a copy when one is configured, and `null` cancels the report for that target. The reporter then filters the keys, applies the spec rules, encodes, and only then commits: `sn` advances, the `msd` gate closes when the output kept `msd`, `bs` and the `ec` buffer clear, and the `bsd` cursor moves. A cancelled or failed report commits nothing.
@@ -425,7 +435,7 @@ The report path for one target:
 flowchart LR
     subgraph assemble["Assemble, a later source wins"]
         direction TB
-        s1["player store"] --> s2["session data"] --> s3["per-call data"] --> s4["target state for the player"] --> s5["derived defaults"]
+        s1["reporter store"] --> s2["session data"] --> s3["per-call data"] --> s4["target state for the reporter"] --> s5["derived defaults"]
     end
     assemble --> tq{"transform<br>configured?"}
     tq -- no --> prep["filter keys<br>apply the spec rules"]
@@ -446,7 +456,7 @@ Filtering follows the target's `keys`. A key the current event requires is inclu
 
 The response keys appear only on `rr`. `cen` appears only on `ce`. `d` and `tpb` follow the object-type rule, and `ab`, `lab`, and `tab` yield to `br`, `lb`, and `tb`, as the encoder does today.
 
-Each interval tick emits one `t` line per live player, in creation order, or one session-only line when the session has no player. Session-triggered events, `t` and `b`, follow that rule. Player-triggered events emit one line for that player. The first `t` report of a target comes one interval after creation. Today's `start()` sends one at once. The `ps` event for `sta` s already marks the start of a session.
+Each interval tick emits one `t` line per live reporter, in creation order, or one session-only line when the session has no reporter. Session-triggered events, `t` and `b`, follow that rule. Reporter-triggered events emit one line for that reporter. The first `t` report of a target comes one interval after creation. Today's `start()` sends one at once. The `ps` event for `sta` s already marks the start of a session.
 
 ### Requests
 
@@ -468,7 +478,9 @@ type CmcdRequestRecord = {
 }
 ```
 
-The record is a plain object. Spread and `Object.assign` keep it. JSON does not keep the link to the origin. A response for a request that crossed a JSON boundary reports under the calling player's session. A request that the transform cancelled still receives a record, so its response is attributed.
+The record is a plain object. Spread and `Object.assign` keep it. JSON does not keep the link to the origin. A response for a request that crossed a JSON boundary reports under the calling reporter's session. A request that the transform cancelled still receives a record, so its response is attributed.
+
+There is no registry of sessions. The record is the key in a reporter-internal `WeakMap`. The value is the origin: the session and the reporter that issued the request, the per-request data, and the start time. `recordResponse()` on any reporter looks the record up and reports through that origin. The entry lives as long as the request object, and the origin keeps its session reachable, so nothing else tracks past sessions.
 
 ### Responses
 
@@ -489,7 +501,7 @@ type CmcdResourceTiming = {
 
 A `PerformanceResourceTiming` entry satisfies `CmcdResourceTiming`. The `rr` report is assembled in this order, and a later source wins:
 
-1. the origin player's store
+1. the origin reporter's store
 2. the session data
 3. the per-request data given to `decorate()`
 4. the derived response keys
@@ -538,7 +550,7 @@ stateDiagram-v2
 
 ### Errors
 
-Runtime data never throws. An unknown or empty value is omitted, as the spec requires. A value the structured-field encoder cannot serialize throws at the call that produced it, and nothing is committed. `createPlayer()` on a disposed session throws. Every other call on a disposed player or session is a no-op.
+Runtime data never throws. An unknown or empty value is omitted, as the spec requires. A value the structured-field encoder cannot serialize throws at the call that produced it, and nothing is committed. `createReporter()` on a disposed session throws. Every other call on a disposed reporter or session is a no-op.
 
 `onError` receives the errors that have no caller. Those are a transform or encoding failure on an interval tick, and a transport that still fails after the back-off cap. Without `onError`, those errors are thrown from the timer callback, as today.
 
@@ -558,48 +570,48 @@ The retention ledger, the eviction pass, the dirty set, and the provenance encod
 
 | `CmcdReporter` | Session API |
 |---|---|
-| `new CmcdReporter(config, requester)` | `createCmcdSession({ ...config, transport })` and `session.createPlayer({ cid })` |
+| `new CmcdReporter(config, requester)` | `createCmcdSession({ ...config, transport })` and `session.createReporter({ cid })` |
 | `enabledKeys` | `keys` |
 | `customHeaderMap` | `headerMap` |
 | `sessionRetention`, `CMCD_REQUEST_PROVENANCE`, the `C` type parameter | removed |
-| `update(data)` | `player.update(data)` with plain values |
+| `update(data)` | `reporter.update(data)` with plain values |
 | `update({ sid })` | dispose the session and create a new one |
-| `recordEvent(PLAY_STATE, data)` and the other state events | `player.update(data)` |
-| `recordEvent(ERROR, { ec })` | `player.recordError(codes)` |
-| `createRequestReport(request, data)` | `player.decorate(request, data)` |
-| `recordResponseReceived(response, data)` | `player.recordResponse(req, info, data)` |
+| `recordEvent(PLAY_STATE, data)` and the other state events | `reporter.update(data)` |
+| `recordEvent(ERROR, { ec })` | `reporter.recordError(codes)` |
+| `createRequestReport(request, data)` | `reporter.decorate(request, data)` |
+| `recordResponseReceived(response, data)` | `reporter.recordResponse(req, info, data)` |
 | `start()` | creation |
 | `stop(true)` | `session.dispose()` |
 | `flush()` | `session.flush()` |
-| `createChildReporter()` (proposed) | `session.createPlayer()` |
+| `createChildReporter()` (proposed) | `session.createReporter()` |
 
 A sketch of the hls.js change in `CMCDController`:
 
-- create the session and one player on `MANIFEST_LOADING`
+- create the session and one reporter on `MANIFEST_LOADING`
 - delete the `starved` and `buffering` flags and the `dl` arithmetic
 - keep the decorated request on the loader wrapper, so `onSuccess` can pass it to `recordResponse()`
-- create one player per interstitial asset, and set `nr` on the primary at asset start and clear it at primary resume
+- create one reporter per interstitial asset, and set `nr` on the primary at asset start and clear it at primary resume
 
 The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` persistence, and the rebuild logic. It passes the decorated request through its interceptors.
 
 ## Drawbacks
 
 - **Two reporting APIs in one package.** Until `CmcdReporter` is removed, both need documentation and tests. Adopters must choose.
-- **Two objects in the simplest integration.** A request-only player still creates a session and a player.
-- **One `t` line per player changes the wire during interstitials.** A collector that expected one interval line per `sid` sees two while an interstitial player exists.
-- **A DOM side effect.** The session listens to `visibilitychange` when a document exists. The `visibility` option turns that off.
+- **Two objects in the simplest integration.** A request-only player still creates a session and a reporter.
+- **One `t` line per reporter changes the wire during interstitials.** A collector that expected one interval line per `sid` sees two while an interstitial reporter exists.
+- **A DOM side effect.** The session listens to `visibilitychange` when a document exists. `derive: { bg: false }` turns that off.
 - **Derived defaults are assumptions.** `dl` from `bl` and `pr`, and `su` from the play state, match what hls.js and dash.js compute today. The spec words `dl` as a possible equivalence only.
 - **Exact attribution needs the returned request.** A player that keeps only the URL gets current-session attribution for late responses.
 - **In-flight requests keep their session reachable.** There is no retention knob. Memory is bounded by the requests the player keeps.
-- **Event-mode code is always bundled** with the session API, because targets are configuration objects.
+- **Event-mode code is always bundled** with the session API, because targets are configuration objects. `CmcdReporter` has the same property today. The factory-function alternative in Rationale would improve on both.
 - **Wire differences from `CmcdReporter`.** The first `t` report comes after one interval. `ec` no longer persists across reports. `bs` is per destination.
 
 ## Rationale and alternatives
 
 - **Refactor in place ([PR #422](https://github.com/streaming-video-technology-alliance/common-media-library/pull/422)).** Keeps the public API and every 2.6 semantic. It organizes session rotation, retention, eviction, dirty tracking, and provenance into units, and it keeps them. This RFC removes them. The design record compares the two.
-- **One object that is both the session and the primary player.** One fewer line in the common case. It recreates the root and child asymmetry of the child-reporters proposal, where a child cannot do what the root does.
-- **An explicit `activate()` for interval reports.** The child-reporters proposal's answer. It needs two calls in the interstitials controller and gives wrong data when a teardown skips the return call. One line per live player needs no call and loses no player.
-- **A presenting-player rule for one interval line.** The first draft of this design used the most recently updated player without `nr`. Overlay and side-by-side interstitials render both players, so the rule flips on every metric push.
+- **One object that is both the session and the primary reporter.** One fewer line in the common case. It recreates the root and child asymmetry of the child-reporters proposal, where a child cannot do what the root does.
+- **An explicit `activate()` for interval reports.** The child-reporters proposal's answer. It needs two calls in the interstitials controller and gives wrong data when a teardown skips the return call. One line per live reporter needs no call and loses no reporter.
+- **A presenting-reporter rule for one interval line.** The first draft of this design used the most recently updated reporter without `nr`. Overlay and side-by-side interstitials render both players, so the rule flips on every metric push.
 - **The provenance record and the retention ledger (2.6.0).** Exact attribution for every request, including undecorated ones, and it survives JSON with a bridge. Its cost is the ledger, the eviction pass, a symbol on `customData`, and a contract that neither adopter meets today.
 - **Attribution from the wire.** Parse the `sid` back out of the `CMCD` query parameter or the `CMCD-Session` header. It works with a URL alone and survives every boundary. It costs a decode per response, it fails in header mode without the headers, and it cannot attribute a cancelled or undecorated request. It remains possible as a later fallback.
 - **A pull model.** A `getState()` callback read at report time gives fresh interval data. A pull cannot see a `sta` transition when it happens, so transitions still need a push, and the player has two data paths.
@@ -611,7 +623,7 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 ## Prior art
 
 - **hls.js** `CMCDController` and **dash.js** `CmcdController` drive `CmcdReporter` today, and both compute the spec behavior listed in Motivation by hand.
-- **Shaka Player** `CmcdManager` is an independent implementation with the same per-player fields and no session sharing.
+- **Shaka Player** `CmcdManager` is an independent implementation with the same fields per media player and no session sharing.
 - **The report transforms RFC** ([`rfc/cmcd-reporter-middleware.md`](./cmcd-reporter-middleware.md)) defined the transform contract this API reuses.
 - **The session retention RFC** ([`rfc/cmcd-session-retention.md`](./cmcd-session-retention.md)) defined the late-response goal this API meets by object lifetime.
 - **The child-reporters RFC** ([PR #398](https://github.com/streaming-video-technology-alliance/common-media-library/pull/398)) defined the state partition between a session and a player that this API makes the primary model.
@@ -620,18 +632,18 @@ The dash.js change deletes `calculateMsd()`, the rebuffer tracking, the `ec` per
 ## Unresolved questions
 
 1. **Configuration shape.** Top-level request settings plus `eventTargets`, as proposed, or a `targets` list of factory functions that tree-shakes event mode.
-2. **`bg` from document visibility by default.** On by default with an opt-out, or off by default.
-3. **`dl` as a derived default.** Keep it, or make `dl` player-supplied only.
-4. **One `t` line per live player.** Collector feedback on two lines per interval during interstitials.
+2. **`bg` from document visibility by default.** On by default with an opt-out, or off by default. **Resolution (2026-09-09):** on by default. `derive: { bg: false }` turns it off.
+3. **`dl` as a derived default.** Keep it, or make `dl` player-supplied only. **Resolution (2026-09-09):** kept as a derived default. A supplied `dl` wins, and `derive: { dl: false }` turns the default off.
+4. **One `t` line per live reporter.** Collector feedback on two lines per interval during interstitials.
 5. **`b` on exit.** `bg=?0`, as today, or a bare `e=b` as the token description implies.
 6. **`ts` in the `update()` payload**, or a second argument.
 7. **A URL-only `recordResponse()`** with attribution parsed from the wire, or the current-session fallback alone.
 8. **`onError` signature.** A single callback, or a context argument that names the target and the stage.
-9. **Names.** `CmcdPlayer` and `CmcdPlayerData` next to the existing `CmcdPlayerState` token union.
+9. **Names.** `CmcdSessionReporter` and `CmcdPlaybackData` next to the existing `CmcdPlayerState` token union.
 
 ## Future possibilities
 
-- `encodeCmcd` accepts the plain values of `CmcdPlayerData`, once the shared preparation step normalizes them.
+- `encodeCmcd` accepts the plain values of `CmcdPlaybackData`, once the shared preparation step normalizes them.
 - Automatic response recording through a `PerformanceObserver`, so a browser player never calls `recordResponse()`.
 - `Retry-After` from a 429 response, when the transport returns headers.
 - A per-target URL filter for the `url` key, per spec item 19. A transform covers it today.


### PR DESCRIPTION
## Description

Draft RFC for a second reporting API in `@svta/cml-cmcd`, next to `CmcdReporter`, plus its design record. Review happens in the comments of this PR, per `rfc/README.md`.

**What the RFC proposes.** Three objects that match the three scopes of CTA-5004-B. A `CmcdSession` is one `sid` and owns the targets, the transport, the timers, and the session totals. A `CmcdPlayer` is one media player and pushes state, records events, decorates requests, and records responses. Targets are internal and own the per-destination state: `sn`, the `msd` gate, the `bs` flag, the `ec` buffer, and the queue. The reporter derives every key the spec defines in terms of state it can observe: `msd`, `bs`, `su`, `dl`, `h`, `bg`, the starvation counters, and the response keys. State-change events come only from `update()`. A session holds several players, and each interval tick emits one `t` line per live player. Late responses report under the session that issued the request through the record on the decorated request, with no retention window and no provenance symbol.

**Why now.** PR #422 restructures `CmcdReporter` while keeping every 2.6 semantic. Before committing to that path, this RFC asks which of those semantics a design built for the version 2 spec would keep. The comparison document answers that for each concept. Two findings from the hls.js and dash.js integrations, read on 2026-09-09, are in the Motivation section. Both players would drop every `rr` event on 2.6 or later, because neither passes the decorated request back. dash.js pairs `update({ sta })` with `recordEvent(PLAY_STATE, data)`, which loses the payload on 2.4 or later.

**Files.**

- `rfc/cmcd-session-api.md`: the proposal for adopters, with the API, one complete example, the contract, the costs, the alternatives, and nine open questions.
- `plans/cmcd-session-api/architecture.md`: the internal units, state, algorithms, the key table that replaces the spread of encoder tables, and the test plan.
- `plans/cmcd-session-api/comparison.md`: `CmcdReporter`, PR #422, and this design compared on size, concepts, spec coverage, and adopter impact.

**For reviewers.** The open questions in the RFC are the decisions this review should make, in particular the configuration shape, `bg` from document visibility by default, the `dl` default, and one `t` line per player during interstitials. `CmcdReporter` does not change in this proposal. Three spec gaps found on the way are listed at the end of the architecture document and can ship as separate fixes.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed (not applicable, no code changes)
- [ ] Docs/guides updated (not applicable, the RFC and the design record are the documents)
- [ ] Changelog updated (not applicable, no package change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
