### PR TITLE
perf(structured-field-values): encode without wrapper objects and repeated passes

### DIFF
--- a/libs/structured-field-values/CHANGELOG.md
+++ b/libs/structured-field-values/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to
 
 - README: the usage example prints its result instead of calling an undefined `assert`.
 - `parseIntegerOrDecimal` creates its `Error` only when parsing fails. Before this change, every call created an `Error` and captured a stack trace, also when parsing succeeded. Every Integer and Decimal in a parsed field passes through this function. Error messages do not change.
+- The encoder allocates less and runs faster. `encodeSfDict`, `encodeSfList`, and `encodeSfItem` no longer wrap bare values in `SfItem` objects, and the dictionary and parameter serializers no longer copy their entries through `Object.entries`, `Array.from`, and `map`. `serializeString` returns a string that needs no escape after one regex test. `serializeKey` checks the character codes in a loop. For a 17-key CMCD request dictionary, one encode takes about 40% less time and allocates 2.1 KB instead of 6.5 KB. The output does not change. The error for `encodeSfItem([1, 2])` now quotes the array as passed, `[1,2]`, instead of the wrapped items.
+- `serializeInnerList` also accepts the list and its parameters as two arguments: `serializeInnerList([1, 2], { a: 1 })`. The `SfInnerList` object form still works.
+- A benchmark for the encoder: `npm run bench -w libs/structured-field-values`. The header of `bench/bench.ts` describes the options.
 
 ### Fixed
 
 - Remove the module-scope template literal that built the `Integer or Decimal` error type name. Rolldown-based bundlers such as tsdown kept that statement and two constants in bundles that never used the parser. `parseIntegerOrDecimal` now builds the name inside the function. Error messages do not change.
+- `serializeDecimal` fails on values of `1e21` and above. Before this change, the magnitude check used the length of `Number.prototype.toString`, which switches to exponent notation at `1e21`, so `serializeDecimal(1e21)` returned `1e+21.0`. RFC 8941 allows at most 12 digits before the decimal point.
 
 
 ## [1.1.5] - 2026-07-28

--- a/libs/structured-field-values/bench/bench.ts
+++ b/libs/structured-field-values/bench/bench.ts
@@ -1,0 +1,293 @@
+/**
+ * Encoder benchmark. Run from libs/structured-field-values after `npm run build`:
+ *
+ *   npm run bench                          time every input, one process per variant and input
+ *   npm run bench -- --baseline=<path>     also measure the encoder exported by another build and report this
+ *                                          build against it; a copy of main's dist folder at
+ *                                          libs/structured-field-values/temp/dist (ignored by git and
+ *                                          lint) can still resolve its @svta/cml-utils import
+ *   npm run bench -- --verify              compare the output of this build with the baseline on every bench input
+ *                                          and on the structured-field-tests corpus (needs --baseline)
+ *   npm run bench -- --only=<text>         only inputs whose name contains the text
+ *
+ * Each (variant, input) pair runs in its own process, so type feedback gathered for one variant never shapes the
+ * code compiled for another. Each process builds the inputs with the SfItem and SfToken classes of its variant,
+ * so instanceof checks match. It makes 30 warm-up batches of 1000 calls, then times 50 batches and reports the
+ * median and p95 per call. Every result string is flattened with charCodeAt, so rope strings pay their cost in
+ * the measurement. The process then collects garbage and counts the heap bytes that 2000 further calls
+ * allocate. The semi-space flags keep the collector out of that window, and the table reports any collection
+ * that ran anyway.
+ */
+import { spawnSync } from 'node:child_process'
+import { readdirSync, readFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+import { performance, PerformanceObserver } from 'node:perf_hooks'
+import { pathToFileURL } from 'node:url'
+import base32 from 'hi-base32'
+import { type EncoderApi, type Input, makeInputs } from './inputs.ts'
+
+type Variant = {
+	name: string;
+	load: () => Promise<EncoderApi>;
+}
+
+type WorkerResult = {
+	median: number;
+	p95: number;
+	bytesPerCall: number;
+	collections: number;
+	length: number;
+}
+
+const BATCH = 1000
+const WARM_UP_BATCHES = 30
+const TIMED_BATCHES = 50
+const ALLOCATION_CALLS = 2000
+const THROWS = 'throws: '
+const CORPUS = resolve(import.meta.dirname, '../../../structured-field-tests')
+
+const args = process.argv.slice(2)
+const baseline = args.find(arg => arg.startsWith('--baseline='))?.slice('--baseline='.length)
+const only = args.find(arg => arg.startsWith('--only='))?.slice('--only='.length)
+const run = args.find(arg => arg.startsWith('--run='))?.slice('--run='.length)
+
+const variants: Variant[] = [
+	{
+		name: 'this build',
+		load: async () => await import('@svta/cml-structured-field-values'),
+	},
+]
+
+if (baseline !== undefined) {
+	variants.unshift({
+		name: 'baseline',
+		load: async () => await import(pathToFileURL(resolve(baseline)).href) as EncoderApi,
+	})
+}
+
+let sink = 0
+
+function selectInputs(api: EncoderApi): Input[] {
+	return makeInputs(api).filter(input => only === undefined || input.name.includes(only))
+}
+
+function percentile(times: number[], fraction: number): number {
+	const sorted = [...times].sort((a, b) => a - b)
+	return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))]
+}
+
+function formatDelta(value: number, base: number): string {
+	const delta = ((value - base) / base) * 100
+	return (delta > 0 ? '+' : '') + delta.toFixed(1) + '%'
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(done => setTimeout(done, ms))
+}
+
+/**
+ * Worker mode: times one variant on one input and prints the result as JSON.
+ */
+async function measure(variantIndex: number, inputIndex: number): Promise<void> {
+	if (typeof gc !== 'function') {
+		throw new Error('measure needs node --expose-gc')
+	}
+
+	const api = await variants[variantIndex].load()
+	const { call } = selectInputs(api)[inputIndex]
+
+	const batch = (): void => {
+		for (let i = 0; i < BATCH; i++) {
+			const output = call()
+			sink += output.charCodeAt(output.length >> 1)
+		}
+	}
+
+	for (let i = 0; i < WARM_UP_BATCHES; i++) {
+		batch()
+	}
+
+	const times: number[] = []
+	for (let i = 0; i < TIMED_BATCHES; i++) {
+		const start = performance.now()
+		batch()
+		times.push((performance.now() - start) * 1e6 / BATCH)
+	}
+
+	gc()
+	gc()
+	await sleep(20)
+
+	let collections = 0
+	const observer = new PerformanceObserver(list => {
+		collections += list.getEntries().length
+	})
+	observer.observe({ entryTypes: ['gc'] })
+
+	const before = process.memoryUsage().heapUsed
+	for (let i = 0; i < ALLOCATION_CALLS; i++) {
+		const output = call()
+		sink += output.charCodeAt(output.length >> 1)
+	}
+	const after = process.memoryUsage().heapUsed
+
+	await sleep(30)
+	observer.disconnect()
+
+	const result: WorkerResult = {
+		median: percentile(times, 0.5),
+		p95: percentile(times, 0.95),
+		bytesPerCall: (after - before) / ALLOCATION_CALLS,
+		collections,
+		length: call().length,
+	}
+	console.log(JSON.stringify(result))
+}
+
+/**
+ * Driver mode: spawns one worker process per (variant, input) pair and prints one table.
+ */
+async function drive(): Promise<void> {
+	const self = resolve(import.meta.filename)
+	const inputs = selectInputs(await variants[variants.length - 1].load())
+
+	console.log(`Node ${process.version}, ${process.arch}, one process per variant and input, ${WARM_UP_BATCHES} warm-up batches of ${BATCH} calls, ${TIMED_BATCHES} timed batches\n`)
+
+	const results: WorkerResult[][] = inputs.map((_, inputIndex) => variants.map((_, variantIndex) => {
+		const nodeArgs = ['--expose-gc', '--min-semi-space-size=64', '--max-semi-space-size=128', '--no-warnings', self, `--run=${variantIndex},${inputIndex}`, ...args]
+		const proc = spawnSync(process.execPath, nodeArgs, { encoding: 'utf8' })
+		if (proc.status !== 0) {
+			throw new Error(proc.stderr)
+		}
+		const lines = proc.stdout.trim().split('\n')
+		return JSON.parse(lines[lines.length - 1])
+	}))
+
+	const bytes = (result: WorkerResult): string => result.bytesPerCall.toFixed(0) + (result.collections > 0 ? ` (${result.collections} gc)` : '')
+
+	if (variants.length === 1) {
+		console.log('| Input | Output chars | Median ns | p95 ns | Heap bytes per call |')
+		console.log('| --- | ---: | ---: | ---: | ---: |')
+		inputs.forEach((input, inputIndex) => {
+			const [result] = results[inputIndex]
+			console.log(`| ${input.name} | ${result.length} | ${result.median.toFixed(0)} | ${result.p95.toFixed(0)} | ${bytes(result)} |`)
+		})
+		return
+	}
+
+	console.log('| Input | Baseline ns, median (p95) | This build ns, median (p95) | Median delta | Baseline bytes per call | This build bytes per call |')
+	console.log('| --- | ---: | ---: | ---: | ---: | ---: |')
+	inputs.forEach((input, inputIndex) => {
+		const [base, current] = results[inputIndex]
+		console.log(`| ${input.name} | ${base.median.toFixed(0)} (${base.p95.toFixed(0)}) | ${current.median.toFixed(0)} (${current.p95.toFixed(0)}) | ${formatDelta(current.median, base.median)} | ${bytes(base)} | ${bytes(current)} |`)
+	})
+}
+
+/**
+ * Builds one case per corpus vector that has an expected value, with the classes of the given encoder.
+ */
+function makeCorpusCases(api: EncoderApi): Input[] {
+	const { SfItem } = api
+
+	const format = (value: any): any => {
+		if (Array.isArray(value)) {
+			return value.map(format)
+		}
+		switch (value?.__type) {
+			case 'binary':
+				return Uint8Array.from(value.value === '' ? [] : base32.decode.asBytes(value.value))
+			case 'token':
+				return Symbol.for(value.value)
+			case 'date':
+				return new Date(value.value * 1000)
+			default:
+				return value
+		}
+	}
+	const formatParams = (params: any[]): Record<string, any> | undefined => (params.length === 0 ? undefined : Object.fromEntries(params.map(format)))
+	const formatItem = ([value, params]: any[]): any => new SfItem(Array.isArray(value) ? value.map(formatItem) : format(value), formatParams(params))
+
+	const files = [
+		...readdirSync(CORPUS).filter(file => file.endsWith('.json')).map(file => resolve(CORPUS, file)),
+		...readdirSync(resolve(CORPUS, 'serialisation-tests')).map(file => resolve(CORPUS, 'serialisation-tests', file)),
+	]
+	const cases: Input[] = []
+
+	for (const file of files) {
+		for (const suite of JSON.parse(readFileSync(file, 'utf8'))) {
+			if (suite.expected === undefined || JSON.stringify(suite.expected).includes('displaystring')) {
+				continue
+			}
+			const name = `${basename(file)}: ${suite.name}`
+			if (suite.header_type === 'item') {
+				cases.push({ name, call: () => api.encodeSfItem(formatItem(suite.expected)) })
+			}
+			else if (suite.header_type === 'list') {
+				cases.push({ name, call: () => api.encodeSfList(suite.expected.map(formatItem)) })
+			}
+			else if (suite.header_type === 'dictionary') {
+				cases.push({ name, call: () => api.encodeSfDict(Object.fromEntries(suite.expected.map(([key, entry]: any[]) => [key, formatItem(entry)]))) })
+			}
+		}
+	}
+
+	return cases
+}
+
+function outcome(input: Input): string {
+	try {
+		return input.call()
+	}
+	catch (error) {
+		return THROWS + (error as Error).message
+	}
+}
+
+/**
+ * Verify mode: compares the output of this build with the baseline on the bench inputs and the corpus.
+ */
+async function verify(): Promise<void> {
+	if (variants.length < 2) {
+		throw new Error('--verify needs --baseline=<path>')
+	}
+
+	const [base, current] = await Promise.all(variants.map(variant => variant.load()))
+	const baseCases = [...selectInputs(base), ...makeCorpusCases(base)]
+	const currentCases = [...selectInputs(current), ...makeCorpusCases(current)]
+	const differences: string[] = []
+	let identical = 0
+	let messageOnly = 0
+
+	baseCases.forEach((baseCase, index) => {
+		const expected = outcome(baseCase)
+		const actual = outcome(currentCases[index])
+		if (expected === actual) {
+			identical++
+		}
+		else if (expected.startsWith(THROWS) && actual.startsWith(THROWS)) {
+			messageOnly++
+			differences.push(`error message  ${baseCase.name}\n    baseline:   ${expected}\n    this build: ${actual}`)
+		}
+		else {
+			differences.push(`OUTPUT         ${baseCase.name}\n    baseline:   ${expected}\n    this build: ${actual}`)
+		}
+	})
+
+	console.log(`${baseCases.length} cases: ${identical} identical, ${messageOnly} differ only in the error message, ${baseCases.length - identical - messageOnly} differ in output`)
+	differences.forEach(line => console.log(`  ${line}`))
+}
+
+if (run !== undefined) {
+	const [variantIndex, inputIndex] = run.split(',').map(Number)
+	await measure(variantIndex, inputIndex)
+}
+else if (args.includes('--verify')) {
+	await verify()
+}
+else {
+	await drive()
+}
+
+if (sink === Infinity) {
+	console.log('unreachable')
+}

