### PR TITLE
fix(structured-field-values): remove a module-scope template literal

### DIFF
--- a/libs/structured-field-values/CHANGELOG.md
+++ b/libs/structured-field-values/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - README: the usage example prints its result instead of calling an undefined `assert`.
 
+### Fixed
+
+- Remove the module-scope template literal that built the `Integer or Decimal` error type name. Rolldown-based bundlers such as tsdown kept that statement and two constants in bundles that never used the parser. `parseIntegerOrDecimal` now builds the name inside the function. Error messages do not change.
+
 
 ## [1.1.5] - 2026-07-28
 

--- a/libs/structured-field-values/src/parse/parseIntegerOrDecimal.ts
+++ b/libs/structured-field-values/src/parse/parseIntegerOrDecimal.ts
@@ -1,4 +1,5 @@
-import { INTEGER_DECIMAL } from '../utils/INTEGER_DECIMAL.ts'
+import { DECIMAL } from '../utils/DECIMAL.ts'
+import { INTEGER } from '../utils/INTEGER.ts'
 import { isInvalidInt } from '../utils/isInvalidInt.ts'
 import type { ParsedValue } from './ParsedValue.ts'
 import { parsedValue } from './ParsedValue.ts'
@@ -78,7 +79,8 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 	let num = ''
 	let value
 	const i = 0
-	const error = parseError(orig, INTEGER_DECIMAL)
+	const type = `${INTEGER} or ${DECIMAL}`
+	const error = parseError(orig, type)
 
 	if (src[i] === '-') {
 		sign = -1
@@ -128,7 +130,7 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 
 		value = parseInt(num) * sign
 		if (isInvalidInt(value)) {
-			throw parseError(num, INTEGER_DECIMAL)
+			throw parseError(num, type)
 		}
 	}
 

--- a/libs/structured-field-values/src/utils/INTEGER_DECIMAL.ts
+++ b/libs/structured-field-values/src/utils/INTEGER_DECIMAL.ts
@@ -1,4 +1,0 @@
-import { DECIMAL } from './DECIMAL.ts'
-import { INTEGER } from './INTEGER.ts'
-
-export const INTEGER_DECIMAL: string = `${INTEGER} or ${DECIMAL}`


### PR DESCRIPTION
## Summary

- A bare `import '@svta/cml-structured-field-values'` kept three unused constants in bundles built with tsdown 0.15.7 (rolldown): `DECIMAL`, `INTEGER`, and the module-scope template literal `INTEGER_DECIMAL` that joined them. Rollup 4.62 dropped all three. The repository rule says no code runs at module scope.
- Root cause: rolldown folds a module-scope `const` to its literal only when that const has exactly one reference. `INTEGER` and `DECIMAL` are also used by `serializeInteger` and `serializeDecimal`, so rolldown could not prove the template literal free of side effects and kept it. Single-file probes confirmed the rule: an `export` or a second use inside any function is enough, and `+` concatenation behaves the same way.
- `parseIntegerOrDecimal` now builds the type name in a local `const` and passes it to both `parseError` calls. The `INTEGER_DECIMAL.ts` file is deleted. Error messages do not change. The public API report has no diff.
- A `/* @__PURE__ */` factory call, the pattern used in `xml` and `cmcd`, also works. Building the string inside the function removes the module-scope computation instead of annotating it, so it needs no factory function in the bundle.

## Packages Changed

| Package | Version | Change Type |
|---------|---------|-------------|
| @svta/cml-structured-field-values | 1.1.5 | fix |

## Test Plan

- [x] Bare-import probe against the rebuilt `dist` with `npx tsdown <entry> --format esm --no-dts`: the output is the `@svta/cml-utils` import line and `export {  };` only. Before the fix it held the three `const` statements.
- [x] Bare-import probe with `npx rollup <entry> --format es`: the output is the import line only, before and after.
- [x] `npm run build -w libs/structured-field-values` and `npm test -w libs/structured-field-values`: 1696 tests pass, 0 fail. The existing tests in `parseIntegerOfDecimal.test.ts` assert the `Integer or Decimal` message text.
- [x] `npm run typecheck` and `npm run lint` pass after a root `npm run build`.
- [x] The API report `libs/structured-field-values/config/cml-structured-field-values.api.md` has no diff.
- [x] `npm run build -w docs` passes with 0 errors. The only warning for this package is the missing `libs/structured-field-values/docs/*.md` glob, which is the same on `main`.

Notes for review:

- `parseIntegerOrDecimal` builds an `Error` at the top of every call, including the success path. That is a separate performance change and is not part of this PR. A follow-up branch is in progress and touches the same function, so whichever merges second has a small conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
