### PR TITLE
fix(cmcd): remove the module-scope tables a bare import keeps

### DIFF
--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to
 
 ### Fixed
 
-- A bare import of the package no longer runs code at module scope. `CmcdReporter` built its required-event-key table with an array spread of `CMCD_STATE_EVENT_FIELDS`. Bundlers kept that table in every bundle that imports the package, even when the bundle does not use `CmcdReporter`
+- A bare import of the package no longer runs code at module scope. `CmcdReporter` built its required-event-key table with an array spread of `CMCD_STATE_EVENT_FIELDS`. `prepareCmcdData` built its key filter table with computed keys. Bundlers kept one or both tables in every bundle that imports the package, even when the bundle uses neither function
 - `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request. The validator still checks the headers and returns their data
 - `validateCmcdRequest` reads the `CMCD` parameter from the query string and ignores the URL fragment. A relative URL no longer throws. When the fragment is the only place with a `CMCD` parameter, the error message says so
 - The encoder applies the "MUST NOT" rules of CTA-5004-B to version 2 payloads. The change covers `encodeCmcd`, `toCmcdHeaders`, `toCmcdQuery`, and `CmcdReporter`, which share `prepareCmcdData`

--- a/libs/cmcd/CHANGELOG.md
+++ b/libs/cmcd/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Fixed
 
+- A bare import of the package no longer runs code at module scope. `CmcdReporter` built its required-event-key table with an array spread of `CMCD_STATE_EVENT_FIELDS`. Bundlers kept that table in every bundle that imports the package, even when the bundle does not use `CmcdReporter`
 - `validateCmcdRequest` reports an error when a request carries CMCD data in both the headers and the `CMCD` query parameter. CTA-5004-B allows one transmission mode per request. The validator still checks the headers and returns their data
 - `validateCmcdRequest` reads the `CMCD` parameter from the query string and ignores the URL fragment. A relative URL no longer throws. When the fragment is the only place with a `CMCD` parameter, the error message says so
 - The encoder applies the "MUST NOT" rules of CTA-5004-B to version 2 payloads. The change covers `encodeCmcd`, `toCmcdHeaders`, `toCmcdQuery`, and `CmcdReporter`, which share `prepareCmcdData`

--- a/libs/cmcd/src/CmcdReporter.ts
+++ b/libs/cmcd/src/CmcdReporter.ts
@@ -136,17 +136,21 @@ const STATE_FIELDS_BY_EVENT: ReadonlyMap<CmcdEventType, StateFieldEntry> = /* @_
 	/* @__PURE__ */ STATE_FIELDS.map(e => [e.event, e]),
 )
 
+function buildRequiredEventKeys(): ReadonlyMap<CmcdEventType, CmcdKey> {
+	return new Map([
+		...CMCD_STATE_EVENT_FIELDS,
+		[CMCD_EVENT_CUSTOM_EVENT, 'cen'] as const,
+		[CMCD_EVENT_ERROR, 'ec'] as const,
+		[CMCD_EVENT_RESPONSE_RECEIVED, 'url'] as const,
+	])
+}
+
 /**
  * Maps each event type to the key CTA-5004-B requires beyond `e` and `ts`.
  * Built from the state-change table plus the three event types whose
  * required key rides the caller's per-event data.
  */
-const CMCD_REQUIRED_EVENT_KEYS: ReadonlyMap<CmcdEventType, CmcdKey> = /* @__PURE__ */ new Map([
-	.../* @__PURE__ */ CMCD_STATE_EVENT_FIELDS,
-	[CMCD_EVENT_CUSTOM_EVENT, 'cen'] as const,
-	[CMCD_EVENT_ERROR, 'ec'] as const,
-	[CMCD_EVENT_RESPONSE_RECEIVED, 'url'] as const,
-])
+const CMCD_REQUIRED_EVENT_KEYS: ReadonlyMap<CmcdEventType, CmcdKey> = /* @__PURE__ */ buildRequiredEventKeys()
 
 /**
  * Whether a required key's value will survive report preparation.

--- a/libs/cmcd/src/prepareCmcdData.ts
+++ b/libs/cmcd/src/prepareCmcdData.ts
@@ -10,7 +10,7 @@ import { CMCD_STATE_EVENT_FIELDS } from './CMCD_STATE_EVENT_FIELDS.ts'
 import type { CmcdFormatterOptions } from './CmcdFormatterOptions.ts'
 import type { CmcdKey } from './CmcdKey.ts'
 import type { CmcdVersion } from './CmcdVersion.ts'
-import { CMCD_EVENT_MODE, CMCD_REQUEST_MODE } from './CmcdReportingMode.ts'
+import { CMCD_EVENT_MODE, CMCD_REQUEST_MODE, type CmcdReportingMode } from './CmcdReportingMode.ts'
 import type { CmcdValue } from './CmcdValue.ts'
 import { isCmcdEventKey } from './isCmcdEventKey.ts'
 import { isCmcdRequestKey } from './isCmcdRequestKey.ts'
@@ -21,9 +21,9 @@ import { isTokenField } from './isTokenField.ts'
 import { isValid } from './isValid.ts'
 import { toTokenString } from './toTokenString.ts'
 
-const filterMap: Record<string, (key: string) => boolean> = {
-	[CMCD_EVENT_MODE]: isCmcdEventKey,
-	[CMCD_REQUEST_MODE]: isCmcdRequestKey,
+const filterMap: Record<CmcdReportingMode, (key: string) => boolean> = {
+	event: isCmcdEventKey,
+	request: isCmcdRequestKey,
 }
 
 /**


### PR DESCRIPTION
## Summary

- A bundle built from a bare `import '@svta/cml-cmcd'`, with no named imports, kept two module-scope tables. The repository rule says no code runs at module scope, and every adopter pays for the retained code.
- `CmcdReporter` built `CMCD_REQUIRED_EVENT_KEYS` with an array spread of `CMCD_STATE_EVENT_FIELDS`. A `/* @__PURE__ */` annotation on an identifier inside a spread element has no effect. Rollup and rolldown both kept the `new Map([...])` call and the constants it reads. The table is now the result of a `/* @__PURE__ */` call to a module-private factory function, the pattern `parseXml` uses for its tree builders.
- `prepareCmcdData` selected its key filter from an object literal with the computed keys `[CMCD_EVENT_MODE]` and `[CMCD_REQUEST_MODE]`. rolldown treats a computed key as a possible side effect, even when the key is a string constant, so it kept the table, both filter functions, and the key sets they read. esbuild-based bundlers are expected to behave the same. Rollup drops it, so the Rollup-only audit for #382 in July 2026 did not see it. The table now uses the literal keys `event` and `request`. The `Record<CmcdReportingMode, ...>` annotation keeps the compile-time check against the mode union.
- Runtime behavior is unchanged. The API report has no diff.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-cmcd | 2.6.1 | fix |

## Test Plan

Probe: an entry file that contains only `import '../../dist/index.js'`, bundled after `npm run build -w libs/cmcd`. The count is the number of top-level statements that are not import declarations or the empty `export {}` marker.

| Bundler | Before | After the first commit | After both commits |
|---------|--------|------------------------|--------------------|
| Rollup 4.62.2, default settings | 10 | 0 | 0 |
| tsdown 0.15.7, peer packages external | 25 | 14 | 0 |
| tsdown 0.15.7, peer packages bundled | 28 | 18 | 3 |

- [x] `npm run build -w libs/cmcd` and `npm test -w libs/cmcd`: 603 tests pass, 2 todo
- [x] `npm run typecheck` and `npm run lint` pass
- [x] `npm run build -w docs` passes
- [x] The API report `libs/cmcd/config/cml-cmcd.api.md` has no diff

Notes for review:

- The two fixes are separate commits. The second one is needed for the tsdown probe to reach zero. Drop it if you want this PR limited to the reporter spread.
- The 3 statements left in the last row come from `@svta/cml-structured-field-values`: the `INTEGER_DECIMAL` template literal and the two constants it reads. That is a separate package and a separate fix.
- Minified, the 10 Rollup statements fold into the single `new Map([...])` statement, which is how the problem was first observed.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [ ] Unit Tests updated or fixed: no unit test change, the bundle probe above is the check
- [ ] Docs/guides updated: not needed, no public API or TSDoc change
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