--- a/libs/structured-field-values/bench/inputs.ts
+++ b/libs/structured-field-values/bench/inputs.ts
@@ -1,0 +1,67 @@
+import type { SfItem, SfToken } from '@svta/cml-structured-field-values'
+
+/**
+ * The encoder exports the benchmark uses. A baseline build loaded from a path provides the same shape.
+ */
+export type EncoderApi = {
+	encodeSfDict: (value: Record<string, any> | Map<string, any>, options?: { whitespace?: boolean }) => string;
+	encodeSfItem: (value: any, params?: Record<string, any>) => string;
+	encodeSfList: (value: any[], options?: { whitespace?: boolean }) => string;
+	SfItem: typeof SfItem;
+	SfToken: typeof SfToken;
+};
+
+export type Input = {
+	name: string;
+	call: () => string;
+};
+
+const COMPACT = { whitespace: false }
+
+/**
+ * Builds the benchmark inputs with the classes of the encoder under test, so that its `instanceof` checks match.
+ * The CMCD dictionaries have the shape `prepareCmcdData` produces for a version 2 request.
+ */
+export function makeInputs({ encodeSfDict, encodeSfItem, encodeSfList, SfItem, SfToken }: EncoderApi): Input[] {
+	const cmcd: Record<string, any> = {
+		bl: 21300,
+		br: [new SfItem(1000, { ot: new SfToken('v') })],
+		bs: true,
+		cid: 'e6f7c1a2-8b6d-4b3e-9f2a-1c2d3e4f5a6b',
+		'com.example-hello': 'world',
+		d: 4004,
+		dl: 21300,
+		mtp: 25400,
+		nor: ['../video/seg_00042.m4s'],
+		ot: new SfToken('v'),
+		rtp: 15000,
+		sf: new SfToken('d'),
+		sid: '6e2fb550-c457-11e9-bb97-0800200c9a66',
+		st: new SfToken('v'),
+		su: true,
+		tb: 6000,
+		v: 2,
+	}
+	const cmcdItems = Object.fromEntries(Object.entries(cmcd).map(([key, value]) => [key, value instanceof SfItem ? value : new SfItem(value)]))
+	const cmcdMap = new Map(Object.entries(cmcd))
+	const integers = Array.from({ length: 20 }, (_, i) => i * 1000 + 7)
+	const wideDict = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`k${i}`, i * 31]))
+	const urls = Array.from({ length: 10 }, (_, i) => `https://cdn.example.com/live/channel-${i}/video/1080p/segment_${String(i).padStart(6, '0')}.m4s?token=abcdef0123456789`)
+	const escaped = Array.from({ length: 10 }, (_, i) => `say "hi" ${i} and \\ backslash \\ path "quoted" end`)
+	const decimals = Array.from({ length: 20 }, (_, i) => 1.2345 + i * 0.371)
+	const bytes = { b: new Uint8Array(32).map((_, i) => i * 7) }
+	const params = { a: 1, b: true, c: new SfToken('tok') }
+
+	return [
+		{ name: 'CMCD dict, 17 keys, bare values', call: () => encodeSfDict(cmcd, COMPACT) },
+		{ name: 'CMCD dict, 17 keys, SfItem values', call: () => encodeSfDict(cmcdItems, COMPACT) },
+		{ name: 'CMCD dict, 17 keys, Map', call: () => encodeSfDict(cmcdMap, COMPACT) },
+		{ name: 'dict, 100 integer keys', call: () => encodeSfDict(wideDict) },
+		{ name: 'list, 20 integers', call: () => encodeSfList(integers) },
+		{ name: 'list, 10 URL strings without escapes', call: () => encodeSfList(urls) },
+		{ name: 'list, 10 strings with quotes and backslashes', call: () => encodeSfList(escaped) },
+		{ name: 'list, 20 decimals', call: () => encodeSfList(decimals) },
+		{ name: 'item "abc" with 3 parameters', call: () => encodeSfItem('abc', params) },
+		{ name: 'dict, one 32-byte sequence', call: () => encodeSfDict(bytes) },
+	]
+}

--- a/libs/structured-field-values/config/cml-structured-field-values.api.md
+++ b/libs/structured-field-values/config/cml-structured-field-values.api.md
@@ -148,6 +148,9 @@ export function serializeError(src: any, type: string, cause?: any): Error;
 // @internal (undocumented)
 export function serializeInnerList(value: SfInnerList): string;
 
+// @internal (undocumented)
+export function serializeInnerList(value: SfItem[] | SfBareItem[], params?: SfParameters): string;
+
 // Warning: (ae-internal-missing-underscore) The name "serializeInteger" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)

