### PR TITLE
perf(structured-field-values): create the parse error only when parsing fails

### DIFF
--- a/libs/structured-field-values/CHANGELOG.md
+++ b/libs/structured-field-values/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - README: the usage example prints its result instead of calling an undefined `assert`.
+- `parseIntegerOrDecimal` creates its `Error` only when parsing fails. Before this change, every call created an `Error` and captured a stack trace, also when parsing succeeded. Every Integer and Decimal in a parsed field passes through this function. Error messages do not change.
 
 ### Fixed
 

--- a/libs/structured-field-values/src/parse/parseIntegerOrDecimal.ts
+++ b/libs/structured-field-values/src/parse/parseIntegerOrDecimal.ts
@@ -5,6 +5,10 @@ import type { ParsedValue } from './ParsedValue.ts'
 import { parsedValue } from './ParsedValue.ts'
 import { parseError } from './parseError.ts'
 
+function integerOrDecimalError(src: string): Error {
+	return parseError(src, `${INTEGER} or ${DECIMAL}`)
+}
+
 // 4.2.4.  Parsing an Integer or Decimal
 //
 // Given an ASCII string as input_string, return an Integer or Decimal.
@@ -79,8 +83,6 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 	let num = ''
 	let value
 	const i = 0
-	const type = `${INTEGER} or ${DECIMAL}`
-	const error = parseError(orig, type)
 
 	if (src[i] === '-') {
 		sign = -1
@@ -88,13 +90,13 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 	}
 
 	if (src.length <= 0) {
-		throw error
+		throw integerOrDecimalError(orig)
 	}
 
 	const re_integer = /^(\d+)?/g
 	const result_integer = re_integer.exec(src) as any
 	if (result_integer[0].length === 0) {
-		throw error
+		throw integerOrDecimalError(orig)
 	}
 	num += result_integer[1]
 	src = src.substring(re_integer.lastIndex)
@@ -102,7 +104,7 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 	if (src[0] === '.') {
 		// decimal
 		if (num.length > 12) {
-			throw error
+			throw integerOrDecimalError(orig)
 		}
 
 		const re_decimal = /^(\.\d+)?/g
@@ -110,13 +112,13 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 		src = src.substring(re_decimal.lastIndex)
 		// 9.2.  If the number of characters after "." in input_number is greater than three, fail parsing.
 		if (result_decimal[0].length === 0 || result_decimal[1].length > 4) {
-			throw error
+			throw integerOrDecimalError(orig)
 		}
 
 		num += result_decimal[1]
 		// 7.6.  If type is "decimal" and input_number contains more than 16 characters, fail parsing.
 		if (num.length > 16) {
-			throw error
+			throw integerOrDecimalError(orig)
 		}
 
 		value = parseFloat(num) * sign
@@ -125,12 +127,12 @@ export function parseIntegerOrDecimal(src: string): ParsedValue<number> {
 		// integer
 		// 7.5.  If type is "integer" and input_number contains more than 15 characters, fail parsing.
 		if (num.length > 15) {
-			throw error
+			throw integerOrDecimalError(orig)
 		}
 
 		value = parseInt(num) * sign
 		if (isInvalidInt(value)) {
-			throw parseError(num, type)
+			throw integerOrDecimalError(num)
 		}
 	}
 

--- a/libs/structured-field-values/test/parseIntegerOfDecimal.test.ts
+++ b/libs/structured-field-values/test/parseIntegerOfDecimal.test.ts
@@ -58,3 +58,23 @@ test('parseIntegerOrDecimal', () => {
 	assert.throws(() => parseIntegerOrDecimal(`999999999999999.1`), /failed to parse "999999999999999.1" as Integer or Decimal/)
 	assert.throws(() => parseIntegerOrDecimal(`1000000000000000`), /failed to parse "1000000000000000" as Integer or Decimal/)
 })
+
+test('parseIntegerOrDecimal does not create an Error when parsing succeeds', () => {
+	const OriginalError = globalThis.Error
+	let errorCount = 0
+	class CountingError extends OriginalError {
+		constructor(message?: string, options?: ErrorOptions) {
+			super(message, options)
+			errorCount++
+		}
+	}
+	globalThis.Error = CountingError as ErrorConstructor
+	try {
+		parseIntegerOrDecimal(`42`)
+		parseIntegerOrDecimal(`-4.5`)
+	}
+	finally {
+		globalThis.Error = OriginalError
+	}
+	assert.strictEqual(errorCount, 0)
+})


### PR DESCRIPTION
## Description

`parseIntegerOrDecimal` created an `Error`, with a stack trace, at the start of every call. `parseBareItem` and `parseDate` call this function for every Integer and Decimal in a structured field. So every CMCD and CMSD header parse paid for Errors it never threw.

The function now calls a small helper at each of its seven failure sites. The helper builds the type name and the `Error` only on that path. Error messages do not change. No other file in `src/parse/` had this pattern.

A new test swaps `globalThis.Error` for a counting subclass and asserts that two successful parses create zero Errors. Before the fix the test failed with `2 !== 0`.

No docs change. The public API and the error messages are unchanged.

### Benchmark

`decodeSfList` on a list of 4000 items. Node 24.16.0, Apple M1 Pro. Median of 15 rounds of 50 parses, after 200 warm-up parses. Three runs per configuration agree within 2 percent.

| Input | Before | After |
|---|---|---|
| 4000 integers | 20.4 ms per list, 195k items/s | 0.65 ms per list, 6.1M items/s |
| 4000 decimals | 21.9 ms per list, 182k items/s | 0.92 ms per list, 4.4M items/s |

<details>
<summary>Benchmark script, run from the repo root with <code>node --input-type=module &lt; bench.mjs</code></summary>

```js
import { decodeSfList } from './libs/structured-field-values/dist/index.js'

const COUNT = 4000
const inputs = {
	integers: Array.from({ length: COUNT }, (_, i) => String(i)).join(', '),
	decimals: Array.from({ length: COUNT }, (_, i) => (i / 8).toFixed(3)).join(', '),
}

for (const [name, input] of Object.entries(inputs)) {
	for (let i = 0; i < 200; i++) decodeSfList(input)
	const times = []
	for (let r = 0; r < 15; r++) {
		const t0 = performance.now()
		for (let i = 0; i < 50; i++) decodeSfList(input)
		times.push((performance.now() - t0) / 50)
	}
	times.sort((a, b) => a - b)
	const median = times[7]
	console.log(`${name}: median ${median.toFixed(3)} ms per list, ${Math.round((COUNT / median) * 1000)} items/s`)
}
```

</details>

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [ ] Docs/guides updated
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