--- a/libs/structured-field-values/package.json
+++ b/libs/structured-field-values/package.json
@@ -38,7 +38,8 @@
 	],
 	"scripts": {
 		"build": "node ../../scripts/build.ts",
-		"test": "node ../../scripts/test.ts"
+		"test": "node ../../scripts/test.ts",
+		"bench": "node bench/bench.ts"
 	},
 	"engines": {
 		"node": ">=20"

--- a/libs/structured-field-values/src/encodeSfItem.ts
+++ b/libs/structured-field-values/src/encodeSfItem.ts
@@ -1,7 +1,9 @@
 import type { SfBareItem } from './SfBareItem.ts'
 import { SfItem } from './SfItem.ts'
 import type { SfParameters } from './SfParameters.ts'
+import { serializeBareItem } from './serialize/serializeBareItem.ts'
 import { serializeItem } from './serialize/serializeItem.ts'
+import { serializeParams } from './serialize/serializeParams.ts'
 
 /**
  * Encode a structured field item to a string
@@ -26,10 +28,10 @@ export function encodeSfItem(value: SfItem): string;
  */
 export function encodeSfItem(value: SfBareItem, params?: SfParameters): string;
 
-export function encodeSfItem(value: SfItem | SfBareItem, params?: SfParameters) {
-	if (!(value instanceof SfItem)) {
-		value = new SfItem(value, params)
+export function encodeSfItem(value: SfItem | SfBareItem, params?: SfParameters): string {
+	if (value instanceof SfItem) {
+		return serializeItem(value)
 	}
 
-	return serializeItem(value)
+	return `${serializeBareItem(value)}${serializeParams(params)}`
 }

--- a/libs/structured-field-values/src/serialize/serializeDecimal.ts
+++ b/libs/structured-field-values/src/serialize/serializeDecimal.ts
@@ -41,7 +41,7 @@ import { serializeError } from './serializeError.ts'
  */
 export function serializeDecimal(value: number): string {
 	const roundedValue = roundToEven(value, 3) // round to 3 decimal places
-	if (Math.floor(Math.abs(roundedValue)).toString().length > 12) {
+	if (Math.abs(roundedValue) >= 1e12) {
 		throw serializeError(value, DECIMAL)
 	}
 	const stringValue = roundedValue.toString()

--- a/libs/structured-field-values/src/serialize/serializeDict.ts
+++ b/libs/structured-field-values/src/serialize/serializeDict.ts
@@ -1,11 +1,7 @@
 import type { SfEncodeOptions } from '../SfEncodeOptions.ts'
-import { SfItem } from '../SfItem.ts'
 import { DICT } from '../utils/DICT.ts'
+import { serializeDictMember } from './serializeDictMember.ts'
 import { serializeError } from './serializeError.ts'
-import { serializeInnerList } from './serializeInnerList.ts'
-import { serializeItem } from './serializeItem.ts'
-import { serializeKey } from './serializeKey.ts'
-import { serializeParams } from './serializeParams.ts'
 
 // 4.1.2.  Serializing a Dictionary
 //
@@ -53,28 +49,16 @@ export function serializeDict(dict: Record<string, any> | Map<string, any>, opti
 		throw serializeError(dict, DICT)
 	}
 
-	const entries = dict instanceof Map ? dict.entries() : Object.entries(dict)
-	const optionalWhiteSpace = options?.whitespace === false ? '' : ' '
+	const parts: string[] = []
 
-	return Array.from(entries)
-		.map(([key, item]) => {
-			if (item instanceof SfItem === false) {
-				item = new SfItem(item)
-			}
-			let output = serializeKey(key)
-			if (item.value === true) {
-				output += serializeParams(item.params)
-			}
-			else {
-				output += '='
-				if (Array.isArray(item.value)) {
-					output += serializeInnerList(item)
-				}
-				else {
-					output += serializeItem(item)
-				}
-			}
-			return output
-		})
-		.join(`,${optionalWhiteSpace}`)
+	if (dict instanceof Map) {
+		dict.forEach((member, key) => parts.push(serializeDictMember(key, member)))
+	}
+	else {
+		for (const key of Object.keys(dict)) {
+			parts.push(serializeDictMember(key, dict[key]))
+		}
+	}
+
+	return parts.join(options?.whitespace === false ? ',' : ', ')
 }

--- a/libs/structured-field-values/src/serialize/serializeDictMember.ts
+++ b/libs/structured-field-values/src/serialize/serializeDictMember.ts
@@ -1,0 +1,39 @@
+import { SfItem } from '../SfItem.ts'
+import type { SfMember } from '../SfMember.ts'
+import { serializeBareItem } from './serializeBareItem.ts'
+import { serializeInnerList } from './serializeInnerList.ts'
+import { serializeKey } from './serializeKey.ts'
+import { serializeParams } from './serializeParams.ts'
+
+/**
+ * Serialize one dictionary member: the key, then the parameters alone for a `true` value, otherwise `=` and the member.
+ *
+ * @internal
+ */
+export function serializeDictMember(key: string, member: SfMember): string {
+	const output = serializeKey(key)
+
+	if (member instanceof SfItem) {
+		const { value, params } = member
+
+		if (value === true) {
+			return `${output}${serializeParams(params)}`
+		}
+
+		if (Array.isArray(value)) {
+			return `${output}=${serializeInnerList(value, params)}`
+		}
+
+		return `${output}=${serializeBareItem(value)}${serializeParams(params)}`
+	}
+
+	if (member === true) {
+		return output
+	}
+
+	if (Array.isArray(member)) {
+		return `${output}=${serializeInnerList(member)}`
+	}
+
+	return `${output}=${serializeBareItem(member)}`
+}

--- a/libs/structured-field-values/src/serialize/serializeInnerList.ts
+++ b/libs/structured-field-values/src/serialize/serializeInnerList.ts
@@ -1,4 +1,7 @@
+import type { SfBareItem } from '../SfBareItem.ts'
 import type { SfInnerList } from '../SfInnerList.ts'
+import type { SfItem } from '../SfItem.ts'
+import type { SfParameters } from '../SfParameters.ts'
 import { serializeItem } from './serializeItem.ts'
 import { serializeParams } from './serializeParams.ts'
 
@@ -27,6 +30,32 @@ import { serializeParams } from './serializeParams.ts'
 /**
  * @internal
  */
-export function serializeInnerList(value: SfInnerList) {
-	return `(${value.value.map(serializeItem).join(' ')})${serializeParams(value.params)}`
+export function serializeInnerList(value: SfInnerList): string;
+
+/**
+ * @internal
+ */
+export function serializeInnerList(value: SfItem[] | SfBareItem[], params?: SfParameters): string;
+
+export function serializeInnerList(value: SfInnerList | SfItem[] | SfBareItem[], params?: SfParameters): string {
+	let list: SfItem[] | SfBareItem[]
+
+	if (Array.isArray(value)) {
+		list = value
+	}
+	else {
+		list = value.value
+		params = value.params
+	}
+
+	let output = '('
+
+	for (let i = 0; i < list.length; i++) {
+		if (i > 0) {
+			output += ' '
+		}
+		output += serializeItem(list[i])
+	}
+
+	return `${output})${serializeParams(params)}`
 }

--- a/libs/structured-field-values/src/serialize/serializeKey.ts
+++ b/libs/structured-field-values/src/serialize/serializeKey.ts
@@ -24,8 +24,23 @@ import { serializeError } from './serializeError.ts'
  * @internal
  */
 export function serializeKey(value: string): string {
-	if (/^[a-z*][a-z0-9\-_.*]*$/.test(value) === false) {
+	if (typeof value !== 'string' || value.length === 0) {
 		throw serializeError(value, KEY)
 	}
+
+	// lcalpha / "*"
+	let code = value.charCodeAt(0)
+	if ((code < 0x61 || code > 0x7a) && code !== 0x2a) {
+		throw serializeError(value, KEY)
+	}
+
+	// lcalpha / DIGIT / "_" / "-" / "." / "*"
+	for (let i = 1; i < value.length; i++) {
+		code = value.charCodeAt(i)
+		if ((code < 0x61 || code > 0x7a) && (code < 0x30 || code > 0x39) && code !== 0x5f && code !== 0x2d && code !== 0x2e && code !== 0x2a) {
+			throw serializeError(value, KEY)
+		}
+	}
+
 	return value
 }

--- a/libs/structured-field-values/src/serialize/serializeList.ts
+++ b/libs/structured-field-values/src/serialize/serializeList.ts
@@ -1,10 +1,8 @@
 import type { SfEncodeOptions } from '../SfEncodeOptions.ts'
-import { SfItem } from '../SfItem.ts'
 import type { SfMember } from '../SfMember.ts'
 import { LIST } from '../utils/LIST.ts'
 import { serializeError } from './serializeError.ts'
-import { serializeInnerList } from './serializeInnerList.ts'
-import { serializeItem } from './serializeItem.ts'
+import { serializeMember } from './serializeMember.ts'
 
 // 4.1.1.  Serializing a List
 //
@@ -37,21 +35,15 @@ export function serializeList(list: SfMember[], options?: SfEncodeOptions): stri
 		throw serializeError(list, LIST)
 	}
 
-	const optionalWhiteSpace = options?.whitespace === false ? '' : ' '
+	const separator = options?.whitespace === false ? ',' : ', '
+	let output = ''
 
-	return list
-		.map(item => {
-			if (item instanceof SfItem === false) {
-				item = new SfItem(item)
-			}
+	for (let i = 0; i < list.length; i++) {
+		if (i > 0) {
+			output += separator
+		}
+		output += serializeMember(list[i])
+	}
 
-			// TODO: Fix this type assertion
-			const i = item as any
-			if (Array.isArray(i.value)) {
-				return serializeInnerList(i)
-			}
-
-			return serializeItem(i)
-		})
-		.join(`,${optionalWhiteSpace}`)
+	return output
 }

--- a/libs/structured-field-values/src/serialize/serializeMember.ts
+++ b/libs/structured-field-values/src/serialize/serializeMember.ts
@@ -1,0 +1,28 @@
+import { SfItem } from '../SfItem.ts'
+import type { SfMember } from '../SfMember.ts'
+import { serializeBareItem } from './serializeBareItem.ts'
+import { serializeInnerList } from './serializeInnerList.ts'
+import { serializeParams } from './serializeParams.ts'
+
+/**
+ * Serialize a list member: an inner list when the value is an array, an item otherwise.
+ *
+ * @internal
+ */
+export function serializeMember(member: SfMember): string {
+	if (member instanceof SfItem) {
+		const { value, params } = member
+
+		if (Array.isArray(value)) {
+			return serializeInnerList(value, params)
+		}
+
+		return `${serializeBareItem(value)}${serializeParams(params)}`
+	}
+
+	if (Array.isArray(member)) {
+		return serializeInnerList(member)
+	}
+
+	return serializeBareItem(member)
+}

--- a/libs/structured-field-values/src/serialize/serializeParams.ts
+++ b/libs/structured-field-values/src/serialize/serializeParams.ts
@@ -33,13 +33,16 @@ export function serializeParams(params?: Record<string, any>): string {
 		return ''
 	}
 
-	return Object.entries(params)
-		.map(([key, value]) => {
-			if (value === true) {
-				return `;${serializeKey(key)}` // omit true
-			}
+	let output = ''
 
-			return `;${serializeKey(key)}=${serializeBareItem(value)}`
-		})
-		.join('')
+	for (const key of Object.keys(params)) {
+		const value = params[key]
+		output += `;${serializeKey(key)}`
+
+		if (value !== true) { // omit true
+			output += `=${serializeBareItem(value)}`
+		}
+	}
+
+	return output
 }

--- a/libs/structured-field-values/src/serialize/serializeString.ts
+++ b/libs/structured-field-values/src/serialize/serializeString.ts
@@ -2,6 +2,12 @@ import { STRING } from '../utils/STRING.ts'
 import { STRING_REGEX } from '../utils/STRING_REGEX.ts'
 import { serializeError } from './serializeError.ts'
 
+// Control characters that fail serialization, and the two characters that need an escape.
+// eslint-disable-next-line no-control-regex
+const ESCAPE_OR_CONTROL_REGEX = /[\x00-\x1f\x7f"\\]/
+const BACKSLASH_REGEX = /\\/g
+const DQUOTE_REGEX = /"/g
+
 // 4.1.6.  Serializing a String
 //
 // Given a String as input_string, return an ASCII string suitable for
@@ -29,10 +35,14 @@ import { serializeError } from './serializeError.ts'
 /**
  * @internal
  */
-export function serializeString(value: string) {
+export function serializeString(value: string): string {
+	if (ESCAPE_OR_CONTROL_REGEX.test(value) === false) {
+		return `"${value}"`
+	}
+
 	if (STRING_REGEX.test(value)) {
 		throw serializeError(value, STRING)
 	}
 
-	return `"${value.replace(/\\/g, `\\\\`).replace(/"/g, `\\"`)}"`
+	return `"${value.replace(BACKSLASH_REGEX, '\\\\').replace(DQUOTE_REGEX, '\\"')}"`
 }

--- a/libs/structured-field-values/src/serialize/serializeToken.ts
+++ b/libs/structured-field-values/src/serialize/serializeToken.ts
@@ -3,6 +3,8 @@ import { symbolToStr } from '../utils/symbolToStr.ts'
 import { TOKEN } from '../utils/TOKEN.ts'
 import { serializeError } from './serializeError.ts'
 
+const TOKEN_REGEX = /^[a-zA-Z*][!#$%&'*+\-.^_`|~\w:/]*$/
+
 // 4.1.7.  Serializing a Token
 //
 // Given a Token as input_token, return an ASCII string suitable for use
@@ -26,7 +28,7 @@ import { serializeError } from './serializeError.ts'
  */
 export function serializeToken(token: symbol | SfToken): string {
 	const value = symbolToStr(token)
-	if (/^([a-zA-Z*])([!#$%&'*+\-.^_`|~\w:/]*)$/.test(value) === false) {
+	if (TOKEN_REGEX.test(value) === false) {
 		throw serializeError(value, TOKEN)
 	}
 	return value

--- a/libs/structured-field-values/test/encodeSfDict.test.ts
+++ b/libs/structured-field-values/test/encodeSfDict.test.ts
@@ -61,6 +61,17 @@ describe('encodeSfDict', () => {
 		)
 	})
 
+	it('encodes inner lists, parameters, and boolean members', () => {
+		assert.deepStrictEqual(encodeSfDict({ a: [1, 2], b: new SfItem([new SfItem(1, { x: true })], { y: 2 }) }), 'a=(1 2), b=(1;x);y=2')
+		assert.deepStrictEqual(encodeSfDict({ a: new SfItem(true, { p: 1 }), b: true, c: new SfItem(false, { q: 2 }) }), 'a;p=1, b, c=?0;q=2')
+		assert.deepStrictEqual(encodeSfDict({ a: new SfItem('x', { p: 1, q: true }) }), 'a="x";p=1;q')
+	})
+
+	it('rejects invalid keys', () => {
+		assert.throws(() => encodeSfDict(new Map([[1, 2]])), /failed to serialize "1" as Key/)
+		assert.throws(() => encodeSfDict({ A: 1 }), /failed to serialize "A" as Key/)
+	})
+
 	it('handles SfToken and Symbol for tokens', () => {
 		assert.deepStrictEqual(
 			encodeSfDict(new Map([

--- a/libs/structured-field-values/test/encodeSfItem.test.ts
+++ b/libs/structured-field-values/test/encodeSfItem.test.ts
@@ -15,6 +15,10 @@ test('encodeSfItem', () => {
 	assert.deepStrictEqual(encodeSfItem(new SfItem(Symbol.for('a'))), `a`)
 	assert.deepStrictEqual(encodeSfItem(new SfItem(new Uint8Array([1, 2, 3]))), `:AQID:`)
 	assert.deepStrictEqual(encodeSfItem(new SfItem(new Date(1659578233000))), `@1659578233`)
+	assert.deepStrictEqual(encodeSfItem('a', { p: 1, q: true }), '"a";p=1;q')
+	assert.deepStrictEqual(encodeSfItem(new SfItem('a', { p: 1 })), '"a";p=1')
+	// @ts-expect-error - This is a test
+	assert.throws(() => encodeSfItem([1, 2]), /as Bare Item/)
 
 	// @ts-expect-error - This is a test
 	// eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/libs/structured-field-values/test/encodeSfList.test.ts
+++ b/libs/structured-field-values/test/encodeSfList.test.ts
@@ -15,6 +15,10 @@ test('encodeSfList', () => {
 		new SfItem(2, { a: 2 }),
 		new SfItem(3, { a: 2 }),
 	]), `1;a=2, 2;a=2, 3;a=2`)
+	assert.deepStrictEqual(encodeSfList([3, new SfItem([4], { a: 1 }), new SfItem(5, { b: true })]), '3, (4);a=1, 5;b')
+	// @ts-expect-error - This is a test
+	assert.deepStrictEqual(encodeSfList([[1, 2], 3]), '(1 2), 3')
+	assert.deepStrictEqual(encodeSfList([true, false]), '?1, ?0')
 })
 
 test('encodeSfList keeps whitespace on unless it is explicitly disabled', () => {

--- a/libs/structured-field-values/test/serializeDecimal.test.ts
+++ b/libs/structured-field-values/test/serializeDecimal.test.ts
@@ -15,4 +15,6 @@ test('serializeDecimal', () => {
 	assert.deepStrictEqual(serializeDecimal(-999_999_999_999.999), '-999999999999.999')
 	assert.throws(() => serializeDecimal(1_000_000_000_000.0), /failed to serialize "1000000000000" as Decimal/)
 	assert.throws(() => serializeDecimal(-1_000_000_000_000.0), /failed to serialize "-1000000000000" as Decimal/)
+	assert.throws(() => serializeDecimal(1e21), /failed to serialize "1e\+21" as Decimal/)
+	assert.throws(() => serializeDecimal(-1e21), /failed to serialize "-1e\+21" as Decimal/)
 })

--- a/libs/structured-field-values/test/serializeInnerList.test.ts
+++ b/libs/structured-field-values/test/serializeInnerList.test.ts
@@ -1,0 +1,11 @@
+import { serializeInnerList, SfItem, SfToken } from '@svta/cml-structured-field-values'
+import assert from 'node:assert'
+import test from 'node:test'
+
+test('serializeInnerList', () => {
+	assert.deepStrictEqual(serializeInnerList({ value: [1, 2], params: { a: 1 } }), '(1 2);a=1')
+	assert.deepStrictEqual(serializeInnerList({ value: [new SfItem(1, { q: true }), new SfItem('x')], params: {} }), '(1;q "x")')
+	assert.deepStrictEqual(serializeInnerList([1, 2]), '(1 2)')
+	assert.deepStrictEqual(serializeInnerList([1, 2], { a: new SfToken('t') }), '(1 2);a=t')
+	assert.deepStrictEqual(serializeInnerList([]), '()')
+})

--- a/libs/structured-field-values/test/serializeKey.test.ts
+++ b/libs/structured-field-values/test/serializeKey.test.ts
@@ -11,6 +11,12 @@ test('serializeKey', () => {
 	assert.deepStrictEqual(serializeKey(`a*0-_.*`), 'a*0-_.*')
 	assert.throws(() => serializeKey(`#`), /failed to serialize "#" as Key/)
 	assert.throws(() => serializeKey(`?`), /failed to serialize "\?" as Key/)
+	assert.throws(() => serializeKey(''), /failed to serialize "" as Key/)
+	assert.throws(() => serializeKey('A'), /failed to serialize "A" as Key/)
+	assert.throws(() => serializeKey('0a'), /failed to serialize "0a" as Key/)
+	assert.throws(() => serializeKey('-a'), /failed to serialize "-a" as Key/)
+	assert.throws(() => serializeKey('a b'), /failed to serialize "a b" as Key/)
+	assert.throws(() => serializeKey('aé'), /failed to serialize "aé" as Key/)
 
 	// @ts-expect-error - This is a test
 	assert.throws(() => serializeKey(0), /failed to serialize "0" as Key/)

--- a/libs/structured-field-values/test/serializeParams.test.ts
+++ b/libs/structured-field-values/test/serializeParams.test.ts
@@ -1,0 +1,10 @@
+import { serializeParams, SfToken } from '@svta/cml-structured-field-values'
+import assert from 'node:assert'
+import test from 'node:test'
+
+test('serializeParams', () => {
+	assert.deepStrictEqual(serializeParams(undefined), '')
+	assert.deepStrictEqual(serializeParams({}), '')
+	assert.deepStrictEqual(serializeParams({ a: 1, b: true, c: 'x', d: new SfToken('t'), e: false }), `;a=1;b;c="x";d=t;e=?0`)
+	assert.throws(() => serializeParams({ A: 1 }), /failed to serialize "A" as Key/)
+})

--- a/libs/structured-field-values/test/serializeString.test.ts
+++ b/libs/structured-field-values/test/serializeString.test.ts
@@ -6,6 +6,10 @@ test('serializeString', () => {
 	assert.deepStrictEqual(serializeString('string'), `"string"`)
 	assert.deepStrictEqual(serializeString('str\\ing'), `"str\\\\ing"`)
 	assert.deepStrictEqual(serializeString('str"ing'), `"str\\"ing"`)
+	assert.deepStrictEqual(serializeString(''), `""`)
+	assert.deepStrictEqual(serializeString('a\\"b'), `"a\\\\\\"b"`)
+	assert.deepStrictEqual(serializeString('tab end'), `"tab end"`)
+	assert.throws(() => serializeString('str\ting'), /failed to serialize "str\ting" as String/)
 	// eslint-disable-next-line no-control-regex
 	assert.throws(() => serializeString('str\x00ing'), /failed to serialize "str\x00ing" as String/)
 	// eslint-disable-next-line no-control-regex

--- a/plans/sfv-encoder-perf/audit.md
+++ b/plans/sfv-encoder-perf/audit.md
@@ -1,0 +1,178 @@
+# Structured field values encoder: performance audit
+
+Date: 2026-09-11. Package: `@svta/cml-structured-field-values` 1.1.5 at commit `b28716d2`. Runtime: Node 24.16.0 on macOS (Darwin 25.6.0).
+
+## Summary
+
+The encoder is half of the cost of `encodeCmcd` for a typical request. The other half is `prepareCmcdData`.
+
+| Step, 17-key CMCD request | ns per call |
+| --- | --- |
+| `encodeCmcd` (prepare and encode) | 4321 |
+| `prepareCmcdData` only | 2089 |
+| `encodeSfDict` on the prepared data | 2173 |
+
+Seven changes, all output-identical to the shipped encoder, make the CMCD dictionary encode 31% to 48% faster and cut its garbage from 6.5 KB to 2.1 KB per call. The absolute numbers are small. At 10 requests per second the saving is about 10 microseconds of CPU and 44 KB of garbage per second. The garbage reduction is the meaningful part for a library that runs on every playback. The changes are also a code cleanup: they remove the `SfItem` wrapper allocation, the `as any` TODO in `serializeList`, and the regex literals that the code-quality rule forbids in hot functions.
+
+Every variant produced the same output and the same error message as the shipped encoder on 1259 cases: the 11 bench inputs and 1248 cases from the `structured-field-tests` corpus, including 539 cases that must fail. One error text differs: `encodeSfItem([1, 2])` reports `[1,2]` instead of `[{"value":1},{"value":2}]`.
+
+## Status
+
+Implemented on branch `perf/sfv-encoder-allocations` (findings 1 to 6). The final measurement is in the section "Final result" below. Finding 7 is a separate change in `@svta/cml-utils`. The side findings are an issue.
+
+## Method
+
+The benchmark lives in `libs/structured-field-values/bench/`, with `npm run bench -w libs/structured-field-values`. It runs each (variant, input) pair in its own process, so type feedback for one variant never shapes another. Each process makes 30 warm-up batches, then times 50 batches of 1000 calls and reports the median and p95 in nanoseconds per call. Every result string is flattened with `charCodeAt`, so rope strings pay their flattening cost inside the measurement.
+
+The staged variants of the audit were scratch copies of the shipped encoder with one change per stage. The repository does not keep them. The final implementation reproduces stage s4j, with one difference: lists append their members instead of joining parts, because the join measured 15% slower on a 20-member list while it measured faster on a 100-member dictionary.
+
+The allocation column runs 2000 calls after `gc()` with `--min-semi-space-size=64`. A `PerformanceObserver` on `gc` entries confirmed that no garbage collection ran inside any measured window, so the `heapUsed` delta is the bytes allocated per call, result included.
+
+The variants are staged. Each stage keeps the changes of the stage before it.
+
+| Stage | Change |
+| --- | --- |
+| s1 | Move the regex literals of `serializeKey`, `serializeToken`, and `serializeString` to module constants |
+| s2 | Replace `Object.entries`, `Array.from`, `map`, and `join` with index loops. Stop wrapping bare values in `new SfItem` |
+| s3 | `serializeString`: one regex test, return the quoted string directly when nothing needs escaping |
+| s4 | `serializeKey` as a `charCodeAt` loop, token regex without capture groups, numeric magnitude check in `serializeDecimal` |
+| s4e | s4 with a `for...of Object.entries` loop in `encodeSfDict` |
+| s4j | s4 with a parts array and one `join` in `encodeSfDict` and `encodeSfList` |
+
+## Results
+
+Median nanoseconds per call. The percentage is the change against the baseline.
+
+| Input | baseline | s2 | s3 | s4 | s4j |
+| --- | --- | --- | --- | --- | --- |
+| CMCD dict, 17 keys, bare values | 2412 | 2183 (-9%) | 1856 (-23%) | 1642 (-32%) | 1666 (-31%) |
+| CMCD dict, 17 keys, `SfItem` values | 2994 | 2229 (-26%) | 1901 (-37%) | 1724 (-42%) | 1741 (-42%) |
+| CMCD dict, 17 keys, `Map` | 2885 | 2027 (-30%) | 1719 (-40%) | 1501 (-48%) | 1503 (-48%) |
+| CMCD dict, 17 keys, built by keyed assignment | 2923 | 2129 (-27%) | 1888 (-35%) | 1677 (-43%) | 1678 (-43%) |
+| Dict, 100 integer keys | 10006 | 11408 (+14%) | 11784 (+18%) | 7352 (-27%) | 6929 (-31%) |
+| List, 20 integers | 630 | 539 (-14%) | 543 (-14%) | 537 (-15%) | 535 (-15%) |
+| List, 10 URL strings without escapes | 2637 | 2578 (-2%) | 1860 (-29%) | 1884 (-29%) | 1846 (-30%) |
+| List, 10 strings with quotes and backslashes | 4303 | 4149 (-4%) | 4395 (+2%) | 4376 (+2%) | 4389 (+2%) |
+| List, 20 decimals | 2038 | 1911 (-6%) | 1929 (-5%) | 1850 (-9%) | 1855 (-9%) |
+| Item `"abc"` with 3 parameters | 631 | 379 (-40%) | 293 (-54%) | 255 (-60%) | 250 (-60%) |
+| Dict with one 32-byte sequence | 1135 | 1088 (-4%) | 1093 (-4%) | 1071 (-6%) | 1054 (-7%) |
+
+Heap bytes allocated per call.
+
+| Input | baseline | s2 | s4 | s4j |
+| --- | --- | --- | --- | --- |
+| CMCD dict, 17 keys, bare values | 6555 | 2802 | 2800 | 2112 |
+| CMCD dict, 17 keys, `Map` | 7227 | 3705 | 3705 | 3017 |
+| Dict, 100 integer keys | 26637 | 12970 | 12970 | 9825 |
+| List, 10 URL strings without escapes | 3482 | 2220 | 2220 | 2220 |
+| Item `"abc"` with 3 parameters | 1538 | 440 | 476 | 441 |
+
+Stage s4e (`Object.entries` loop) was slower than s4 on the `SfItem` and keyed-assignment inputs and allocated 3889 bytes per CMCD dict. It is not recommended.
+
+Three separate runs gave the same ranking. The baseline of the bare-values CMCD row moved between 2391 and 3014 ns across runs, so its s4j delta ranged from -29% to -48%. The other three CMCD rows stayed within 3% of the numbers above, and s4j stayed between 1498 and 1741 ns on all four.
+
+## Findings, ranked by measured effect
+
+### 1. Container functions allocate a wrapper and four arrays per call
+
+`serializeDict` calls `Object.entries`, copies the result with `Array.from`, maps it to strings, and joins. It wraps every bare value in `new SfItem`, and the `SfItem` constructor maps every inner list into more `SfItem` objects. `serializeList` and `serializeParams` follow the same pattern. For a 17-key CMCD dict, this is 17 pair arrays, 17 wrapper objects, one entries array, one copy, one mapped array, and one joined string.
+
+Fix: iterate `Object.keys` by index, read `value` and `params` from an `SfItem` or use the bare value, and push member strings into one parts array joined once. `serializeParams` and `serializeInnerList` have few members and can build their string with `+=`.
+
+Effect: stage s2 and s4j columns. A parts array with `join` and `+=` cost the same at 17 keys. At 100 keys `+=` is 14% slower than the baseline and `join` is 31% faster, so `join` is the safe choice for dictionaries and lists.
+
+### 2. `serializeString` always runs three regex passes
+
+The function tests for control characters, then runs two global `replace` calls for backslash and double quote. Most strings contain neither. Measured on a 36-character session id: 170 ns.
+
+Fix: test one regex, `/[\x00-\x1f\x7f"\\]/`, first. If it does not match, return `'"' + value + '"'`. Otherwise run the existing check and the two replaces.
+
+| String | current | fast path |
+| --- | --- | --- |
+| Session id, 36 chars | 170 ns | 63 ns |
+| URL, 92 chars | 225 ns | 143 ns |
+| 44 chars with quotes and backslashes | 387 ns | 404 ns |
+
+Effect: URL list -29%. Strings that need escaping pay one extra test, +2%.
+
+### 3. `serializeKey` runs a regex on every key
+
+CMCD keys are 1 to 3 characters. A `charCodeAt` loop is faster than the regex below about 12 characters and slower above.
+
+| Key | regex | loop |
+| --- | --- | --- |
+| `br` | 20 ns | 6 ns |
+| `com.example-hello`, 17 chars | 32 ns | 42 ns |
+| 33 chars | 44 ns | 77 ns |
+
+Effect on the CMCD dict: -11% on top of s3. On 100 short keys: from +18% to -27%. Custom CMCD keys such as `com.example-hello` lose 10 ns each. The loop adds about 150 bytes to the bundle where the regex is 40 bytes.
+
+### 4. `serializeParams` uses `Object.entries().map().join()`
+
+Same pattern as finding 1, on the parameters of every item. Measured with 3 parameters: 305 ns with entries, map, and join. 132 ns with an `Object.keys` index loop and `+=`. `for...in` is 110 ns but also visits inherited properties, so `Object.keys` keeps the current semantics.
+
+Effect: item with 3 parameters -40% in s2, -60% in s4.
+
+### 5. Regex literals inside hot functions
+
+`serializeKey`, `serializeToken`, and `serializeString` create their regex from a literal on every call. The code-quality rule requires module constants. V8 clones a cached boilerplate, so the measured cost is near zero: 19.7 ns against 19.9 ns for the key regex. Do this for the rule, not for speed. The token regex also has two capture groups that `test` does not need. Removing them saves 2 ns per token.
+
+### 6. `serializeDecimal` builds a string to check the magnitude
+
+`Math.floor(Math.abs(roundedValue)).toString().length > 12` allocates a string. `Math.abs(roundedValue) >= 1e12` is equivalent for valid input, is 8.4 ns against 5.0 ns, and fixes a bug: `serializeDecimal(1e21)` returns `1e+21.0` today because `toString` switches to exponent notation. Decimals are rare in CMCD, so the speed effect is small. The 20-decimal list gains 9% overall, mostly from finding 1.
+
+### 7. `encodeBase64` in `@svta/cml-utils` spreads the bytes into `String.fromCharCode`
+
+`serializeByteSequence` calls `encodeBase64`, which is `btoa(String.fromCharCode(...binary))`. The spread passes every byte as an argument.
+
+| Input | spread (current) | `apply` in 32 KB chunks | manual loop | `Buffer` (Node only) |
+| --- | --- | --- | --- | --- |
+| 32 bytes | 845 ns | 207 ns | 303 ns | 118 ns |
+| 4 KB | 90 µs | 13 µs | 34 µs | 0.6 µs |
+| 64 KB | 1722 µs | 296 µs | 552 µs | 8 µs |
+| 200 KB | `RangeError: Maximum call stack size exceeded` | 267 KB string | | |
+
+Fix: `String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000))` per chunk. This is a `cml-utils` change and a bug fix, so it belongs in its own PR. `Uint8Array.prototype.toBase64` is not available in Node 24. Byte sequences do not occur in CMCD.
+
+### Not worth changing
+
+- The `instanceof` order in `serializeBareItem`: 5.2 ns either way.
+- `value.toString()` against `'' + value` for integers: 3 ns.
+- `for...in` in place of `Object.keys`: 20 ns per params object, and it changes semantics.
+
+## Side findings, correctness
+
+These are not performance issues. They need a decision on whether to change behavior.
+
+- `serializeString` accepts non-ASCII characters. `serializeString('héllo')` returns `"héllo"`. RFC 8941 section 4.1.6 step 1 requires serialization to fail. The `structured-field-tests` corpus has no non-ASCII vector, so the test suite cannot catch this.
+- `serializeDate` emits fractions. `serializeDate(new Date(1500))` returns `@1.5`. RFC 9651 section 4.1.10 serializes the date as an Integer.
+- `serializeDecimal(1e21)` returns `1e+21.0`. See finding 6.
+- `serializeDict` and `serializeList` reject a plain `SfInnerList` object although the `SfMember` type includes it. `encodeSfDict({ a: { value: [1, 2], params: {} } })` throws `failed to serialize ... as Bare Item`, because the object is wrapped as a bare value.
+- `sf-serialization.test.ts` cannot detect a missing failure. If a `must_fail` vector encodes without an error, `suite.canonical[0]` throws a `TypeError` inside the same `try` block, and the `catch` asserts `must_fail === true`, which passes. The corpus has 539 `must_fail` serialization vectors. The shipped encoder does fail on all of them today, verified by `bench.mjs --verify`.
+
+## Final result
+
+Measured with `npm run bench -- --baseline=temp/dist/index.js` from `libs/structured-field-values`, where `temp/dist` is a copy of the `main` build. Median nanoseconds per call, p95 in brackets, then heap bytes allocated per call.
+
+| Input | main | this branch | delta | bytes main | bytes this branch |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| CMCD dict, 17 keys, bare values | 2949 (3446) | 1750 (2003) | -40.6% | 6530 | 2130 |
+| CMCD dict, 17 keys, `SfItem` values | 2830 (3183) | 1899 (2049) | -32.9% | 5586 | 2130 |
+| CMCD dict, 17 keys, `Map` | 2946 (4393) | 1695 (1857) | -42.5% | 7203 | 2003 |
+| Dict, 100 integer keys | 10148 (10554) | 9016 (10164) | -11.2% | 26598 | 9833 |
+| List, 20 integers | 649 (731) | 544 (670) | -16.2% | 1418 | 1346 |
+| List, 10 URL strings without escapes | 2627 (4774) | 1887 (2085) | -28.2% | 3458 | 2197 |
+| List, 10 strings with quotes and backslashes | 4319 (4559) | 4359 (4595) | +0.9% | 9613 | 8358 |
+| List, 20 decimals | 1966 (2113) | 1815 (2075) | -7.7% | 2236 | 1850 |
+| Item `"abc"` with 3 parameters | 630 (764) | 283 (346) | -55.0% | 1514 | 418 |
+| Dict with one 32-byte sequence | 1174 (1377) | 1037 (1296) | -11.7% | 2882 | 2882 |
+
+Five runs of the committed code gave the same ranking. The 100-key dictionary row moved the most: between -11% and -24%, with -17% in three of the five runs. The CMCD rows stayed between -33% and -43%.
+
+`npm run bench -- --baseline=temp/dist/index.js --verify` reported 1258 identical outputs and error messages on the bench inputs and the corpus. The decimal fix is not in the corpus.
+
+The key loop of `serializeDict` measured the same as `for...of`, `forEach`, and an index loop. The `Map` path uses `Map.prototype.forEach`, which avoids one entry array per member. A `for...of` loop measured about 170 ns faster on 17 entries but allocated 1 KB more. The strings-with-escapes row pays one extra regex test.
+
+## Recommendation
+
+Findings 1 to 6 are one PR in `structured-field-values`. Finding 7 is one PR in `utils`, with a test for a 200 KB input. The side findings are one issue. The non-ASCII and date checks change behavior for callers who pass invalid input today, so they need a decision before a fix.

--- a/plans/sfv-encoder-perf/steps.md
+++ b/plans/sfv-encoder-perf/steps.md
@@ -1,0 +1,263 @@
+# Encoder performance: implementation steps
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply findings 1 to 6 of [audit.md](audit.md) to `@svta/cml-structured-field-values` without changing any output, fix finding 7 in `@svta/cml-utils`, and open an issue for the side findings.
+
+**Architecture:** The container serializers stop wrapping bare values in `SfItem`. They read `value` and `params` from an `SfItem` or use the bare value, and join member strings once. The leaf serializers keep their signatures. `serializeInnerList` gains a `(list, params)` overload so the containers can pass a bare array without an allocation. `serializeDecimal` compares the magnitude as a number.
+
+**Tech Stack:** TypeScript, Node 24 `node:test`, the `structured-field-tests` corpus, tsdown build, api-extractor.
+
+## Global constraints
+
+- Output must stay identical to `main` on the bench inputs and the corpus. One exception: `serializeDecimal` fails on values of `1e21` and above.
+- Every error message stays the same, except the array text in `encodeSfItem([1, 2])`.
+- No module-scope side effects. Regex constants are allowed, `STRING_REGEX` is the precedent.
+- Tests import from the package name. Build before test.
+- Commit with `git commit -s`, conventional type, and the `Co-Authored-By` trailer.
+- Do not bump versions. Add changelog notes under `## [Unreleased]`.
+
+---
+
+### Task 1: `serializeDecimal` magnitude check
+
+**Files:**
+- Modify: `libs/structured-field-values/src/serialize/serializeDecimal.ts`
+- Test: `libs/structured-field-values/test/serializeDecimal.test.ts`
+
+- [x] **Step 1: Add the failing assertions**
+
+```ts
+assert.throws(() => serializeDecimal(1e21), /failed to serialize "1e\+21" as Decimal/)
+assert.throws(() => serializeDecimal(-1e21), /failed to serialize "-1e\+21" as Decimal/)
+```
+
+- [x] **Step 2: Run the test and confirm it fails**
+
+Run from `libs/structured-field-values`: `node --test test/serializeDecimal.test.ts`
+Expected: `Missing expected exception`, because the function returns `1e+21.0`.
+
+- [x] **Step 3: Replace the string length check**
+
+```ts
+if (Math.abs(roundedValue) >= 1e12) {
+	throw serializeError(value, DECIMAL)
+}
+```
+
+- [x] **Step 4: Build and run the package tests**
+
+Run from the repository root: `npm run build -w libs/structured-field-values && npm test -w libs/structured-field-values`
+Expected: all tests pass.
+
+- [x] **Step 5: Commit**
+
+`fix(structured-field-values): reject decimals of 1e21 and above`
+
+### Task 2: `serializeInnerList` accepts a list and parameters
+
+**Files:**
+- Modify: `libs/structured-field-values/src/serialize/serializeInnerList.ts`
+- Create: `libs/structured-field-values/test/serializeInnerList.test.ts`
+
+**Interfaces:**
+- Produces: `serializeInnerList(value: SfInnerList): string` and `serializeInnerList(value: SfItem[] | SfBareItem[], params?: SfParameters): string`. Task 4 calls the second form.
+
+- [x] **Step 1: Write the failing test**
+
+```ts
+import { serializeInnerList, SfItem, SfToken } from '@svta/cml-structured-field-values'
+import assert from 'node:assert'
+import test from 'node:test'
+
+test('serializeInnerList', () => {
+	assert.deepStrictEqual(serializeInnerList({ value: [1, 2], params: { a: 1 } }), '(1 2);a=1')
+	assert.deepStrictEqual(serializeInnerList({ value: [new SfItem(1, { q: true }), new SfItem('x')], params: {} }), '(1;q "x")')
+	assert.deepStrictEqual(serializeInnerList([1, 2]), '(1 2)')
+	assert.deepStrictEqual(serializeInnerList([1, 2], { a: new SfToken('t') }), '(1 2);a=t')
+	assert.deepStrictEqual(serializeInnerList([]), '()')
+})
+```
+
+- [x] **Step 2: Run the test and confirm it fails**
+
+Expected: `TypeError`, because the array form has no `value.value`.
+
+- [x] **Step 3: Implement the overload with an index loop**
+
+```ts
+export function serializeInnerList(value: SfInnerList): string;
+export function serializeInnerList(value: SfItem[] | SfBareItem[], params?: SfParameters): string;
+export function serializeInnerList(value: SfInnerList | SfItem[] | SfBareItem[], params?: SfParameters): string {
+	let list: SfItem[] | SfBareItem[]
+	if (Array.isArray(value)) {
+		list = value
+	}
+	else {
+		list = value.value
+		params = value.params
+	}
+
+	let output = '('
+	for (let i = 0; i < list.length; i++) {
+		if (i > 0) {
+			output += ' '
+		}
+		output += serializeItem(list[i])
+	}
+
+	return `${output})${serializeParams(params)}`
+}
+```
+
+- [x] **Step 4: Build, test, commit**
+
+`perf(structured-field-values): serialize inner lists without a mapped array`
+
+### Task 3: Leaf serializers
+
+**Files:**
+- Modify: `libs/structured-field-values/src/serialize/serializeKey.ts`, `serializeToken.ts`, `serializeString.ts`, `serializeParams.ts`
+- Test: `libs/structured-field-values/test/serializeKey.test.ts`, `serializeString.test.ts`, create `serializeParams.test.ts`
+
+- [x] **Step 1: Add guard tests that pass today and must keep passing**
+
+```ts
+// serializeKey.test.ts
+assert.throws(() => serializeKey(''), /failed to serialize "" as Key/)
+assert.throws(() => serializeKey('A'), /failed to serialize "A" as Key/)
+assert.throws(() => serializeKey('0a'), /failed to serialize "0a" as Key/)
+assert.throws(() => serializeKey('-a'), /failed to serialize "-a" as Key/)
+assert.throws(() => serializeKey('a b'), /failed to serialize "a b" as Key/)
+assert.throws(() => serializeKey('aé'), /failed to serialize "aé" as Key/)
+
+// serializeString.test.ts
+assert.deepStrictEqual(serializeString(''), `""`)
+assert.deepStrictEqual(serializeString('a\\"b'), `"a\\\\\\"b"`)
+assert.deepStrictEqual(serializeString('tab\tend'.replace('\t', ' ')), `"tab end"`)
+assert.throws(() => serializeString('str\ting'), /failed to serialize "str\ting" as String/)
+
+// serializeParams.test.ts
+assert.deepStrictEqual(serializeParams(undefined), '')
+assert.deepStrictEqual(serializeParams({}), '')
+assert.deepStrictEqual(serializeParams({ a: 1, b: true, c: 'x', d: new SfToken('t'), e: false }), `;a=1;b;c="x";d=t;e=?0`)
+assert.throws(() => serializeParams({ A: 1 }), /failed to serialize "A" as Key/)
+```
+
+- [x] **Step 2: Run the tests, confirm they pass against the current build**
+
+- [x] **Step 3: Rewrite the four functions**
+
+`serializeKey`: `typeof` guard, first character `a-z` or `*`, then `a-z 0-9 _ - . *` by `charCodeAt`.
+`serializeToken`: module constant `TOKEN_REGEX = /^[a-zA-Z*][!#$%&'*+\-.^_`|~\w:/]*$/`.
+`serializeString`: module constants `STRING_ESCAPE_REGEX = /[\x00-\x1f\x7f"\\]/`, `BACKSLASH_REGEX = /\\/g`, `DQUOTE_REGEX = /"/g`. Return `"${value}"` when `STRING_ESCAPE_REGEX` does not match.
+`serializeParams`: `Object.keys` loop with `+=`.
+
+- [x] **Step 4: Build, test, commit**
+
+`perf(structured-field-values): validate keys and strings in one pass`
+
+### Task 4: Container serializers
+
+**Files:**
+- Create: `libs/structured-field-values/src/serialize/serializeMember.ts` (package private, not exported from `serialize/index.ts`)
+- Create: `libs/structured-field-values/src/serialize/serializeDictMember.ts` (package private)
+- Modify: `serializeDict.ts`, `serializeList.ts`, `encodeSfItem.ts`
+- Test: `encodeSfDict.test.ts`, `encodeSfList.test.ts`, `encodeSfItem.test.ts`
+
+**Interfaces:**
+- `serializeMember(member: SfMember): string`: inner list for an array or an `SfItem` with an array value, item otherwise.
+- `serializeDictMember(key: string, member: SfMember): string`: key, then parameters only for `true`, else `=` and the member.
+
+- [x] **Step 1: Add guard tests that pass today**
+
+```ts
+// encodeSfDict.test.ts
+assert.deepStrictEqual(encodeSfDict({ a: [1, 2], b: new SfItem([new SfItem(1, { x: true })], { y: 2 }) }), 'a=(1 2), b=(1;x);y=2')
+assert.deepStrictEqual(encodeSfDict({ a: new SfItem(true, { p: 1 }), b: true, c: new SfItem(false, { q: 2 }) }), 'a;p=1, b, c=?0;q=2')
+assert.deepStrictEqual(encodeSfDict({ a: new SfItem('x', { p: 1, q: true }) }), 'a="x";p=1;q')
+assert.throws(() => encodeSfDict(new Map([[1, 2]])), /failed to serialize "1" as Key/)
+assert.throws(() => encodeSfDict({ A: 1 }), /failed to serialize "A" as Key/)
+
+// encodeSfList.test.ts
+assert.deepStrictEqual(encodeSfList([[1, 2], 3, new SfItem([4], { a: 1 }), new SfItem(5, { b: true })]), '(1 2), 3, (4);a=1, 5;b')
+assert.deepStrictEqual(encodeSfList([true, false]), '?1, ?0')
+
+// encodeSfItem.test.ts
+assert.deepStrictEqual(encodeSfItem('a', { p: 1, q: true }), '"a";p=1;q')
+assert.deepStrictEqual(encodeSfItem(new SfItem('a', { p: 1 })), '"a";p=1')
+assert.throws(() => encodeSfItem([1, 2]), /as Bare Item/)
+```
+
+- [x] **Step 2: Run the tests, confirm they pass against the current build**
+
+- [x] **Step 3: Rewrite the containers**
+
+`serializeDict`: `Object.keys` loop or `Map` iteration, `parts.push(serializeDictMember(key, member))`, `parts.join(separator)`.
+`serializeList`: index loop that appends the members with `+=`. A parts array with `join` measured 15% slower on a 20-member list. Remove the `as any` TODO.
+`encodeSfItem`: `serializeItem(value)` for an `SfItem`, else `serializeBareItem(value) + serializeParams(params)`.
+
+- [x] **Step 4: Build, test, typecheck, lint**
+
+Run from the repository root: `npm run build -w libs/structured-field-values && npm test -w libs/structured-field-values && npm run typecheck && npx eslint libs/structured-field-values`
+
+- [x] **Step 5: Commit**
+
+`perf(structured-field-values): serialize containers without wrapper objects`
+
+### Task 5: Benchmark
+
+**Files:**
+- Create: `libs/structured-field-values/bench/bench.ts`, `libs/structured-field-values/bench/inputs.ts`
+- Modify: `libs/structured-field-values/package.json` (add `"bench": "node bench/bench.ts"`)
+
+- [x] **Step 1: Port `plans/sfv-encoder-perf/bench` to TypeScript.** Variants: this build and `--baseline=<dist path>`. Build the inputs with the `SfItem` and `SfToken` classes of the variant under test, so `instanceof` matches. Modes: timing, allocation, `--verify` against the corpus.
+- [x] **Step 2: Run `npm run bench -w libs/structured-field-values -- --baseline=temp/dist/index.js --verify`** and confirm zero differences except the decimal case. Result: 1258 identical.
+- [x] **Step 3: Run the timing bench and record the table in `audit.md`.**
+- [x] **Step 4: Commit** `chore(structured-field-values): add an encoder benchmark`
+
+### Task 6: Changelog, API report, tree-shaking probe
+
+- [x] Add `### Changed` and `### Fixed` notes under `## [Unreleased]` in `libs/structured-field-values/CHANGELOG.md`.
+- [x] Review the diff of `config/cml-structured-field-values.api.md`. The only expected change is the `serializeInnerList` overload.
+- [x] Bundle a bare `import '@svta/cml-structured-field-values'` with Rollup and tsdown. Nothing but import lines may survive.
+- [x] Run `npm test` at the repository root.
+- [x] Commit `docs(structured-field-values): changelog and design record for the encoder changes`, push the branch, hand the PR to Casey.
+
+### Task 7: `encodeBase64` in utils (branch from `main`)
+
+**Files:**
+- Modify: `libs/utils/src/encodeBase64.ts`
+- Create: `libs/utils/test/encodeBase64.test.ts`
+- Modify: `libs/utils/CHANGELOG.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('encodeBase64 handles inputs above the argument limit', () => {
+	const bytes = new Uint8Array(200_000).map((_, i) => i & 255)
+	const encoded = encodeBase64(bytes)
+	assert.deepStrictEqual(encoded.length, 266_668)
+	assert.deepStrictEqual(decodeBase64(encoded), bytes)
+})
+```
+
+Expected failure: `RangeError: Maximum call stack size exceeded`.
+
+- [ ] **Step 2: Encode in 32 KB chunks**
+
+```ts
+export function encodeBase64(binary: Uint8Array): string {
+	let text = ''
+	for (let i = 0; i < binary.length; i += 0x8000) {
+		text += String.fromCharCode.apply(null, binary.subarray(i, i + 0x8000) as unknown as number[])
+	}
+	return btoa(text)
+}
+```
+
+- [ ] **Step 3: Build utils and structured-field-values, run both test suites, commit, push.**
+
+### Task 8: Issue for the side findings
+
+- [ ] Open one issue with the four correctness findings from `audit.md`, one section each, with the reproducing call and the RFC reference.


### PR DESCRIPTION
## Description

The encoder of `@svta/cml-structured-field-values` allocates less and runs faster. The output does not change.

- `encodeSfDict`, `encodeSfList`, and `encodeSfItem` no longer wrap bare values in `SfItem`. `serializeDict` collects one part per member and joins once. `serializeList` and `serializeInnerList` append their members.
- `serializeString` returns a string that needs no escape after one regex test.
- `serializeKey` checks the character codes in a loop. `serializeToken` keeps its regex as a module constant without capture groups.
- `serializeParams` loops over `Object.keys` instead of entries, map, and join.
- `serializeInnerList` also accepts `(list, params)`. The `SfInnerList` object form still works. This overload is the only change in the API report.
- `serializeDecimal` compares the magnitude as a number. `serializeDecimal(1e21)` now fails instead of returning `1e+21.0`.
- New benchmark: `npm run bench -w libs/structured-field-values`. The header of `bench/bench.ts` lists the options.

`encodeSfDict` is about half of the cost of `encodeCmcd` for a 17-key request. The audit in [plans/sfv-encoder-perf/audit.md](https://github.com/streaming-video-technology-alliance/common-media-library/blob/perf/sfv-encoder-allocations/plans/sfv-encoder-perf/audit.md) has the analysis. The table shows `npm run bench -- --baseline=temp/dist/index.js`, where `temp/dist` is a copy of the `main` build. Median per call, then heap bytes allocated per call.

| Input | main | this PR | delta | bytes main | bytes this PR |
| --- | ---: | ---: | ---: | ---: | ---: |
| CMCD dict, 17 keys, bare values | 2949 ns | 1750 ns | -41% | 6530 | 2130 |
| CMCD dict, 17 keys, `SfItem` values | 2830 ns | 1899 ns | -33% | 5586 | 2130 |
| CMCD dict, 17 keys, `Map` | 2946 ns | 1695 ns | -43% | 7203 | 2003 |
| Dict, 100 integer keys | 10148 ns | 9016 ns | -11% | 26598 | 9833 |
| List, 20 integers | 649 ns | 544 ns | -16% | 1418 | 1346 |
| List, 10 URL strings | 2627 ns | 1887 ns | -28% | 3458 | 2197 |
| List, 10 strings with quotes and backslashes | 4319 ns | 4359 ns | +1% | 9613 | 8358 |
| Item with 3 parameters | 630 ns | 283 ns | -55% | 1514 | 418 |

Review notes:

- `npm run bench -- --baseline=temp/dist/index.js --verify` compared both builds on the bench inputs and on the whole `structured-field-tests` corpus: 1258 identical outputs and error messages. The decimal fix is not in the corpus and has its own test.
- One error text changes: `encodeSfItem([1, 2])` reports `[1,2]` instead of the wrapped items.
- The `Map` path uses `forEach`. It allocates about 1 KB less per 17-key dict than `for...of` and runs about 170 ns slower.
- Strings that need an escape pay one extra regex test, the +1% row.
- `serializeMember` and `serializeDictMember` are package private.
- A bare `import` of the package still bundles to only the `@svta/cml-utils` import line with Rollup and tsdown.
- No version bump. The changelog notes are under Unreleased.
- The audit found four correctness gaps that change behavior when fixed. They are in #462, not in this PR.

## Requirements Checklist

- [x] All commits have DCO sign-off from the author
- [x] Unit Tests updated or fixed
- [x] Docs/guides updated
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
